### PR TITLE
Add set/get methods to manager for RPC HTTP/WS ports.

### DIFF
--- a/pc/manager.cpp
+++ b/pc/manager.cpp
@@ -3,8 +3,6 @@
 
 using namespace pc;
 
-#define PC_RPC_HTTP_PORT      8899
-#define PC_RPC_WEBSOCKET_PORT 8900
 #define PC_RECONNECT_TIMEOUT  (120L*1000000000L)
 #define PC_BLOCKHASH_TIMEOUT  3
 #define PC_PUB_INTERVAL       (293L*PC_NSECS_IN_MSEC)
@@ -36,7 +34,9 @@ void manager_sub::on_add_symbol( manager *, price * )
 // manager
 
 manager::manager()
-: sub_( nullptr ),
+: rhport_( 8899 ),
+  rwport_( 8900 ),
+  sub_( nullptr ),
   status_( 0 ),
   num_sub_( 0 ),
   kidx_( (unsigned)-1 ),
@@ -93,6 +93,26 @@ void manager::set_rpc_host( const std::string& rhost )
 std::string manager::get_rpc_host() const
 {
   return rhost_;
+}
+
+void manager::set_rpc_http_port( int port )
+{
+  rhport_ = port;
+}
+
+int manager::get_rpc_http_port() const
+{
+  return rhport_;
+}
+
+void manager::set_rpc_ws_port( int port )
+{
+  rwport_ = port;
+}
+
+int manager::get_rpc_ws_port() const
+{
+  return rwport_;
 }
 
 void manager::set_capture_file( const std::string& cap_file )
@@ -227,11 +247,11 @@ bool manager::init()
   }
 
   // add rpc_client connection to net_loop and initialize
-  hconn_.set_port( PC_RPC_HTTP_PORT );
+  hconn_.set_port( rhport_ );
   hconn_.set_host( rhost_ );
   hconn_.set_net_loop( &nl_ );
   clnt_.set_http_conn( &hconn_ );
-  wconn_.set_port( PC_RPC_WEBSOCKET_PORT );
+  wconn_.set_port( rwport_ );
   wconn_.set_host( rhost_ );
   wconn_.set_net_loop( &nl_ );
   clnt_.set_ws_conn( &wconn_ );

--- a/pc/manager.hpp
+++ b/pc/manager.hpp
@@ -53,6 +53,14 @@ namespace pc
     void set_rpc_host( const std::string& );
     std::string get_rpc_host() const;
 
+    // solana rpc http port
+    void set_rpc_http_port( int port );
+    int get_rpc_http_port() const;
+
+    // solana rpc websocket port
+    void set_rpc_ws_port( int port );
+    int get_rpc_ws_port() const;
+
     // server listening port
     void set_listen_port( int port );
     int get_listen_port() const;
@@ -183,6 +191,8 @@ namespace pc
     acc_map_t    amap_;     // account to symbol pricing info
     spx_vec_t    svec_;     // symbol price subscriber/publishers
     std::string  rhost_;    // rpc host
+    int          rhport_;   // rpc http port
+    int          rwport_;   // rpc ws port
     std::string  cdir_;     // content directory
     manager_sub *sub_;      // subscription callback
     int          status_;   // status bitmap

--- a/pc/net_socket.cpp
+++ b/pc/net_socket.cpp
@@ -1059,6 +1059,7 @@ bool ws_connect::init()
   http_request msg;
   msg.init( "GET", "/" );
   msg.add_hdr( "Connection", "Upgrade" );
+  msg.add_hdr( "Upgrade", "websocket" );
   msg.add_hdr( "Sec-WebSocket-Key", "dGhlIHNhbXBsZSBub25jZQ==" );
   msg.add_hdr( "Sec-WebSocket-Version", "13" );
   msg.commit();


### PR DESCRIPTION
Also, add "Upgrade: websocket" header in WS upgrade request.

Note: This does not yet add command line flags for HTTP/WS port to all the CLI tools.