### PR TITLE
Update websocket jsonrpc subscribe request parsing and response building

### DIFF
--- a/pc/user.cpp
+++ b/pc/user.cpp
@@ -210,8 +210,9 @@ void user::parse_sub_price( uint32_t tok, uint32_t itok )
   do {
     // unpack and verify parameters
     uint32_t ntok,ptok = jp_.find_val( tok, "params" );
-    if ( ptok == 0 || jp_.get_type(ptok) != jtree::e_obj ) break;
-    if ( 0 == (ntok = jp_.find_val( ptok, "account" ) ) ) break;
+    if ( ptok == 0 || jp_.get_type(ptok) != jtree::e_arr ) break;
+    if ( 0 == (ntok = jp_.get_first( ptok ))) break;
+    if ( 0 == (ntok = jp_.find_val( ntok , "account" ) ) ) break;
     pub_key pkey;
     pkey.init_from_text( jp_.get_str( ntok ) );
     price *sptr = sptr_->get_price( pkey );
@@ -222,9 +223,7 @@ void user::parse_sub_price( uint32_t tok, uint32_t itok )
 
     // create result
     add_header();
-    jw_.add_key( "result", json_wtr::e_obj );
-    jw_.add_key( "subscription", sub_id );
-    jw_.pop();
+    jw_.add_key( "result", sub_id );
     add_tail( itok );
 
     // add subscription
@@ -240,8 +239,9 @@ void user::parse_sub_price_sched( uint32_t tok, uint32_t itok )
   do {
     // unpack and verify parameters
     uint32_t ntok,ptok = jp_.find_val( tok, "params" );
-    if ( ptok == 0 || jp_.get_type(ptok) != jtree::e_obj ) break;
-    if ( 0 == (ntok = jp_.find_val( ptok, "account" ) ) ) break;
+    if ( ptok == 0 || jp_.get_type(ptok) != jtree::e_arr ) break;
+    if ( 0 == (ntok = jp_.get_first( ptok ))) break;
+    if ( 0 == (ntok = jp_.find_val( ntok , "account" ) ) ) break;
     pub_key pkey;
     pkey.init_from_text( jp_.get_str( ntok ) );
     price *sptr = sptr_->get_price( pkey );
@@ -252,9 +252,7 @@ void user::parse_sub_price_sched( uint32_t tok, uint32_t itok )
 
     // create result
     add_header();
-    jw_.add_key( "result", json_wtr::e_obj );
-    jw_.add_key( "subscription", sub_id );
-    jw_.pop();
+    jw_.add_key( "result", sub_id );
     add_tail( itok );
     return;
   } while( 0 );

--- a/pctest/init_key_store.sh
+++ b/pctest/init_key_store.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 check()
 {


### PR DESCRIPTION
This PR fixes the websocket jsonrpc subscription endpoint.
I found that the implementation was different than almost everything I have checked online (is there any RFC for the subscription part? I only found [this](https://www.jsonrpc.org/specification)).

The jsonrpc subscribe endpoints should return the subscription ID straight in the *result* field. Whereas in pyth-client we wrap the id in a an object with a `subscription` field containing the ID.
Also, the parameter provided should be either an array or a null value, but we ask for an object containing the account field we are interested in.

Because of that, the usage of the rust [jsonrpc library](https://github.com/paritytech/jsonrpc) was impossible. I messed for hours until realising :P. All the online documentations about jsonrpc are all stating that the id should be straight in the result and that the arguments should be wrapped in an array. See:
- https://besu.hyperledger.org/en/stable/HowTo/Interact/APIs/RPC-PubSub
- https://geth.ethereum.org/docs/rpc/pubsub

With this patch, we are able to use the rust jsonrpc library without trouble. Please let me know whether I missed something or if my fix is wrong (I also fixed the absolute path used in the init script to make it more portable, as a NixOS user, it was impossible for me to run it).