### PR TITLE
Add pyth_tx to the release target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,7 +81,7 @@ target_link_libraries( pyth_tx ${PC_DEP} )
 #
 
 install( TARGETS pc DESTINATION lib )
-install( TARGETS pyth pythd pyth_csv DESTINATION bin )
+install( TARGETS pyth pythd pyth_csv pyth_tx DESTINATION bin )
 install( FILES ${PC_HDR} DESTINATION include/pc )
 install( FILES program/src/oracle/oracle.h DESTINATION include/oracle )
 


### PR DESCRIPTION
I'm building a snap for our production deployment and the release target does not include pyth_tx 