### PR TITLE
[pyth] Add "get_all_products" command and fix various crashes.

### DIFF
--- a/pc/manager.cpp
+++ b/pc/manager.cpp
@@ -518,9 +518,15 @@ void manager::reconnect_rpc()
     clnt_.send( sreq_ );
 
     // subscribe to program updates
-    preq_->set_commitment( get_commitment() );
-    preq_->set_program( get_program_pub_key() );
-    clnt_.send( preq_ );
+    pub_key *gpub = get_program_pub_key();
+    if ( !gpub ) {
+      set_err_msg( "missing or invalid program public key [" +
+          get_program_pub_key_file() + "]" );
+    } else {
+      preq_->set_commitment( get_commitment() );
+      preq_->set_program( gpub );
+      clnt_.send( preq_ );
+    }
 
     // gather latest info on mapping accounts
     for( get_mapping *mptr: mvec_ ) {

--- a/pc/request.cpp
+++ b/pc/request.cpp
@@ -2145,10 +2145,12 @@ void price::update_pub()
   // update publishing index
   pub_idx_ = (unsigned)-1;
   pub_key *pkey = get_manager()->get_publish_pub_key();
-  for( unsigned i=0; i != pptr_->num_; ++i ) {
-    if ( pc_pub_key_equal( &pptr_->comp_[i].pub_, (pc_pub_key_t*)pkey ) ) {
-      pub_idx_ = i;
-      break;
+  if ( pkey ) {
+    for( unsigned i=0; i != pptr_->num_; ++i ) {
+      if ( pc_pub_key_equal( &pptr_->comp_[i].pub_, (pc_pub_key_t*)pkey ) ) {
+        pub_idx_ = i;
+        break;
+      }
     }
   }
 }

--- a/pcapps/pyth.cpp
+++ b/pcapps/pyth.cpp
@@ -74,6 +74,8 @@ int usage()
   std::cerr << "  -j\n"
             << "     Output results in json format where applicable\n"
             << std::endl;
+  std::cerr << "  -d" << std::endl;
+  std::cerr << "     Turn on debug logging\n" << std::endl;
   return 1;
 }
 
@@ -311,12 +313,13 @@ int on_get_balance( int argc, char **argv )
   commitment cmt = commitment::e_confirmed;
   std::string rpc_host = get_rpc_host();
   std::string key_dir  = get_key_store();
-  while( (opt = ::getopt(argc,argv, "r:k:p:c:h" )) != -1 ) {
+  while( (opt = ::getopt(argc,argv, "r:k:p:c:dh" )) != -1 ) {
     switch(opt) {
       case 'r': rpc_host = optarg; break;
       case 'k': key_dir = optarg; break;
       case 'p': knm = optarg; break;
       case 'c': cmt = str_to_commitment(optarg); break;
+      case 'd': log::set_level( PC_LOG_DBG_LVL ); break;
       default: return usage();
     }
   }

--- a/pcapps/pyth.cpp
+++ b/pcapps/pyth.cpp
@@ -1014,6 +1014,11 @@ int on_get_product_list( int argc, char **argv )
     std::cerr << "pyth: " << mgr.get_err_msg() << std::endl;
     return 1;
   }
+  if ( !mgr.has_status( PC_PYTH_HAS_MAPPING ) ) {
+    std::cerr << "pyth: mapping not ready, check mapping key ["
+              << mgr.get_mapping_pub_key_file() << "]" << std::endl;
+    return 1;
+  }
   // list key/symbol pairs
   if ( !do_json ) {
     std::string astr;
@@ -1204,6 +1209,11 @@ int on_get_product( int argc, char **argv )
   mgr.set_commitment( cmt );
   if ( !mgr.init() || !mgr.bootstrap() ) {
     std::cerr << "pyth: " << mgr.get_err_msg() << std::endl;
+    return 1;
+  }
+  if ( !mgr.has_status( PC_PYTH_HAS_MAPPING ) ) {
+    std::cerr << "pyth: mapping not ready, check mapping key ["
+              << mgr.get_mapping_pub_key_file() << "]" << std::endl;
     return 1;
   }
   // get product and serialize to stdout


### PR DESCRIPTION
Closes #13 
Closes #11 

```
pyth: Add hidden -d debug logging flag to help text. 
```
```
manager: Set error state if program key is not found.

Previously, the code would crash here.
```
```
pyth: Print error and return 1 on mapping key failure.

Previously, pyth would return a 0 exit code but not return any data.
This could happen if the mapping key is missing or invalid.

Also, only try updating the price::pub_idx_ if the manager actually
has a publish public key. This was causing a crash when running the
tools without a publish keypair. This should be valid for running
in monitoring / consuming modes.
```
```
pyth: Add get_all_products command. 
```