### PR TITLE
add filtering based on account type to getProgramAccounts

### DIFF
--- a/pc/net_socket.cpp
+++ b/pc/net_socket.cpp
@@ -1471,6 +1471,12 @@ void json_wtr::add_key_verbatim( str key, str val )
   add( val );
 }
 
+void json_wtr::add_key_enc_base58( str key, str val )
+{
+  add_key_only( key );
+  add_enc_base58( val );
+}
+
 void json_wtr::add_key( str key, type_t t )
 {
   add_key_only( key );

--- a/pc/net_socket.hpp
+++ b/pc/net_socket.hpp
@@ -446,6 +446,7 @@ namespace pc
     void add_key( str key, jtrue );
     void add_key( str key, jfalse );
     void add_key_verbatim( str key, str );
+    void add_key_enc_base58( str key, str val );
 
     // add array value
     void add_val( str val );

--- a/pc/rpc_client.hpp
+++ b/pc/rpc_client.hpp
@@ -378,6 +378,7 @@ namespace pc
     public:
       // parameters
       void set_program( pub_key * );
+      void set_account_type( uint32_t );
 
       get_program_accounts();
       void request( json_wtr& ) override;
@@ -387,6 +388,7 @@ namespace pc
 
     private:
       pub_key    *pgm_;
+      uint32_t    acct_type_;
     };
 
     // get all (pyth) transactions in a slot


### PR DESCRIPTION
filtering by account type avoids sending the larger accounts assigned to the program that don't update often (or at all)

it was tested with this code:

`areq_->set_account_type( PC_ACCTYPE_PRICE );`

which will be included in a later pull request

this reduced bandwidth usage by 50% for this RPC call
