### PR TITLE
Add bison trails nginx config

### DIFF
--- a/doc/https-for-rpc-providers.md
+++ b/doc/https-for-rpc-providers.md
@@ -12,6 +12,8 @@ This lack will be remedied in a future release but in order to address the probl
 | 7901 | Figment | HTTP RPC and websocket |
 | 7802 | TritonOne | websocket only |
 | 7902 | TritonOne | HTTP RPC and websocket |
+| 7803 | BisonTrails | websocket only |
+| 7903 | BisonTrails | HTTP RPC and websocket |
 
 ## Running `nginx` as a standalone, unprivileged process
 

--- a/doc/nginx-configs/bison-trails-virt-server-config.conf
+++ b/doc/nginx-configs/bison-trails-virt-server-config.conf
@@ -1,0 +1,83 @@
+#
+# Bison Trails configuration snippet
+#
+# Can be included directly in /etc/nginx/sites-available/ (Debian based distros)
+# or /etc/nginx/conf.d/ (Red Hat based distros)
+#
+# Bison Trails currently only supports http basic authentication. To
+# get the basic auth digest, you need to use the base64 encoded version
+# of USERNAME:PASSWORD.
+#
+# From a linux machine, you can do this replacing USERNAME and PASSWORD
+# with the credentials from the bison trails QT "API Access" tab:
+#
+#    echo USERNAME:PASSWORD | base64 -w0
+#
+# Use the base64 encoded value for REPLACE_ME_WITH_YOUR_AUTH_TOKEN.
+#
+# YOUR_SERVER and REPLACE_ME_WITH_YOUR_AUTH_TOKEN should be replaced with the
+# appropriate values for your organization
+#
+
+# Bison Trails RPC & websocket with auth
+server {
+    listen 7903;
+
+    # Remove "https://" and any trailing slash e.g. 977c2599-63f9-4c6b-9eed-49dada416a3f.solana.bison.run
+    set $upstream_host YOUR_SERVER;
+    set $basic_auth_digest REPLACE_ME_WITH_YOUR_AUTH_TOKEN;
+
+    location / {
+        try_files /nonexistent-used-for-try-testing @$http_upgrade;
+    }
+
+    location @websocket {
+        proxy_pass https://$upstream_host/ws$request_uri;
+        proxy_http_version 1.1;
+        proxy_set_header Host $proxy_host;
+        # websocket requirements
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "Upgrade";
+        # Bison Trails specific authentication requirement
+        proxy_set_header Authorization "Basic $basic_auth_digest";
+        proxy_redirect https://$proxy_host http://$server_name:$server_port;
+        proxy_redirect https:// http://;
+    }
+
+    location @ {
+        proxy_pass https://$upstream_host/rpc$request_uri;
+        proxy_http_version 1.1;
+        proxy_set_header Host $proxy_host;
+        proxy_set_header Connection "";
+        # Bison Trails specific authentication requirement
+        proxy_set_header Authorization "Basic $basic_auth_digest";
+        proxy_redirect https://$proxy_host http://$server_name:$server_port;
+        proxy_redirect https:// http://;
+    }
+}
+
+#
+# This is a separate port for handling only websocket connections that some developers
+# have found greatly eases debugging.  It provides the same functionality as the first
+# location stanza in the virtual server above.
+#
+
+server {
+    listen 7803;
+
+    set $upstream_host YOUR_SERVER;
+    set $basic_auth_digest REPLACE_ME_WITH_YOUR_AUTH_TOKEN;
+
+    location / {
+        proxy_pass https://$upstream_host/ws$request_uri;
+        proxy_http_version 1.1;
+        proxy_set_header Host $proxy_host;
+        # websocket requirements
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "Upgrade";
+        # Bison Trails specific authentication requirement
+        proxy_set_header Authorization "Basic $basic_auth_digest";
+        proxy_redirect https://$proxy_host http://$server_name:$server_port;
+        proxy_redirect https:// http://;
+    }
+}


### PR DESCRIPTION
This adds a nginx config to reverse proxy [Bison Trails](https://bisontrails.co/)

Tested locally:

```
$ websocat -v ws://localhost:7803
[INFO  websocat::lints] Auto-inserting the line mode
[INFO  websocat::stdio_threaded_peer] get_stdio_peer (threaded)
[INFO  websocat::ws_client_peer] get_ws_client_peer
[INFO  websocat::ws_client_peer] Connected to ws
{"jsonrpc": "2.0", "id": 1, "method": "logsSubscribe", "params": [ {"mentions": ["11111111111111111111111111111111"]}, { "commitment": "finalized"}]}
{"jsonrpc":"2.0","result":4,"id":1}
^C

$ websocat -v ws://localhost:7903
[INFO  websocat::lints] Auto-inserting the line mode
[INFO  websocat::stdio_threaded_peer] get_stdio_peer (threaded)
[INFO  websocat::ws_client_peer] get_ws_client_peer
[INFO  websocat::ws_client_peer] Connected to ws
{"jsonrpc": "2.0", "id": 1, "method": "logsSubscribe", "params": [ {"mentions": ["11111111111111111111111111111111"]}, { "commitment": "finalized"}]}
{"jsonrpc":"2.0","result":5,"id":1}
^C

$ curl http://localhost:7903/health; echo
unknown

$ curl -X POST -H 'Content-Type: application/json' -d '{"jsonrpc":"2.0","id":1,"method":"getHealth"}' http://localhost:7903
{"jsonrpc":"2.0","error":{"code":-32005,"message":"Node is unhealthy","data":{"numSlotsBehind":null}},"id":1}
```