### PR TITLE
Nginx proxy config cleanup

### DIFF
--- a/doc/nginx-configs/blockdaemon-virt-server-config.conf
+++ b/doc/nginx-configs/blockdaemon-virt-server-config.conf
@@ -16,29 +16,34 @@ server {
         try_files /nonexistent-used-for-try-testing @$http_upgrade;
     }
 
+    # These need to be manually edited to your specific config.
+    set $upstream_host YOUR_SERVER;
+    set $auth_token REPLACE_ME_WITH_YOUR_AUTH_TOKEN;
+
     location @websocket {
         # Cheat a little to make sure we don't have a trailing slash on the
         # path or we get a 405 response (method not allowed)
-        proxy_pass https://YOUR_SERVER-solana-01.bdnodes.net/$http_upgrade;
+        proxy_pass https://$upstream_host/$http_upgrade;
         proxy_http_version 1.1;
         proxy_set_header Host $proxy_host;
         # websocket requirements
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "Upgrade";
         # Blockdaemon specific authentication requirement
-        proxy_set_header Authorization "Bearer REPLACE_ME_WITH_YOUR_AUTH_TOKEN";
+        proxy_set_header Authorization "Bearer $auth_token";
         proxy_redirect https://$proxy_host http://$server_name:$server_port;
         proxy_redirect https:// http://;
     }
 
     location @ {
-        proxy_pass https://YOUR_SERVER-solana-01.bdnodes.net$request_uri;
+        # Example: companyname-solana-09.bdnodes.net
+        proxy_pass https://$upstream_host$request_uri;
         proxy_http_version 1.1;
         proxy_set_header Host $proxy_host;
         # HTTP v.1.1 keepalive requirements
         proxy_set_header Connection "";
         # Blockdaemon specific authentication requirement
-        proxy_set_header Authorization "Bearer REPLACE_ME_WITH_YOUR_AUTH_TOKEN";
+        proxy_set_header Authorization "Bearer $auth_token";
         proxy_redirect https://$proxy_host http://$server_name:$server_port;
         proxy_redirect https:// http://;
     }
@@ -53,15 +58,18 @@ server {
 server {
     listen 7800;
 
+    set $upstream_host YOUR_SERVER;
+    set $auth_token REPLACE_ME_WITH_YOUR_AUTH_TOKEN;
+
     location / {
-        proxy_pass https://YOUR_SERVER-solana-01.bdnodes.net/websocket;
+        proxy_pass https://$upstream_host/websocket;
         proxy_http_version 1.1;
         proxy_set_header Host $proxy_host;
         # websocket requirements
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "Upgrade";
         # Blockdaemon specific authentication requirement
-        proxy_set_header Authorization "Bearer REPLACE_ME_WITH_YOUR_AUTH_TOKEN";
+        proxy_set_header Authorization "Bearer $auth_token";
         proxy_redirect https://$proxy_host http://$server_name:$server_port;
         proxy_redirect https:// http://;
     }

--- a/doc/nginx-configs/figment-virt-server-config.conf
+++ b/doc/nginx-configs/figment-virt-server-config.conf
@@ -12,6 +12,8 @@
 server {
     listen 7901;
 
+    set $auth_token REPLACE_ME_WITH_YOUR_AUTH_TOKEN;
+
     location / {
         try_files /nonexistent-used-for-try-testing @$http_upgrade;
     }
@@ -24,7 +26,7 @@ server {
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "Upgrade";
         # Figment specific authentication requirement
-        proxy_set_header Authorization REPLACE_ME_WITH_YOUR_AUTH_TOKEN;
+        proxy_set_header Authorization "$auth_token";
         proxy_redirect https://$proxy_host http://$server_name:$server_port;
         proxy_redirect https:// http://;
     }
@@ -35,7 +37,7 @@ server {
         proxy_set_header Host $proxy_host;
         proxy_set_header Connection "";
         # Figment specific authentication requirement
-        proxy_set_header Authorization REPLACE_ME_WITH_YOUR_AUTH_TOKEN;
+        proxy_set_header Authorization "$auth_token";
         proxy_redirect https://$proxy_host http://$server_name:$server_port;
         proxy_redirect https:// http://;
     }

--- a/doc/nginx-configs/triton-one-virt-server-config.conf
+++ b/doc/nginx-configs/triton-one-virt-server-config.conf
@@ -12,13 +12,17 @@
 server {
     listen 7902;
 
+    # e.g: companyname1.rpcpool.com
+    set $upstream_host YOUR_SERVER;
+    set $auth_token REPLACE_ME_WITH_YOUR_AUTH_TOKEN;
+
     location / {
         try_files /nonexistent-used-for-try-testing @$http_upgrade;
     }
 
     location @websocket {
         # With authentication
-        proxy_pass https://YOUR_SERVER.rpcpool.com/REPLACE_ME_WITH_YOUR_AUTH_TOKEN$request_uri;
+        proxy_pass https://$upstream_host/$auth_token$request_uri;
 
         # Without authentication, i.e. IP allow listed
         #proxy_pass https://YOUR_SERVER.rpcpool.com$request_uri;
@@ -33,10 +37,10 @@ server {
 
     location @ {
         # With authentication
-        proxy_pass https://YOUR_SERVER.rpcpool.com/REPLACE_ME_WITH_YOUR_AUTH_TOKEN$request_uri;
+        proxy_pass https://$upstream_host/$auth_token$request_uri;
 
         # Without authentication, i.e. IP allow listed
-        #proxy_pass https://YOUR_SERVER.rpcpool.com$request_uri;
+        #proxy_pass https://$upstream_host$request_uri;
         proxy_http_version 1.1;
         proxy_set_header Host $proxy_host;
         proxy_set_header Connection "";
@@ -54,12 +58,16 @@ server {
 server {
     listen 7802;
 
+    # e.g: companyname1.rpcpool.com
+    set $upstream_host YOUR_SERVER;
+    set $auth_token REPLACE_ME_WITH_YOUR_AUTH_TOKEN;
+
     location / {
         # With authentication
-        proxy_pass https://YOUR_SERVER.rpcpool.com/REPLACE_ME_WITH_YOUR_AUTH_TOKEN;
+        proxy_pass https://$upstream_host/$auth_token;
 
         # Without authentication, i.e. IP allow listed
-        #proxy_pass https://YOUR_SERVER.rpcpool.com;
+        #proxy_pass https://$upstream_host;
         proxy_http_version 1.1;
         proxy_set_header Host $proxy_host;
         # websocket requirements


### PR DESCRIPTION
Using variables for the hosts in the example configs lets nginx resolve them lazily. This allows editing only the specific config you want to test and nginx will still start to test things out.

Otherwise, nginx fails to start when one of the `proxy_pass` hosts failed to lookup `YOUR_SERVER...`. It looks like this:

        2021/09/16 11:52:29 [emerg] 126854#0: host not found in upstream "YOUR_SERVER-solana-01.bdnodes.net" in blockdaemon-virt-server-config.conf:64


Note: The triton one config was only tested with ip whitelisting as I didn't have access to a triton cluster with authentication enabled.

Block Daemon
----------------

```
$ curl -X POST -H 'Content-Type: application/json' -d '{"jsonrpc":"2.0","id":1,"method":"getHealth"}' http://localhost:7900
{"jsonrpc":"2.0","result":"ok","id":1}

$ curl -X POST -H 'Content-Type: application/json' -d '{"jsonrpc":"2.0","id":1,"method":"getVersion"}' http://localhost:7900
{"jsonrpc":"2.0","result":{"feature-set":3623616870,"solana-core":"1.6.25"},"id":1}

$ websocat -v ws://localhost:7900
[INFO  websocat::lints] Auto-inserting the line mode
[INFO  websocat::stdio_threaded_peer] get_stdio_peer (threaded)
[INFO  websocat::ws_client_peer] get_ws_client_peer
[INFO  websocat::ws_client_peer] Connected to ws
{"jsonrpc": "2.0", "id": 1, "method": "logsSubscribe", "params": [ {"mentions": ["11111111111111111111111111111111"]}, { "commitment": "finalized"}]}
{"jsonrpc":"2.0","result":0,"id":1}
^C

$ websocat -v ws://localhost:7800
[INFO  websocat::lints] Auto-inserting the line mode
[INFO  websocat::stdio_threaded_peer] get_stdio_peer (threaded)
[INFO  websocat::ws_client_peer] get_ws_client_peer
[INFO  websocat::ws_client_peer] Connected to ws
{"jsonrpc": "2.0", "id": 1, "method": "logsSubscribe", "params": [ {"mentions": ["11111111111111111111111111111111"]}, { "commitment": "finalized"}]}
{"jsonrpc":"2.0","result":1,"id":1}
^C
```

Figment
-------

```
$ websocat -v ws://localhost:7901
[INFO  websocat::lints] Auto-inserting the line mode
[INFO  websocat::stdio_threaded_peer] get_stdio_peer (threaded)
[INFO  websocat::ws_client_peer] get_ws_client_peer
[INFO  websocat::ws_client_peer] Connected to ws
{"jsonrpc": "2.0", "id": 1, "method": "logsSubscribe", "params": [ {"mentions": ["11111111111111111111111111111111"]}, { "commitment": "finalized"}]}
{"jsonrpc":"2.0","result":203932,"id":1}
^C

$ websocat -v ws://localhost:7801
[INFO  websocat::lints] Auto-inserting the line mode
[INFO  websocat::stdio_threaded_peer] get_stdio_peer (threaded)
[INFO  websocat::ws_client_peer] get_ws_client_peer
[INFO  websocat::ws_client_peer] Connected to ws
{"jsonrpc": "2.0", "id": 1, "method": "logsSubscribe", "params": [ {"mentions": ["11111111111111111111111111111111"]}, { "commitment": "finalized"}]}
{"jsonrpc":"2.0","result":225505,"id":1}
^C

$ curl -X POST -H 'Content-Type: application/json' -d '{"jsonrpc":"2.0","id":1,"method":"getHealth"}' http://localhost:7901
{"jsonrpc":"2.0","result":"ok","id":1}
```

Triton One
------------

```
$ curl -X POST -H 'Content-Type: application/json' -d '{"jsonrpc":"2.0","id":1,"method":"getHealth"}' http://localhost:7902
{"jsonrpc":"2.0","result":"ok","id":1}

$ websocat -v ws://localhost:7902
[INFO  websocat::lints] Auto-inserting the line mode
[INFO  websocat::stdio_threaded_peer] get_stdio_peer (threaded)
[INFO  websocat::ws_client_peer] get_ws_client_peer
[INFO  websocat::ws_client_peer] Connected to ws
{"jsonrpc": "2.0", "id": 1, "method": "logsSubscribe", "params": [ {"mentions": ["11111111111111111111111111111111"]}, { "commitment": "finalized"}]}
{"jsonrpc":"2.0","result":1,"id":1}
^C

$ websocat -v ws://localhost:7802
[INFO  websocat::lints] Auto-inserting the line mode
[INFO  websocat::stdio_threaded_peer] get_stdio_peer (threaded)
[INFO  websocat::ws_client_peer] get_ws_client_peer
[INFO  websocat::ws_client_peer] Connected to ws
{"jsonrpc": "2.0", "id": 1, "method": "logsSubscribe", "params": [ {"mentions": ["11111111111111111111111111111111"]}, { "commitment": "finalized"}]}
{"jsonrpc":"2.0","result":0,"id":1}
^C
```