### PR TITLE
change qset tests to reflect proper lprice/uprice sorting in confidence calculation

### DIFF
--- a/pyth/tests/qset/18.result
+++ b/pyth/tests/qset/18.result
@@ -1,1 +1,1 @@
-{"exponent":-3,"price":11031,"conf":246,"status":"trading"}
+{"exponent":-3,"price":11031,"conf":250,"status":"trading"}

--- a/pyth/tests/qset/19.result
+++ b/pyth/tests/qset/19.result
@@ -1,1 +1,1 @@
-{"exponent":-3,"price":11031,"conf":246,"status":"trading"}
+{"exponent":-3,"price":11031,"conf":259,"status":"trading"}

--- a/pyth/tests/qset/20.result
+++ b/pyth/tests/qset/20.result
@@ -1,1 +1,1 @@
-{"exponent":-3,"price":11037,"conf":256,"status":"trading"}
+{"exponent":-3,"price":11037,"conf":271,"status":"trading"}

--- a/pyth/tests/qset/22.json
+++ b/pyth/tests/qset/22.json
@@ -1,17 +1,17 @@
 {
- "exponent": 0,
- "quotes": [
-  {
-   "price": 10000,
-   "conf": 5
-  },
-  {
-   "price": 10010,
-   "conf": 5
-  },
-  {
-   "price": 10000,
-   "conf": 1
-  }
- ]
+  "exponent": -3,
+  "quotes": [
+    {
+      "price": 10000000,
+      "conf": 5000
+    },
+    {
+      "price": 10010000,
+      "conf": 5000
+    },
+    {
+      "price": 10000000,
+      "conf": 1000
+    }
+  ]
 }

--- a/pyth/tests/qset/22.result
+++ b/pyth/tests/qset/22.result
@@ -1,1 +1,1 @@
-{"exponent":0,"price":10000,"conf":2,"status":"trading"}
+{"exponent":-3,"price":10000000,"conf":2417,"status":"trading"}

--- a/pyth/tests/qset/31.result
+++ b/pyth/tests/qset/31.result
@@ -1,1 +1,1 @@
-{"exponent":-8,"price":4329847900000,"conf":3031550000,"status":"trading"}
+{"exponent":-8,"price":4329847900000,"conf":1758723921,"status":"trading"}

--- a/pyth/tests/qset/32.result
+++ b/pyth/tests/qset/32.result
@@ -1,1 +1,1 @@
-{"exponent":-8,"price":4329847900000,"conf":3031550000,"status":"trading"}
+{"exponent":-8,"price":4329847900000,"conf":1758723921,"status":"trading"}

--- a/pyth/tests/qset/33.result
+++ b/pyth/tests/qset/33.result
@@ -1,1 +1,1 @@
-{"exponent":-8,"price":4329847900000,"conf":3031550000,"status":"trading"}
+{"exponent":-8,"price":4329847900000,"conf":1758723921,"status":"trading"}


### PR DESCRIPTION
Numerous test cases had incorrect aggregate confidence intervals. In calculating the wgt_ptile of the uprice and lprice in upd_aggregate, the quotes need to be sorted by lprice and uprice before those respective calls to wgt_ptile. They are currently sorted by quote price, which is often not the same, leading to an incorrect aggregate confidence interval

These tests now fail.