### PR TITLE
M1 Mac dockerfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,19 @@ make
 # run unit tests
 ctest
 ```
+
+### M1 Mac Build Instructions
+
+We have a dockerfile that allows you to build the on-chain program on an M1 Mac.
+You can build the docker image using the following command:
+
+```
+docker build . --platform linux/amd64 -f docker/mac/Dockerfile -t pyth-client
+```
+
+You can then open a shell in the image by running:
+
+```
+docker run -it --platform linux/amd64 pyth-client
+```
+

--- a/docker/mac/Dockerfile
+++ b/docker/mac/Dockerfile
@@ -15,7 +15,7 @@ COPY --chown=pyth:pyth . pyth-client/
 
 ENV CC=clang
 ENV CXX=clang++
-RUN cd pyth-client && mkdir build && cd build && cmake .. && make
+RUN cd pyth-client && ./scripts/build.sh
 
 RUN echo "\nexport PATH=\$PATH:\$HOME/pyth-client/build" >> .profile
 RUN echo "\nexport PYTHONPATH=\${PYTHONPATH:+\${PYTHONPATH}:}\$HOME/pyth-client" >> .profile

--- a/docker/mac/Dockerfile
+++ b/docker/mac/Dockerfile
@@ -1,0 +1,21 @@
+FROM ubuntu:20.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update
+RUN apt-get install -qq cmake curl git libzstd1 libzstd-dev python3-pytest sudo zlib1g zlib1g-dev libssl-dev clang llvm
+
+# Grant sudo access to pyth user
+RUN echo "pyth ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+
+RUN useradd -m pyth
+USER pyth
+WORKDIR /home/pyth
+
+COPY --chown=pyth:pyth . pyth-client/
+
+ENV CC=clang
+ENV CXX=clang++
+RUN cd pyth-client && mkdir build && cd build && cmake .. && make
+
+RUN echo "\nexport PATH=\$PATH:\$HOME/pyth-client/build" >> .profile
+RUN echo "\nexport PYTHONPATH=\${PYTHONPATH:+\${PYTHONPATH}:}\$HOME/pyth-client" >> .profile


### PR DESCRIPTION
The client library can't be built on M1 macs because it depends on some linux-specific libraries. This Dockerfile lets mac users build the code via docker.