### PR TITLE
`Dockerfile` improvements

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -7,6 +7,7 @@ on:
 
 env:
   SOLANA_VERSION: 1.7.12
+  DOCKER_SERVER: docker.io
 
 jobs:
   build:
@@ -14,14 +15,45 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - run: echo "BRANCH=$( echo ${GITHUB_REF##*/} )" >> $GITHUB_ENV
-      - run: echo "DOCKER_TAG=${BRANCH}" >> $GITHUB_ENV
-      - run: echo "DOCKER_IMAGE=$( echo ${GITHUB_REPOSITORY}:${DOCKER_TAG} )" >> $GITHUB_ENV
-      - run: docker build -f docker/Dockerfile --build-arg SOLANA_VERSION=${{ env.SOLANA_VERSION }} --tag ${{ env.DOCKER_IMAGE }} .
-      # publish to docker.io
-      - run: echo "${{ secrets.DOCKER_IO_PASS }}" | docker login docker.io -u ${{ secrets.DOCKER_IO_USER }} --password-stdin
-        if: startsWith( github.ref, 'refs/tags/' )
-      - run: docker image tag ${DOCKER_IMAGE} docker.io/pythfoundation/pyth-client:${DOCKER_TAG}
-        if: startsWith( github.ref, 'refs/tags/' )
-      - run: docker image push docker.io/pythfoundation/pyth-client:${DOCKER_TAG}
-        if: startsWith( github.ref, 'refs/tags/' )
+
+      - name: Initialize Environment
+        run: |
+          set -eux
+          DOCKER_IMAGE="${GITHUB_REPOSITORY}:${GITHUB_REF##*/}"
+          echo "DOCKER_IMAGE=${DOCKER_IMAGE}" >> "${GITHUB_ENV}"
+
+      - name: Build Docker Image
+        run: |
+          set -eux
+
+          # GITHUB_WORKSPACE may be relative to "/".
+          cd /
+          cd "${GITHUB_WORKSPACE}"
+
+          docker build \
+            --file docker/Dockerfile \
+            --build-arg SOLANA_VERSION="${{ env.SOLANA_VERSION }}" \
+            --tag "${{ env.DOCKER_IMAGE }}" \
+            .
+
+      - name: Publish Docker Image
+        run: |
+          # Do not set -x before referencing secrets.
+          set -eu
+
+          echo "${{ secrets.DOCKER_IO_PASS }}" | docker login \
+            "${{ env.DOCKER_SERVER }}" \
+            -u "${{ secrets.DOCKER_IO_USER }}" \
+            --password-stdin
+
+          set -x
+          SRC="${{ env.DOCKER_IMAGE }}"
+          DST="${{ env.DOCKER_SERVER }}/${SRC}"
+          docker image tag "${SRC}" "${DST}"
+          docker image push "${DST}"
+
+        # Only publish if tagged as a release.
+        if: |
+          startsWith( github.ref, 'refs/tags/devnet-' )
+          || startsWith( github.ref, 'refs/tags/testnet-' )
+          || startsWith( github.ref, 'refs/tags/mainnet-' )

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,39 +1,67 @@
 ARG SOLANA_VERSION
-
 FROM solanalabs/solana:v${SOLANA_VERSION}
 
+# Redeclare SOLANA_VERSION in the new build stage.
+# Persist in env for docker run & inspect.
+ARG SOLANA_VERSION
+ENV SOLANA_VERSION="${SOLANA_VERSION}"
+
 RUN apt-get update
-RUN apt-get install -qq cmake curl g++ gcc-multilib git libzstd1 libzstd-dev python3-pytest sudo zlib1g zlib1g-dev
+RUN apt-get install -qq \
+  cmake \
+  curl \
+  g++ \
+  gcc-multilib \
+  git \
+  libzstd1 \
+  libzstd-dev \
+  python3-pytest \
+  sudo \
+  zlib1g \
+  zlib1g-dev
 
 # Grant sudo access to pyth user
 RUN echo "pyth ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
-
 RUN useradd -m pyth
+
 USER pyth
 WORKDIR /home/pyth
+COPY --chown=pyth:pyth . pyth-client/
 
-COPY --chown=pyth:pyth ${GITHUB_WORKSPACE} pyth-client/
+RUN echo "\n\
+export PATH=\"\${PATH}:\${HOME}/pyth-client/build\"\n\
+export PYTHONPATH=\"\${PYTHONPATH:+\$PYTHONPATH:}\${HOME}/pyth-client\"\n\
+" >> .profile
 
+# Build off-chain binaries.
 RUN cd pyth-client && ./scripts/build.sh
 
-RUN echo "\nexport PATH=\$PATH:\$HOME/pyth-client/build" >> .profile
+# Install rust and add ". ~/.cargo/env" to ~/.profile.
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+  | sh -s -- -y --default-toolchain none
 
-RUN echo "\nexport PYTHONPATH=\${PYTHONPATH:+\${PYTHONPATH}:}\$HOME/pyth-client" >> .profile
+# Copy solana sdk to modify makefile and header.
+RUN mkdir solana
+RUN cp -a /usr/bin/sdk solana
 
-# Install Rust
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain none
+# Enable all clang warnings.
+RUN sed -i \
+  's/-Werror/-Wall -Wextra -Wconversion -Werror/g' \
+  solana/sdk/bpf/c/bpf.mk
 
-# Link Solana location for makefile
-RUN mkdir solana && cp -a /usr/bin/sdk solana && sed -i 's/-Werror/-Wall -Wextra -Wconversion -Werror/g' solana/sdk/bpf/c/bpf.mk && sed -i 's/-z notext/-z notext -z defs/g' solana/sdk/bpf/c/bpf.mk
+# Disallow missing symbols in ld.
+RUN sed -i \
+  's/-z notext/-z notext -z defs/g' \
+  solana/sdk/bpf/c/bpf.mk
 
-# Build the program
-RUN PATH=$PATH:$HOME/.cargo/bin && cd pyth-client/program && make V=1
+# https://github.com/solana-labs/solana/issues/21198
+RUN sed -i \
+  's/\(^uint64_t sol_invoke_signed_c(\)/__attribute__(( weak )) \1/g' \
+  solana/sdk/bpf/c/inc/solana_sdk.h
 
-# Print hash of the program
-RUN sha256sum -b pyth-client/target/oracle.so
-
+# Build and test the oracle program.
+RUN cd pyth-client && ./scripts/build-bpf.sh program
 RUN /bin/bash -l -c "pytest-3 --pyargs pyth"
 
 ENTRYPOINT []
 CMD []
-

--- a/scripts/build-bpf.sh
+++ b/scripts/build-bpf.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+#
+# Build given bpf makefile dir (./program by default):
+#   ~/pyth-client$ ./scripts/build-bpf.sh
+#   ~/pyth-client/program$ ../scripts/build-bpf.sh .
+#   ~/$ ./pyth-client/scripts/build-bpf.sh ./serum-pyth/program
+#
+
+set -eu
+
+BUILD_DIR="$( cd "${1:-program}" && pwd )"
+
+if [[ ! -f "${BUILD_DIR}/makefile" ]]
+then
+  >&2 echo "Not a makefile dir: ${BUILD_DIR}"
+  exit 1
+fi
+
+if ! which cargo 2> /dev/null
+then
+  # shellcheck disable=SC1090
+  source "${CARGO_HOME:-$HOME/.cargo}/env"
+fi
+
+set -x
+
+cd "${BUILD_DIR}"
+make V=1 clean
+make V=1 "${@:2}"
+sha256sum ../target/*.so

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,4 +1,15 @@
-#!/bin/bash
+#!/usr/bin/env bash
+#
+# release build:
+#   ~/pyth-client$ ./scripts/build.sh [build]
+#
+# debug build:
+#   ~/pyth-client$ ./scripts/build.sh debug
+#
+# build other project:
+#   ~/pyth-client$ ./scripts/build.sh ../serum-pyth/build
+#   ~/serum-pyth$ ../pyth-client/scripts/build.sh
+#
 
 set -eu
 
@@ -7,10 +18,7 @@ then
   BUILD_DIR="$1"
   shift
 else
-  THIS_DIR="$( dirname "${BASH_SOURCE[0]}" )"
-  THIS_DIR="$( cd "${THIS_DIR}" && pwd )"
-  ROOT_DIR="$( dirname "${THIS_DIR}" )"
-  BUILD_DIR="${ROOT_DIR}/build"
+  BUILD_DIR="build"
 fi
 
 ROOT_DIR="$( mkdir -p "${BUILD_DIR}" && cd "${BUILD_DIR}/.." && pwd )"
@@ -19,6 +27,13 @@ BUILD_DIR="$( realpath --relative-to="${ROOT_DIR}" "${BUILD_DIR}" )"
 if [[ ! -v CMAKE_ARGS && $BUILD_DIR == *debug* ]]
 then
   CMAKE_ARGS=( "-DCMAKE_BUILD_TYPE=Debug" )
+fi
+
+# Check before rm -rf $BUILD_DIR
+if [[ ! -f "${ROOT_DIR}/CMakeLists.txt" ]]
+then
+  >&2 echo "Not a cmake project dir: ${ROOT_DIR}"
+  exit 1
 fi
 
 set -x


### PR DESCRIPTION
- make `-z defs` work with bpf sources calling `sol_invoke`
- add `build-bpf.sh`, intended to be shared by `serum-pyth`
- remove `GITHUB_WORKSPACE` reference from `Dockerfile`
  - old behavior was expanding to an empty string
  - instead set build context to `GITHUB_WORKSPACE` in `docker.yaml`
- make `SOLANA_VERSION` available for `docker run`/`docker inspect`
- comments, whitespace, github workflow step names
