### PR TITLE
Changes for CLion:

### DIFF
--- a/.idea/cmake.xml
+++ b/.idea/cmake.xml
@@ -4,6 +4,7 @@
     <configurations>
       <configuration PROFILE_NAME="Debug" ENABLED="true" CONFIG_NAME="Debug" />
       <configuration PROFILE_NAME="Release" ENABLED="true" CONFIG_NAME="Release" />
+      <configuration PROFILE_NAME="BPF" ENABLED="true" CONFIG_NAME="Release" TOOLCHAIN_NAME="BPF" GENERATION_OPTIONS="-DSOLANA=$CMakeProjectParentDir$/solana" />
     </configurations>
   </component>
 </project>

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,10 +1,18 @@
 <component name="InspectionProjectProfileManager">
   <profile version="1.0">
     <option name="myName" value="Project Default" />
-    <inspection_tool class="SpellCheckingInspection" enabled="false" level="TYPO" enabled_by_default="false">
-      <option name="processCode" value="true" />
-      <option name="processLiterals" value="true" />
-      <option name="processComments" value="true" />
+    <inspection_tool class="GrazieInspection" enabled="true" level="TYPO" enabled_by_default="false">
+      <scope name="markdown" level="TYPO" enabled="true" />
+    </inspection_tool>
+    <inspection_tool class="SpellCheckingInspection" enabled="true" level="TYPO" enabled_by_default="false">
+      <scope name="markdown" level="TYPO" enabled="true">
+        <option name="processCode" value="false" />
+        <option name="processLiterals" value="false" />
+        <option name="processComments" value="true" />
+      </scope>
+      <option name="processCode" value="false" />
+      <option name="processLiterals" value="false" />
+      <option name="processComments" value="false" />
     </inspection_tool>
   </profile>
 </component>

--- a/.idea/scopes/markdown.xml
+++ b/.idea/scopes/markdown.xml
@@ -1,0 +1,3 @@
+<component name="DependencyValidationManager">
+  <scope name="markdown" pattern="file:*.md||file[pyth-client]:**/*.md" />
+</component>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,3 +118,33 @@ add_test( test_net test_net )
 
 add_executable( fuzz pctest/fuzz.cpp )
 target_link_libraries( fuzz ${PC_DEP} )
+
+
+#
+# bpf static analysis (CLion)
+#
+
+function( add_bpf_lib targ )
+  if( SOLANA AND NOT BPF )
+    set( BPF ${SOLANA}/sdk/bpf )
+  endif()
+  if( BPF )
+    add_library( ${targ} STATIC ${ARGN} )
+    if( ${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.21" )
+      # bpf.mk uses --std=c17
+      set_property( TARGET ${targ} PROPERTY C_STANDARD 17 )
+    else()
+      set_property( TARGET ${targ} PROPERTY C_STANDARD 11 )
+    endif()
+    set_property( TARGET ${targ} PROPERTY C_STANDARD_REQUIRED ON )
+    set_property( TARGET ${targ} PROPERTY C_EXTENSIONS OFF )
+    target_compile_definitions( ${targ} PRIVATE __bpf__=1 )
+    target_include_directories( ${targ} SYSTEM PRIVATE
+      ${BPF}/c/inc
+      ${BPF}/dependencies/criterion/include
+    )
+  endif()
+endfunction()
+
+# test_oracle.c includes oracle.c
+add_bpf_lib( test-oracle-bpf program/src/oracle/test_oracle.c )


### PR DESCRIPTION
- Add pseudo-bpf cmake target conditionalized on `-DSolana`, passed via CLion but not build scripts.
  - Enable static analysis on `program/` sources and resolving solana & criterion headers.
- Restrict spelling and grammar checks to markdown files.