### PR TITLE
build.sh: remove usage of `realpath` (requires coreutils on OS X)

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -22,7 +22,8 @@ else
 fi
 
 ROOT_DIR="$( mkdir -p "${BUILD_DIR}" && cd "${BUILD_DIR}/.." && pwd )"
-BUILD_DIR="$( realpath --relative-to="${ROOT_DIR}" "${BUILD_DIR}" )"
+BUILD_DIR="$( cd "${BUILD_DIR}" && pwd )"
+BUILD_DIR="$( basename "${BUILD_DIR}" )"
 
 if [[ ! -v CMAKE_ARGS && $BUILD_DIR == *debug* ]]
 then


### PR DESCRIPTION
This scripts should generally be used from within the Docker env, but it's sometimes useful to run it from the host for local testing. This change avoids requiring `brew install coreutils` on OS X.