### PR TITLE
Use http/1.1 for both websockets and regular rpc

### DIFF
--- a/doc/example-nginx-triton1.conf
+++ b/doc/example-nginx-triton1.conf
@@ -22,6 +22,7 @@ http {
   server {
     listen 7900;
     location / {
+      proxy_http_version 1.1;
       proxy_set_header Upgrade $http_upgrade;
       proxy_set_header Connection "Upgrade";
       proxy_pass https://backend/YOUR_AUTH_TOKEN_HERE/;


### PR DESCRIPTION
With http/1.0 negotiation for websockets, the websocket negotiation will fail.

This is per the HTTP spec:
https://developer.mozilla.org/en-US/docs/Web/HTTP/Protocol_upgrade_mechanism