### PR TITLE
use http/1.1 for websockets

### DIFF
--- a/doc/example-nginx-bisontrails.conf
+++ b/doc/example-nginx-bisontrails.conf
@@ -23,6 +23,7 @@ http {
   server {
     listen 7900;
     location / {
+      proxy_http_version 1.1;
       proxy_set_header Upgrade $http_upgrade;
       proxy_set_header Connection "Upgrade";
       proxy_pass https://backend/ws;
@@ -30,6 +31,7 @@ http {
       proxy_set_header Host YOUR_NODE;
     }
   }
+
   server {
     listen 7899;
     location / {

--- a/doc/example-nginx-blockdaemon.conf
+++ b/doc/example-nginx-blockdaemon.conf
@@ -24,6 +24,7 @@ http {
   server {
     listen 7900;
     location / {
+      proxy_http_version 1.1;
       proxy_set_header Upgrade $http_upgrade;
       proxy_set_header Connection "Upgrade";
       proxy_set_header Authorization "Bearer YOUR_AUTH_TOKEN_HERE";

--- a/doc/example-nginx-figment.conf
+++ b/doc/example-nginx-figment.conf
@@ -22,6 +22,7 @@ http {
   server {
     listen 7900;
     location / {
+      proxy_http_version 1.1;
       proxy_set_header Upgrade $http_upgrade;
       proxy_set_header Connection "Upgrade";
       proxy_pass https://backend/apikey/YOUR_AUTH_TOKEN_HERE/;


### PR DESCRIPTION
"""
Use http/1.1 for both websockets and regular rpc (#137)

With http/1.0 negotiation for websockets, the websocket negotiation will fail.
"""