### PR TITLE
Accessors for base/quote currencies

### DIFF
--- a/pc/request.cpp
+++ b/pc/request.cpp
@@ -505,6 +505,16 @@ str price::get_symbol()
   return prod_->get_symbol();
 }
 
+str price::get_base()
+{
+  return prod_->get_base();
+}
+
+str price::get_quote()
+{
+  return prod_->get_quote();
+}
+
 bool price::get_attr( attr_id aid, str& val ) const
 {
   return prod_->get_attr( aid, val );

--- a/pc/request.cpp
+++ b/pc/request.cpp
@@ -295,6 +295,20 @@ str product::get_symbol()
   return sym;
 }
 
+str product::get_base()
+{
+  str base;
+  get_attr( attr_id( "base" ), base);
+  return base;
+}
+
+str product::get_quote()
+{
+  str quote;
+  get_attr( attr_id( "quote_currency" ), quote);
+  return quote;
+}
+
 void product::reset()
 {
   reset_err();

--- a/pc/request.cpp
+++ b/pc/request.cpp
@@ -295,7 +295,7 @@ str product::get_symbol()
   return sym;
 }
 
-str product::get_base()
+str product::get_base_asset()
 {
   str base;
   get_attr( attr_id( "base" ), base);
@@ -505,9 +505,9 @@ str price::get_symbol()
   return prod_->get_symbol();
 }
 
-str price::get_base()
+str price::get_base_asset()
 {
-  return prod_->get_base();
+  return prod_->get_base_asset();
 }
 
 str price::get_quote_currency()

--- a/pc/request.cpp
+++ b/pc/request.cpp
@@ -302,7 +302,7 @@ str product::get_base()
   return base;
 }
 
-str product::get_quote()
+str product::get_quote_currency()
 {
   str quote;
   get_attr( attr_id( "quote_currency" ), quote);
@@ -510,9 +510,9 @@ str price::get_base()
   return prod_->get_base();
 }
 
-str price::get_quote()
+str price::get_quote_currency()
 {
-  return prod_->get_quote();
+  return prod_->get_quote_currency();
 }
 
 bool price::get_attr( attr_id aid, str& val ) const

--- a/pc/request.hpp
+++ b/pc/request.hpp
@@ -243,6 +243,12 @@ namespace pc
     // convenience wrapper equiv to: get_product()->get_symbol()
     str get_symbol();
 
+    // Get the base currency for the product (from the list of product attributes).
+    str get_base();
+
+    // Get the quote currency for the product (from the list of product attributes).
+    str get_quote();
+
     // convenience wrapper equiv to: get_product()->get_sttr()
     bool get_attr( attr_id, str& ) const;
 

--- a/pc/request.hpp
+++ b/pc/request.hpp
@@ -160,7 +160,7 @@ namespace pc
     // Get the base currency (from attr_dict)
     str get_base();
     // Get the quote currency (from attr_dict)
-    str get_quote();
+    str get_quote_currency();
 
     // iterate through associated price accounts (quotes) associated
     // with this product
@@ -251,7 +251,7 @@ namespace pc
     str get_base();
 
     // Get the quote currency for the product (from the list of product attributes).
-    str get_quote();
+    str get_quote_currency();
 
     // convenience wrapper equiv to: get_product()->get_sttr()
     bool get_attr( attr_id, str& ) const;

--- a/pc/request.hpp
+++ b/pc/request.hpp
@@ -158,7 +158,7 @@ namespace pc
     // symbol from attr_dict
     str get_symbol();
     // Get the base currency (from attr_dict)
-    str get_base();
+    str get_base_asset();
     // Get the quote currency (from attr_dict)
     str get_quote_currency();
 
@@ -247,8 +247,8 @@ namespace pc
     // convenience wrapper equiv to: get_product()->get_symbol()
     str get_symbol();
 
-    // Get the base currency for the product (from the list of product attributes).
-    str get_base();
+    // Get the base asset for the product (from the list of product attributes).
+    str get_base_asset();
 
     // Get the quote currency for the product (from the list of product attributes).
     str get_quote_currency();

--- a/pc/request.hpp
+++ b/pc/request.hpp
@@ -157,6 +157,10 @@ namespace pc
 
     // symbol from attr_dict
     str get_symbol();
+    // Get the base currency (from attr_dict)
+    str get_base();
+    // Get the quote currency (from attr_dict)
+    str get_quote();
 
     // iterate through associated price accounts (quotes) associated
     // with this product


### PR DESCRIPTION
These accessors make it easy for people to avoid using the symbol