### PR TITLE
Add batch price update instruction to Oracle

### DIFF
--- a/pc/rpc_client.cpp
+++ b/pc/rpc_client.cpp
@@ -809,7 +809,7 @@ rpc::upd_price::upd_price()
   ckey_( nullptr ),
   gkey_( nullptr ),
   akey_( nullptr ),
-  cmd_( e_cmd_upd_price )
+  cmd_( e_cmd_upd_price_no_fail_on_error )
 {
 }
 
@@ -851,7 +851,7 @@ void rpc::upd_price::set_price( int64_t px,
   price_ = px;
   conf_  = conf;
   st_    = st;
-  cmd_   = is_agg?e_cmd_agg_price:e_cmd_upd_price;
+  cmd_   = is_agg?e_cmd_agg_price:e_cmd_upd_price_no_fail_on_error;
 }
 
 void rpc::upd_price::set_slot( const uint64_t pub_slot )

--- a/pc/rpc_client.cpp
+++ b/pc/rpc_client.cpp
@@ -884,52 +884,6 @@ public:
   }
 };
 
-void rpc::upd_price::build_tx( bincode& tx )
-{
-  // signatures section
-  tx.add_len<1>();      // one signature (publish)
-  size_t pub_idx = tx.reserve_sign();
-
-  // message header
-  size_t tx_idx = tx.get_pos();
-  tx.add( (uint8_t)1 ); // pub is only signing account
-  tx.add( (uint8_t)0 ); // read-only signed accounts
-  tx.add( (uint8_t)2 ); // sysvar and program-id are read-only
-                        // unsigned accounts
-
-  // accounts
-  tx.add_len<4>();      // 4 accounts: publish, symbol, sysvar, program
-  tx.add( *pkey_ );     // publish account
-  tx.add( *akey_ );     // symbol account
-  tx.add( *(pub_key*)sysvar_clock ); // sysvar account
-  tx.add( *gkey_ );     // programid
-
-  // recent block hash
-  tx.add( *bhash_ );    // recent block hash
-
-  // instructions section
-  tx.add_len<1>();      // one instruction
-  tx.add( (uint8_t)3);  // program_id index
-  tx.add_len<3>();      // 3 accounts: publish, symbol, sysvar
-  tx.add( (uint8_t)0 ); // index of publish account
-  tx.add( (uint8_t)1 ); // index of symbol account
-  tx.add( (uint8_t)2 ); // index of sysvar account
-
-  // instruction parameter section
-  tx.add_len<sizeof(cmd_upd_price)>();
-  tx.add( (uint32_t)PC_VERSION );
-  tx.add( (int32_t)cmd_ );
-  tx.add( (int32_t)st_ );
-  tx.add( (int32_t)0 );
-  tx.add( price_ );
-  tx.add( conf_ );
-  tx.add( pub_slot_ );
-
-  // all accounts need to sign transaction
-  tx.sign( pub_idx, tx_idx, *ckey_ );
-  sig_.init_from_buf( (const uint8_t*)(tx.get_buf() + pub_idx) );
-}
-
 bool rpc::upd_price::build_tx(
   bincode& tx, upd_price* upds[], const unsigned n
 )

--- a/pc/rpc_client.hpp
+++ b/pc/rpc_client.hpp
@@ -429,7 +429,6 @@ namespace pc
       static bool request( json_wtr&, upd_price*[], const unsigned n );
 
     private:
-      void build_tx( bincode& );
       static bool build_tx( bincode&, upd_price*[], unsigned n );
 
       hash         *bhash_;

--- a/program/src/oracle/oracle.c
+++ b/program/src/oracle/oracle.c
@@ -520,7 +520,7 @@ static uint64_t upd_price( SolParameters *prm, SolAccountInfo *ka )
   // reject if this price corresponds to the same or earlier time
   pc_price_info_t *fptr = &pptr->comp_[i].latest_;
   sysvar_clock_t *sptr = (sysvar_clock_t*)ka[clock_idx].data;
-  if ( cptr->cmd_ == e_cmd_upd_price &&
+  if ( ( cptr->cmd_ == e_cmd_upd_price || cptr->cmd_ == e_cmd_upd_price_no_fail_on_error ) &&
        cptr->pub_slot_ <= fptr->pub_slot_ ) {
     return ERROR_INVALID_ARGUMENT;
   }
@@ -531,12 +531,18 @@ static uint64_t upd_price( SolParameters *prm, SolAccountInfo *ka )
   }
 
   // update component price if required
-  if ( cptr->cmd_ == e_cmd_upd_price ) {
+  if ( cptr->cmd_ == e_cmd_upd_price || cptr->cmd_ == e_cmd_upd_price_no_fail_on_error ) {
     fptr->price_    = cptr->price_;
     fptr->conf_     = cptr->conf_;
     fptr->status_   = cptr->status_;
     fptr->pub_slot_ = cptr->pub_slot_;
   }
+  return SUCCESS;
+}
+
+static uint64_t upd_price_no_fail_on_error( SolParameters *prm, SolAccountInfo *ka )
+{
+  upd_price( prm, ka );
   return SUCCESS;
 }
 
@@ -551,19 +557,20 @@ static uint64_t dispatch( SolParameters *prm, SolAccountInfo *ka )
   }
   switch(hdr->cmd_) {
     case e_cmd_upd_price:
-    case e_cmd_agg_price:     return upd_price( prm, ka );
-    case e_cmd_init_mapping:  return init_mapping( prm, ka );
-    case e_cmd_add_mapping:   return add_mapping( prm, ka );
-    case e_cmd_add_product:   return add_product( prm, ka );
-    case e_cmd_upd_product:   return upd_product( prm, ka );
-    case e_cmd_add_price:     return add_price( prm, ka );
-    case e_cmd_add_publisher: return add_publisher( prm, ka );
-    case e_cmd_del_publisher: return del_publisher( prm, ka );
-    case e_cmd_init_price:    return init_price( prm, ka );
-    case e_cmd_init_test:     return init_test( prm, ka );
-    case e_cmd_upd_test:      return upd_test( prm, ka );
-    case e_cmd_set_min_pub:   return set_min_pub( prm, ka );
-    default:                  return ERROR_INVALID_ARGUMENT;
+    case e_cmd_agg_price:                  return upd_price( prm, ka );
+    case e_cmd_upd_price_no_fail_on_error: return upd_price_no_fail_on_error( prm, ka );
+    case e_cmd_init_mapping:               return init_mapping( prm, ka );
+    case e_cmd_add_mapping:                return add_mapping( prm, ka );
+    case e_cmd_add_product:                return add_product( prm, ka );
+    case e_cmd_upd_product:                return upd_product( prm, ka );
+    case e_cmd_add_price:                  return add_price( prm, ka );
+    case e_cmd_add_publisher:              return add_publisher( prm, ka );
+    case e_cmd_del_publisher:              return del_publisher( prm, ka );
+    case e_cmd_init_price:                 return init_price( prm, ka );
+    case e_cmd_init_test:                  return init_test( prm, ka );
+    case e_cmd_upd_test:                   return upd_test( prm, ka );
+    case e_cmd_set_min_pub:                return set_min_pub( prm, ka );
+    default:                               return ERROR_INVALID_ARGUMENT;
   }
 }
 

--- a/program/src/oracle/oracle.h
+++ b/program/src/oracle/oracle.h
@@ -221,6 +221,12 @@ typedef enum {
   // key[2] sysvar_clock account  [readable]
   e_cmd_upd_price,
 
+  // publish component price, never returning an error even if the update failed
+  // key[0] funding account       [signer writable]
+  // key[1] price account         [writable]
+  // key[2] sysvar_clock account  [readable]
+  e_cmd_upd_price_no_fail_on_error,
+
   // compute aggregate price
   // key[0] funding account       [signer writable]
   // key[1] price account         [writable]

--- a/pyth/tests/conftest.py
+++ b/pyth/tests/conftest.py
@@ -321,6 +321,19 @@ def pyth_add_publisher(
     return pyth_add_price
 
 
+@pytest.fixture(scope='session')
+def solana_logs(solana_test_validator, solana_keygen):
+    with open("solana_logs.txt", 'w') as f:
+        cmd = [
+            'solana', 'logs',
+            '--url', 'localhost',
+            '--keypair', solana_keygen[1],
+        ]
+        p = subprocess.Popen(cmd, stdout=f)
+        yield
+        p.kill()
+
+
 @pytest.fixture(scope='function')
 def pyth_init_price(solana_test_validator, pyth_dir, pyth_add_publisher):
 

--- a/pyth/tests/test_update_price.py
+++ b/pyth/tests/test_update_price.py
@@ -9,7 +9,7 @@ import random
 from pyth.tests.conftest import PRODUCTS
 
 @pytest.mark.asyncio
-async def test_batch_update_price(solana_test_validator, pythd, pyth_dir, pyth_init_product, pyth_init_price):
+async def test_batch_update_price(solana_test_validator, solana_logs, pythd, pyth_dir, pyth_init_product, pyth_init_price):
 
     messageIds = itertools.count()
 


### PR DESCRIPTION
### Overview
This PR adds a new instruction to the Oracle: `cmd_upd_price_no_fail_on_error`. This is exactly the same as `cmd_upd_price`, but never fails the instruction, and therefore the transaction, even if the update is unsuccessful. This is because we will soon send update instructions in batches, and want to prevent a failure in one price feed blocking updates of other prices.

### Approach
- Add the `cmd_upd_price_no_fail_on_error` instruction.
- Change `pythd` to send `cmd_upd_price_no_fail_on_error` JPRC requests instead of `cmd_upd_price`.

### Testing
- `pythd` changes: the existing `pythd` integration tests for the JRPC `update_price` request will now cover the new `e_cmd_upd_price_no_fail_on_error` code paths.
- Oracle changes: new Oracle tests for the `cmd_upd_price_no_fail_on_error` instructions have been added, demonstrating the optimistic failure semantics.

### Caveats
All price update transactions will appear on-chain, even if they are unsuccessful. This means publishers will have to rely on [inspecting publishing slots](https://github.com/pyth-network/pyth-client/blob/main/doc/publish_slot.md) to be sure if their updates were successful.