### PR TITLE
Remove old aggregation logic.

### DIFF
--- a/program/src/oracle/test_oracle.c
+++ b/program/src/oracle/test_oracle.c
@@ -577,7 +577,7 @@ Test( oracle, upd_aggregate ) {
   upd_aggregate( px, 1001 );
   cr_assert( px->agg_.price_ == 145 );
   cr_assert( px->agg_.conf_ == 55 );
-  cr_assert( px->twap_.val_ == 108 );
+  cr_assert( px->twap_.val_ == 106 );
   cr_assert( px->twac_.val_ == 16 );
   cr_assert( px->num_qt_ == 2 );
 
@@ -591,8 +591,8 @@ Test( oracle, upd_aggregate ) {
   upd_aggregate( px, 1001 );
   cr_assert( px->agg_.price_ == 200 );
   cr_assert( px->agg_.conf_ == 90 );
-  cr_assert( px->twap_.val_ == 116 );
-  cr_assert( px->twac_.val_ == 22 );
+  cr_assert( px->twap_.val_ == 114 );
+  cr_assert( px->twac_.val_ == 23 );
   cr_assert( px->num_qt_ == 3 );
 
   // four publishers
@@ -606,8 +606,8 @@ Test( oracle, upd_aggregate ) {
   upd_aggregate( px, 1001 );
   cr_assert( px->agg_.price_ == 245 );
   cr_assert( px->agg_.conf_ == 85 );
-  cr_assert( px->twap_.val_ == 124 );
-  cr_assert( px->twac_.val_ == 27 );
+  cr_assert( px->twap_.val_ == 125 );
+  cr_assert( px->twac_.val_ == 28 );
   cr_assert( px->last_slot_ == 1001 );
   cr_assert( px->num_qt_ == 4 );
 

--- a/pyth/tests/qset/36.result
+++ b/pyth/tests/qset/36.result
@@ -1,1 +1,1 @@
-{"exponent":-8,"price":0,"conf":0,"status":"unknown"}
+{"exponent":-8,"price":1002000000,"conf":48998000000,"status":"trading"}

--- a/pyth/tests/qset/39.result
+++ b/pyth/tests/qset/39.result
@@ -1,1 +1,1 @@
-{"exponent":-8,"price":0,"conf":0,"status":"unknown"}
+{"exponent":-8,"price":115000000,"conf":94900000,"status":"trading"}


### PR DESCRIPTION
This removes the old aggregation logic and simply stores the price and confidence directly in the aggregate. This follows up on the aggregation logic in v2 extracted from #139 and removes the grafting on input to the TWAP calculation.