### PR TITLE
Add Compiler flag to ignore deprecated OpenSSL declarations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ set( CMAKE_INCLUDE_CURRENT_DIR ON )
 include_directories( program/src/ )
 
 # gcc compiler/linker flags
-add_compile_options( -ggdb -Wall -Wextra -Wsign-conversion -Werror -m64 )
+add_compile_options( -ggdb -Wall -Wextra -Wsign-conversion -Werror -Wno-deprecated-declarations -m64 )
 set( CMAKE_CXX_FLAGS -std=c++11 )
 set( CMAKE_C_FLAGS -std=c99 )
 set( CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -pthread")


### PR DESCRIPTION
When compiling against OpenSSL versions => 3.0, the build will error out
due to the usage of methods like SHA256_Update, SHA256_Init, etc..

See: https://wiki.openssl.org/index.php/OpenSSL_3.0

While these functions should probably be ported to their new
equivalents, this at least allows for the client to be compiled.