### PR TITLE
Add documentation and update example for batch price updates

### DIFF
--- a/doc/cpp-batching-upgrade.md
+++ b/doc/cpp-batching-upgrade.md
@@ -1,0 +1,13 @@
+# Batch Price Updates
+
+As of 2.10.1, `pyth-client` has support for sending batched price updates. This significantly reduces SOL burn, so we strongly advise that you update to this newer version.
+
+## Websocket API
+If you are using the [websocket JRPC API](websocket_api.md) to send updates to `pythd`, all you need to do is update the version of pythd you are running to [`2.10.1`](https://github.com/pyth-network/pyth-client/releases/tag/mainnet-v2.10.1).
+
+## C++ Bindings
+If you are linking against the C++ bindings, you will need to make some changes to your code to support sending batched updates.
+
+Instead of sending individual price updates in response to `price_sched` callbacks, you will now need to call `pc::price::send` with a vector of `pc::price` objects that you wish to publish, in response to `on_slot_publish` callbacks. These will then be batched into transactions. The [`test_publish.cpp`](../pctest/test_publish.cpp) example has been updated to use this new approach.
+
+**Important**: this is a breaking change for C++ publishers, so you will need to update your code as described above for `2.10.1` to work.

--- a/pctest/test_publish.cpp
+++ b/pctest/test_publish.cpp
@@ -59,6 +59,12 @@ public:
   // callback for re-initialization of price account (with diff. exponent)
   void on_response( pc::price_init *, uint64_t ) override;
 
+  // user-facing method to update the price this publisher will send
+  void update_price( int64_t px_, uint64_t sprd_ );
+
+  // the pyth price publisher for this symbol
+  pc::price *sym_;
+
 private:
   void unsubscribe();
 
@@ -72,7 +78,8 @@ private:
 };
 
 test_publish::test_publish( pc::price *sym, int64_t px, uint64_t sprd )
-: sub_( this ),
+: sym_( sym ),
+  sub_( this ),
   px_( px ),
   sprd_( sprd ),
   rcnt_( 0UL )
@@ -262,6 +269,11 @@ void test_publish::on_response( pc::price_init *ptr, uint64_t )
     .add( "symbol", sym->get_symbol() )
     .add( "exponent", sym->get_price_exponent() )
     .end();
+}
+
+// Updates the price value stored locally, without sending the update.
+void test_publish::update_price( int64_t px_, uint64_t sprd_ ) {
+  sym_->update_no_send( px_, sprd_, pc::symbol_status::e_trading, false );
 }
 
 std::string get_rpc_host()

--- a/pctest/test_publish.cpp
+++ b/pctest/test_publish.cpp
@@ -3,6 +3,7 @@
 #include <unistd.h>
 #include <signal.h>
 #include <iostream>
+#include <stdlib.h>
 
 class test_publish;
 
@@ -38,7 +39,6 @@ public:
 
   void teardown();
 
-private:
   test_publish *pub1_;     // SYMBOL1 publisher
   test_publish *pub2_;     // SYMBOL2 publisher
 };
@@ -353,6 +353,11 @@ int usage()
   return 1;
 }
 
+int64_t random_value( )
+{
+  return rand() % 10 + 1;
+}
+
 int main(int argc, char** argv)
 {
   // unpack options
@@ -418,6 +423,15 @@ int main(int argc, char** argv)
   // and requests to submit price
   while( do_run && !mgr.get_is_err() ) {
     mgr.poll( do_wait );
+
+    // Submit new price updates
+    if ( sub.pub1_ != nullptr ) {
+      sub.pub1_->update_price( random_value() ,  uint64_t( random_value() ) );
+    }
+    if ( sub.pub2_ != nullptr ) {
+      sub.pub2_->update_price( random_value() ,  uint64_t( random_value() ) );
+    }
+
   }
 
   // report any errors on exit


### PR DESCRIPTION
This PR adds some documentation explaining how publishers which link to the C++ bindings need to modify their code in order to send batch price updates. The `test_publish.cpp` example has also been updated to demonstrate this.