### PR TITLE
Store value of previous price aggregate if the status is trading

### DIFF
--- a/pctest/fuzz.cpp
+++ b/pctest/fuzz.cpp
@@ -266,9 +266,7 @@ void test_upd_ema(int64_t n, int64_t d, pd_t* val) {
     }
     qs->expo_ = -9;
 
-    pc_price_t prc[1];
-    prc->drv1_ = 1;
-    upd_ema(ema, val, conf, 1, qs, prc);
+    upd_ema(ema, val, conf, 1, qs);
 
     pd_t result[1];
     result->v_ = ema->val_;

--- a/pctest/test_qset.cpp
+++ b/pctest/test_qset.cpp
@@ -149,7 +149,7 @@ int main( int argc,char** argv )
     ptr->latest_.pub_slot_ =
       static_cast< uint64_t >( static_cast< int64_t >( slot ) + pub_slot );
   }
-  upd_aggregate( px, slot+1 );
+  upd_aggregate( px, slot+1, 1234 );
 
   char const* status = "invalid value";
   switch ( px->agg_.status_ ) {

--- a/pctest/test_twap.cpp
+++ b/pctest/test_twap.cpp
@@ -77,10 +77,11 @@ int main( int argc,char** argv )
   pc_price_t px[1];
   __builtin_memset( px, 0, sizeof( pc_price_t ) );
   uint64_t slot = 1000;
+  int64_t timestamp = 1234;
   px->last_slot_ = slot;
   px->agg_.pub_slot_ = slot;
   px->num_  = 0;
-  upd_aggregate( px, slot+1 );
+  upd_aggregate( px, slot+1, timestamp );
   pc_qset_t *qs = nullptr;
 
   // skip first line

--- a/program/src/oracle/oracle.c
+++ b/program/src/oracle/oracle.c
@@ -459,6 +459,7 @@ static uint64_t upd_test( SolParameters *prm, SolAccountInfo *ka )
 
   // compute aggregate price
   uint64_t slot = 1000UL;
+  int64_t timestamp = 5678;
   px->last_slot_= slot;
   px->agg_.pub_slot_ = slot;
   px->expo_      = cmd->expo_;
@@ -470,7 +471,7 @@ static uint64_t upd_test( SolParameters *prm, SolAccountInfo *ka )
     ptr->latest_.conf_   = cmd->conf_[i];
     ptr->latest_.pub_slot_ = slot + (uint64_t)cmd->slot_diff_[i];
   }
-  upd_aggregate( px, slot+1 );
+  upd_aggregate( px, slot+1, timestamp );
 
   return SUCCESS;
 }
@@ -527,7 +528,7 @@ static uint64_t upd_price( SolParameters *prm, SolAccountInfo *ka )
 
   // update aggregate price as necessary
   if ( sptr->slot_ > pptr->agg_.pub_slot_ ) {
-    upd_aggregate( pptr, sptr->slot_ );
+    upd_aggregate( pptr, sptr->slot_, sptr->unix_timestamp_ );
   }
 
   // update component price if required

--- a/program/src/oracle/oracle.h
+++ b/program/src/oracle/oracle.h
@@ -157,7 +157,7 @@ typedef struct pc_price
   uint64_t        valid_slot_;        // valid on-chain slot of agg. price
   pc_ema_t        twap_;              // time-weighted average price
   pc_ema_t        twac_;              // time-weighted average conf interval
-  int64_t         drv1_;              // space for future derived values
+  int64_t         timestamp_;         // unix timestamp of aggregate price
   uint8_t         min_pub_;           // min publishers for valid price
   int8_t          drv2_;              // space for future derived values
   int16_t         drv3_;              // space for future derived values
@@ -167,7 +167,7 @@ typedef struct pc_price
   uint64_t        prev_slot_;         // valid slot of previous aggregate with TRADING status
   int64_t         prev_price_;        // aggregate price of previous aggregate with TRADING status
   uint64_t        prev_conf_;         // confidence interval of previous aggregate with TRADING status
-  uint64_t        drv5_;              // space for future derived values
+  int64_t         prev_timestamp_;    // unix timestamp of previous aggregate with TRADING status
   pc_price_info_t agg_;               // aggregate price information
   pc_price_comp_t comp_[PC_COMP_SIZE];// component prices
 } pc_price_t;

--- a/program/src/oracle/oracle.h
+++ b/program/src/oracle/oracle.h
@@ -164,9 +164,9 @@ typedef struct pc_price
   int32_t         drv4_;              // space for future derived values
   pc_pub_key_t    prod_;              // product id/ref-account
   pc_pub_key_t    next_;              // next price account in list
-  uint64_t        prev_slot_;         // valid slot of previous update
-  int64_t         prev_price_;        // aggregate price of previous update
-  uint64_t        prev_conf_;         // confidence interval of previous update
+  uint64_t        prev_slot_;         // valid slot of previous aggregate with TRADING status
+  int64_t         prev_price_;        // aggregate price of previous aggregate with TRADING status
+  uint64_t        prev_conf_;         // confidence interval of previous aggregate with TRADING status
   uint64_t        drv5_;              // space for future derived values
   pc_price_info_t agg_;               // aggregate price information
   pc_price_comp_t comp_[PC_COMP_SIZE];// component prices

--- a/program/src/oracle/test_oracle.c
+++ b/program/src/oracle/test_oracle.c
@@ -569,6 +569,9 @@ Test( oracle, upd_aggregate ) {
   cr_assert( px->twac_.val_ == 10 );
   cr_assert( px->num_qt_ == 1 );
   cr_assert( px->timestamp_ == 1 );
+  cr_assert( px->prev_slot_ == 0 );
+  cr_assert( px->prev_price_ == 0 );
+  cr_assert( px->prev_conf_ == 0 );
   cr_assert( px->prev_timestamp_ == 0 );
 
   // two publishers
@@ -584,6 +587,9 @@ Test( oracle, upd_aggregate ) {
   cr_assert( px->twac_.val_ == 16 );
   cr_assert( px->num_qt_ == 2 );
   cr_assert( px->timestamp_ == 2 );
+  cr_assert( px->prev_slot_ == 1000 );
+  cr_assert( px->prev_price_ == 100 );
+  cr_assert( px->prev_conf_ == 10 );
   cr_assert( px->prev_timestamp_ == 1 );
 
   // three publishers
@@ -600,6 +606,9 @@ Test( oracle, upd_aggregate ) {
   cr_assert( px->twac_.val_ == 22 );
   cr_assert( px->num_qt_ == 3 );
   cr_assert( px->timestamp_ == 3 );
+  cr_assert( px->prev_slot_ == 1000 );
+  cr_assert( px->prev_price_ == 147 );
+  cr_assert( px->prev_conf_ == 48 );
   cr_assert( px->prev_timestamp_ == 2 );
 
   // four publishers
@@ -618,6 +627,9 @@ Test( oracle, upd_aggregate ) {
   cr_assert( px->last_slot_ == 1001 );
   cr_assert( px->num_qt_ == 4 );
   cr_assert( px->timestamp_ == 4 );
+  cr_assert( px->prev_slot_ == 1000 );
+  cr_assert( px->prev_price_ == 191 );
+  cr_assert( px->prev_conf_ == 74 );
   cr_assert( px->prev_timestamp_ == 3 );
 
   upd_aggregate( px, 1025, 5 );
@@ -625,6 +637,9 @@ Test( oracle, upd_aggregate ) {
   cr_assert( px->last_slot_ == 1025 );
   cr_assert( px->num_qt_ == 4 );
   cr_assert( px->timestamp_ == 5 );
+  cr_assert( px->prev_slot_ == 1001 );
+  cr_assert( px->prev_price_ == 235 );
+  cr_assert( px->prev_conf_ == 99 );
   cr_assert( px->prev_timestamp_ == 4 );
 
   // check what happens when nothing publishes for a while
@@ -633,6 +648,7 @@ Test( oracle, upd_aggregate ) {
   cr_assert( px->last_slot_ == 1025 );
   cr_assert( px->num_qt_ == 0 );
   cr_assert( px->timestamp_ == 10 );
+  cr_assert( px->prev_slot_ == 1025 );
   cr_assert( px->prev_timestamp_ == 5 );
 }
 

--- a/program/src/oracle/test_oracle.c
+++ b/program/src/oracle/test_oracle.c
@@ -562,12 +562,14 @@ Test( oracle, upd_aggregate ) {
   px->last_slot_ = 1000;
   px->agg_.pub_slot_ = 1000;
   px->comp_[0].latest_ = p1;
-  upd_aggregate( px, 1001 );
+  upd_aggregate( px, 1001, 1 );
   cr_assert( px->agg_.price_ == 100 );
   cr_assert( px->agg_.conf_ == 10 );
   cr_assert( px->twap_.val_ == 100 );
   cr_assert( px->twac_.val_ == 10 );
   cr_assert( px->num_qt_ == 1 );
+  cr_assert( px->timestamp_ == 1 );
+  cr_assert( px->prev_timestamp_ == 0 );
 
   // two publishers
   px->num_ = 0;
@@ -575,12 +577,14 @@ Test( oracle, upd_aggregate ) {
   px->agg_.pub_slot_ = 1000;
   px->comp_[px->num_++].latest_ = p2;
   px->comp_[px->num_++].latest_ = p1;
-  upd_aggregate( px, 1001 );
+  upd_aggregate( px, 1001, 2 );
   cr_assert( px->agg_.price_ == 147 );
   cr_assert( px->agg_.conf_ == 48 );
   cr_assert( px->twap_.val_ == 108 );
   cr_assert( px->twac_.val_ == 16 );
   cr_assert( px->num_qt_ == 2 );
+  cr_assert( px->timestamp_ == 2 );
+  cr_assert( px->prev_timestamp_ == 1 );
 
   // three publishers
   px->num_ = 0;
@@ -589,12 +593,14 @@ Test( oracle, upd_aggregate ) {
   px->comp_[px->num_++].latest_ = p2;
   px->comp_[px->num_++].latest_ = p1;
   px->comp_[px->num_++].latest_ = p3;
-  upd_aggregate( px, 1001 );
+  upd_aggregate( px, 1001, 3 );
   cr_assert( px->agg_.price_ == 191 );
   cr_assert( px->agg_.conf_ == 74 );
   cr_assert( px->twap_.val_ == 116 );
   cr_assert( px->twac_.val_ == 22 );
   cr_assert( px->num_qt_ == 3 );
+  cr_assert( px->timestamp_ == 3 );
+  cr_assert( px->prev_timestamp_ == 2 );
 
   // four publishers
   px->num_ = 0;
@@ -604,24 +610,30 @@ Test( oracle, upd_aggregate ) {
   px->comp_[px->num_++].latest_ = p1;
   px->comp_[px->num_++].latest_ = p4;
   px->comp_[px->num_++].latest_ = p2;
-  upd_aggregate( px, 1001 );
+  upd_aggregate( px, 1001, 4 );
   cr_assert( px->agg_.price_ == 235 );
   cr_assert( px->agg_.conf_ == 99 );
   cr_assert( px->twap_.val_ == 124 );
   cr_assert( px->twac_.val_ == 27 );
   cr_assert( px->last_slot_ == 1001 );
   cr_assert( px->num_qt_ == 4 );
+  cr_assert( px->timestamp_ == 4 );
+  cr_assert( px->prev_timestamp_ == 3 );
 
-  upd_aggregate( px, 1025 );
+  upd_aggregate( px, 1025, 5 );
   cr_assert( px->agg_.status_ == PC_STATUS_TRADING );
   cr_assert( px->last_slot_ == 1025 );
   cr_assert( px->num_qt_ == 4 );
+  cr_assert( px->timestamp_ == 5 );
+  cr_assert( px->prev_timestamp_ == 4 );
 
   // check what happens when nothing publishes for a while
-  upd_aggregate( px, 1026 );
+  upd_aggregate( px, 1026, 10 );
   cr_assert( px->agg_.status_ == PC_STATUS_UNKNOWN );
   cr_assert( px->last_slot_ == 1025 );
   cr_assert( px->num_qt_ == 0 );
+  cr_assert( px->timestamp_ == 10 );
+  cr_assert( px->prev_timestamp_ == 5 );
 }
 
 Test( oracle, del_publisher ) {

--- a/program/src/oracle/test_oracle.c
+++ b/program/src/oracle/test_oracle.c
@@ -650,6 +650,19 @@ Test( oracle, upd_aggregate ) {
   cr_assert( px->timestamp_ == 10 );
   cr_assert( px->prev_slot_ == 1025 );
   cr_assert( px->prev_timestamp_ == 5 );
+
+  // Check that the prev_* fields don't update if the aggregate status is UNKNOWN
+  uint64_t prev_slot_ = px->prev_slot_;
+  int64_t prev_price_ = px->prev_price_;
+  uint64_t prev_conf_ = px->prev_conf_;
+  int64_t prev_timestamp_ = px->prev_timestamp_;
+  upd_aggregate( px, 1028, 12 );
+  cr_assert( px->agg_.status_ == PC_STATUS_UNKNOWN );
+  cr_assert( px->timestamp_ == 12 );
+  cr_assert( px->prev_slot_ == prev_slot_ );
+  cr_assert( px->prev_price_ == prev_price_ );
+  cr_assert( px->prev_conf_ == prev_conf_ );
+  cr_assert( px->prev_timestamp_ == prev_timestamp_ );
 }
 
 Test( oracle, del_publisher ) {

--- a/program/src/oracle/upd_aggregate.h
+++ b/program/src/oracle/upd_aggregate.h
@@ -190,7 +190,7 @@ static inline void upd_aggregate( pc_price_t *ptr, uint64_t slot, int64_t timest
 
   // Update the value of the previous price, if it had TRADING status.
   if ( ptr->agg_.status_ == PC_STATUS_TRADING ) {
-    ptr->prev_slot_      = ptr->valid_slot_;
+    ptr->prev_slot_      = ptr->agg_.pub_slot_;
     ptr->prev_price_     = ptr->agg_.price_;
     ptr->prev_conf_      = ptr->agg_.conf_;
     ptr->prev_timestamp_ = ptr->timestamp_;

--- a/program/src/oracle/upd_aggregate.h
+++ b/program/src/oracle/upd_aggregate.h
@@ -82,7 +82,7 @@ static pc_qset_t *qset_new( int expo )
 
 static void upd_ema(
     pc_ema_t *ptr, pd_t *val, pd_t *conf, int64_t nslot, pc_qset_t *qs
-    , pc_price_t *prc_ptr)
+    )
 {
   pd_t numer[1], denom[1], cwgt[1], wval[1], decay[1], diff[1], one[1];
   pd_new( one, 100000000L, -8 );
@@ -103,15 +103,8 @@ static void upd_ema(
     pd_add( decay, decay, one, qs->fact_ );
 
     // compute numer/denom and new value from decay factor
-    if ( prc_ptr->drv1_ ) {
-      pd_load( numer, ptr->numer_ );
-      pd_load( denom, ptr->denom_ );
-    }
-    else {
-      // temporary upgrade code
-      pd_new_scale( numer, ptr->numer_, PD_EMA_EXPO );
-      pd_new_scale( denom, ptr->denom_, PD_EMA_EXPO );
-    }
+    pd_load( numer, ptr->numer_ );
+    pd_load( denom, ptr->denom_ );
     if ( numer->v_ < 0 || denom->v_ < 0 ) {
       // temporary reset twap on negative value
       pd_set( numer, val );
@@ -135,7 +128,6 @@ static void upd_ema(
     ptr->numer_ = numer1;
     ptr->denom_ = denom1;
   }
-  prc_ptr->drv1_ = 1;
 }
 
 static inline void upd_twap(
@@ -144,8 +136,8 @@ static inline void upd_twap(
   pd_t px[1], conf[1];
   pd_new_scale( px, ptr->agg_.price_, ptr->expo_ );
   pd_new_scale( conf, ( int64_t )( ptr->agg_.conf_ ), ptr->expo_ );
-  upd_ema( &ptr->twap_, px, conf, nslots, qs, ptr );
-  upd_ema( &ptr->twac_, conf, conf, nslots, qs, ptr );
+  upd_ema( &ptr->twap_, px, conf, nslots, qs );
+  upd_ema( &ptr->twac_, conf, conf, nslots, qs );
 }
 
 // compute weighted percentile

--- a/program/src/oracle/upd_aggregate.h
+++ b/program/src/oracle/upd_aggregate.h
@@ -177,7 +177,7 @@ static void wgt_ptile(
 }
 
 // update aggregate price
-static inline void upd_aggregate( pc_price_t *ptr, uint64_t slot )
+static inline void upd_aggregate( pc_price_t *ptr, uint64_t slot, int64_t timestamp )
 {
   // only re-compute aggregate in next slot
   if ( slot <= ptr->agg_.pub_slot_ ) {
@@ -190,14 +190,16 @@ static inline void upd_aggregate( pc_price_t *ptr, uint64_t slot )
 
   // Update the value of the previous price, if it had TRADING status.
   if ( ptr->agg_.status_ == PC_STATUS_TRADING ) {
-    ptr->prev_slot_  = ptr->valid_slot_;
-    ptr->prev_price_ = ptr->agg_.price_;
-    ptr->prev_conf_  = ptr->agg_.conf_;
+    ptr->prev_slot_      = ptr->valid_slot_;
+    ptr->prev_price_     = ptr->agg_.price_;
+    ptr->prev_conf_      = ptr->agg_.conf_;
+    ptr->prev_timestamp_ = ptr->timestamp_;
   }
 
   // update aggregate details ready for next slot
   ptr->valid_slot_ = ptr->agg_.pub_slot_;// valid slot-time of agg. price
   ptr->agg_.pub_slot_ = slot;            // publish slot-time of agg. price
+  ptr->timestamp_ = timestamp;
 
   uint32_t numv = 0;
   uint32_t vidx[ PC_COMP_SIZE ];

--- a/program/src/oracle/upd_aggregate.h
+++ b/program/src/oracle/upd_aggregate.h
@@ -196,10 +196,12 @@ static inline void upd_aggregate( pc_price_t *ptr, uint64_t slot )
   // get number of slots from last published valid price
   int64_t agg_diff = ( int64_t )slot - ( int64_t )( ptr->last_slot_ );
 
-  // copy previous price
-  ptr->prev_slot_  = ptr->valid_slot_;
-  ptr->prev_price_ = ptr->agg_.price_;
-  ptr->prev_conf_  = ptr->agg_.conf_;
+  // Update the value of the previous price, if it had TRADING status.
+  if ( ptr->agg_.status_ == PC_STATUS_TRADING ) {
+    ptr->prev_slot_  = ptr->valid_slot_;
+    ptr->prev_price_ = ptr->agg_.price_;
+    ptr->prev_conf_  = ptr->agg_.conf_;
+  }
 
   // update aggregate details ready for next slot
   ptr->valid_slot_ = ptr->agg_.pub_slot_;// valid slot-time of agg. price


### PR DESCRIPTION
This PR changes the semantics of the `pc_price.prev_slot_`, `pc_price.prev_price_` and `pc_price.prev_conf_` fields to only store the value of the previous price aggregate if the previous price aggregate had a status of TRADING. We also store a new piece of data, the Solana unix timestamp of this previous aggregate, for convenience.