### PR TITLE
Fix inaccurate num_sent metric for last element in batch

### DIFF
--- a/pc/request.cpp
+++ b/pc/request.cpp
@@ -729,6 +729,7 @@ bool price::send( price *prices[], const unsigned n )
 
   manager *mgr1 = nullptr;
 
+  // Build an upd_price rpc request for every price
   for ( unsigned i = 0, j = 0; i < n; ++i ) {
     price *const p = prices[ i ];
     if ( PC_UNLIKELY( ! p->init_ && ! p->init_publish() ) ) {
@@ -772,6 +773,8 @@ bool price::send( price *prices[], const unsigned n )
     p->preq_->set_block_hash( mgr->get_recent_block_hash() );
     upds_.emplace_back( p->preq_ );
 
+    // If the batch is full, or we have reached the end, send the upd_price requests in upds_.
+    // These correspond to the prices[j..i], inclusive.
     if (
       upds_.size() >= mgr->get_max_batch_size()
       || ( upds_.size() && ( i + 1 ) == n )

--- a/pc/request.cpp
+++ b/pc/request.cpp
@@ -823,7 +823,7 @@ bool price::send( price *prices[], const unsigned n )
         p1->inc_sent();
       }
 
-      j = i;
+      j = i + 1;
       upds_.clear();
     }
   }

--- a/pc/request.cpp
+++ b/pc/request.cpp
@@ -774,7 +774,7 @@ bool price::send( price *prices[], const unsigned n )
     upds_.emplace_back( p->preq_ );
 
     // If the batch is full, or we have reached the end, send the upd_price requests in upds_.
-    // These correspond to the prices[j..i], inclusive.
+    // These correspond to the valid prices[j..i], inclusive.
     if (
       upds_.size() >= mgr->get_max_batch_size()
       || ( upds_.size() && ( i + 1 ) == n )


### PR DESCRIPTION
The counter tracking the start element of each batch inside `pc::price::send` does not take into account the fact that the counter tracking the end of each batch is inclusive.

This results in the `inc_sent` method being called twice for the last element of each batch, resulting in an artifically low hit rate metric for those elements.