### PR TITLE
Filter out publisher quotes with wide CIs

### DIFF
--- a/program/src/oracle/oracle.c
+++ b/program/src/oracle/oracle.c
@@ -6,7 +6,7 @@
 #include "upd_aggregate.h"
 
 // Returns the minimum number of lamports required to make an account
-// with dlen bytes of data rent exempt. These values were calculated 
+// with dlen bytes of data rent exempt. These values were calculated
 // using the getMinimumBalanceForRentExemption RPC call, and are
 // guaranteed never to increase.
 static uint64_t rent_exempt_amount( uint64_t dlen )
@@ -561,9 +561,14 @@ static uint64_t upd_price( SolParameters *prm, SolAccountInfo *ka )
 
   // update component price if required
   if ( cptr->cmd_ == e_cmd_upd_price || cptr->cmd_ == e_cmd_upd_price_no_fail_on_error ) {
+    uint32_t status = cptr->status_;
+    if (cptr->conf_ * PC_MAX_CI > cptr->price_) {
+      status = PC_STATUS_UNKNOWN;
+    }
+
     fptr->price_    = cptr->price_;
     fptr->conf_     = cptr->conf_;
-    fptr->status_   = cptr->status_;
+    fptr->status_   = status;
     fptr->pub_slot_ = cptr->pub_slot_;
   }
   return SUCCESS;

--- a/program/src/oracle/oracle.c
+++ b/program/src/oracle/oracle.c
@@ -562,7 +562,14 @@ static uint64_t upd_price( SolParameters *prm, SolAccountInfo *ka )
   // update component price if required
   if ( cptr->cmd_ == e_cmd_upd_price || cptr->cmd_ == e_cmd_upd_price_no_fail_on_error ) {
     uint32_t status = cptr->status_;
-    if (cptr->conf_ * PC_MAX_CI > cptr->price_) {
+
+    // Set publisher's status to unknown unless their CI is sufficiently tight.
+    int64_t threshold_conf = (cptr->price_ / PC_MAX_CI_DIVISOR);
+    if (threshold_conf < 0) {
+      // Safe as long as threshold_conf isn't the min int64, which it isn't as long as PRICE_CONF_THRESHOLD > 1.
+      threshold_conf = -threshold_conf;
+    }
+    if ( cptr->conf_ > (uint64_t) threshold_conf ) {
       status = PC_STATUS_UNKNOWN;
     }
 

--- a/program/src/oracle/oracle.c
+++ b/program/src/oracle/oracle.c
@@ -566,7 +566,7 @@ static uint64_t upd_price( SolParameters *prm, SolAccountInfo *ka )
     // Set publisher's status to unknown unless their CI is sufficiently tight.
     int64_t threshold_conf = (cptr->price_ / PC_MAX_CI_DIVISOR);
     if (threshold_conf < 0) {
-      // Safe as long as threshold_conf isn't the min int64, which it isn't as long as PRICE_CONF_THRESHOLD > 1.
+      // Safe as long as threshold_conf isn't the min int64, which it isn't as long as PC_MAX_CI_DIVISOR > 1.
       threshold_conf = -threshold_conf;
     }
     if ( cptr->conf_ > (uint64_t) threshold_conf ) {

--- a/program/src/oracle/oracle.h
+++ b/program/src/oracle/oracle.h
@@ -23,9 +23,9 @@ extern "C" {
 #define PC_MAX_NUM_DECIMALS  16
 #define PC_PROD_ACC_SIZE    512
 #define PC_EXP_DECAY         -9
-// If ci * this number > price, set publisher status to unknown.
+// If ci > price / PC_MAX_CI_DIVISOR, set publisher status to unknown.
 // (e.g., 20 means ci must be < 5% of price)
-#define PC_MAX_CI_MULTIPLE   20
+#define PC_MAX_CI_DIVISOR    20
 
 #ifndef PC_HEAP_START
 #define PC_HEAP_START (0x300000000)

--- a/program/src/oracle/oracle.h
+++ b/program/src/oracle/oracle.h
@@ -23,6 +23,9 @@ extern "C" {
 #define PC_MAX_NUM_DECIMALS  16
 #define PC_PROD_ACC_SIZE    512
 #define PC_EXP_DECAY         -9
+// If ci * this number > price, set publisher status to unknown.
+// (e.g., 20 means ci must be < 5% of price)
+#define PC_MAX_CI_MULTIPLE   20
 
 #ifndef PC_HEAP_START
 #define PC_HEAP_START (0x300000000)


### PR DESCRIPTION
We've had several instances where publishers have submitted prices that are far from everyone else, but with really wide CIs. The aggregation logic is robust to this case, so a single publisher doing this will not cause a problem. However, this particular problem happens frequently enough that I would like to deal with it in a better way.

In previous cases when this has happened, we have asked publishers to not provide a price if their spread / CI is too wide. E.g., the serum publisher implements this logic https://github.com/pyth-network/pyth-serum/blob/main/program/src/serum-pyth/serum-pyth.c#L266 . 

However, it's a little silly that we keep asking publishers to do this when we can do it directly in the on-chain program. This change copies that serum publisher logic into the logic for updating a publisher's price.

