### PR TITLE
Flush batches early

### DIFF
--- a/pc/manager.cpp
+++ b/pc/manager.cpp
@@ -753,7 +753,7 @@ void manager::on_response( rpc::get_slot *res )
   if (has_status( PC_PYTH_RPC_CONNECTED ) && !is_pub_) {
     // Flush any partial batches of updates, as we've reached the end of the list of products.
     for( user *uptr = olist_.first(); uptr; uptr = uptr->get_next() ) {
-      uptr->send_pending_upds();
+      uptr->send_pending_upds(uptr->num_pending_upds());
     }
   }
 

--- a/pc/manager.cpp
+++ b/pc/manager.cpp
@@ -506,7 +506,7 @@ void manager::poll( bool do_wait )
     // request product quotes from pythd's clients while connected
     poll_schedule();
 
-    // send any pending complete price update batches to solana
+    // Flush any pending complete batches of price updates by submitting solana TXs.
     for( user *uptr = olist_.first(); uptr; uptr = uptr->get_next() ) {
       if (uptr->num_pending_upds() >= get_max_batch_size()) {
         uptr->send_pending_upds(get_max_batch_size());

--- a/pc/user.cpp
+++ b/pc/user.cpp
@@ -330,17 +330,27 @@ void user::parse_get_product( uint32_t tok, uint32_t itok )
   add_tail( itok );
 }
 
-void user::send_pending_upds()
+uint32_t user::num_pending_upds()
+{
+  return pending_vec_.size();
+}
+
+void user::send_pending_upds(uint32_t n)
 {
   if ( pending_vec_.empty() ) {
     return;
   }
 
-  if ( !price::send( pending_vec_.data(), pending_vec_.size()) ) {
+  uint32_t n_sent = n;
+  if (pending_vec_.size() < n) {
+    n_sent = pending_vec_.size();
+  }
+
+  if ( !price::send( pending_vec_.data(), n_sent) ) {
     add_error( 0, PC_BATCH_SEND_FAILED, "batch send failed - please check the pyth logs" );
   }
 
-  pending_vec_.clear();
+  pending_vec_.erase(0, n_sent);
 }
 
 void user::parse_get_all_products( uint32_t itok )

--- a/pc/user.cpp
+++ b/pc/user.cpp
@@ -350,7 +350,7 @@ void user::send_pending_upds(uint32_t n)
     add_error( 0, PC_BATCH_SEND_FAILED, "batch send failed - please check the pyth logs" );
   }
 
-  pending_vec_.erase(0, n_sent);
+  pending_vec_.erase(pending_vec_.begin(), pending_vec_.begin() + n_sent);
 }
 
 void user::parse_get_all_products( uint32_t itok )

--- a/pc/user.hpp
+++ b/pc/user.hpp
@@ -43,7 +43,11 @@ namespace pc
     // symbol price schedule callback
     void on_response( price_sched *, uint64_t ) override;
 
+    // number of pending price updates that are queued to be sent.
+    uint32_t num_pending_upds();
+
     // send all pending updates
+    // TODO: rename
     void send_pending_upds();
 
   private:

--- a/pc/user.hpp
+++ b/pc/user.hpp
@@ -43,11 +43,11 @@ namespace pc
     // symbol price schedule callback
     void on_response( price_sched *, uint64_t ) override;
 
-    // number of pending price updates that are queued to be sent.
+    // Get the number of pending price updates that are queued to be sent.
     uint32_t num_pending_upds();
 
-    // send all pending updates
-    // TODO: rename
+    // send up to n pending price updates. If n > the max batch size,
+    // this will split the price updates into multiple transactions.
     void send_pending_upds(uint32_t n);
 
   private:

--- a/pc/user.hpp
+++ b/pc/user.hpp
@@ -48,7 +48,7 @@ namespace pc
 
     // send all pending updates
     // TODO: rename
-    void send_pending_upds();
+    void send_pending_upds(uint32_t n);
 
   private:
 


### PR DESCRIPTION
At the moment, pythd sends all of the price update transactions at roughly the same time. I think this is causing the later transactions to fail (though I'm not 100% sure).

Before we added batching, pythd staggered price updates by staggering requests for prices. When the client responded to this request, pythd immediately sent a price update transaction. This approach had the effect of staggering the update transactions (because the staggered update request schedule is directly reflected in the TXs). We lost this staggering when we added batching, because the client responses were queued and then flushed at the start of the next slot.

This change adds back staggering by eagerly sending transactions for any complete batches during the slot. It also explicitly flushes any pending updates at the end of the price request schedule; this flushing handles the case where there aren't enough prices to complete a single batch.