### PR TITLE
Publish pythd releases

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -10,6 +10,7 @@ env:
   DOCKER_HUB: docker.io
   DOCKER_USER: ${{ secrets.DOCKER_IO_USER }}
   IS_RELEASE: ${{
+    startsWith( github.ref, 'refs/tags/pythd-' ) ||
     startsWith( github.ref, 'refs/tags/devnet-' ) ||
     startsWith( github.ref, 'refs/tags/testnet-' ) ||
     startsWith( github.ref, 'refs/tags/mainnet-' ) }}


### PR DESCRIPTION
This allows us to publish images for pythd releases independently of the oracle releases.