### PR TITLE
Batch price updates across all websocket users

### DIFF
--- a/pc/manager.cpp
+++ b/pc/manager.cpp
@@ -449,9 +449,9 @@ void manager::send_pending_ups()
   // or time since the previously sent batch is greater than PC_FLUSH_INTERVAL
   // the buffer is being updated by user class un user::parse_upd_price
   int64_t curr_ts = get_now();
-  if (curr_ts - previous_ts_ > PC_FLUSH_INTERVAL) {
-    n_to_send = pr_upds_.size();
-  } else if (pr_upds_.size() >= get_max_batch_size()) {
+  if (curr_ts - last_upd_ts_> PC_FLUSH_INTERVAL) {
+    n_to_send = pending_upds_.size();
+  } else if (pending_upds_.size() >= get_max_batch_size()) {
     n_to_send = get_max_batch_size();
   }
 
@@ -460,13 +460,13 @@ void manager::send_pending_ups()
   }
 
   // send batch of price updates to solana
-  price::send( pr_upds_.data(), n_to_send);
+  price::send( pending_upds_.data(), n_to_send);
 
   // remove the sent elements from the vector
-  pr_upds_.erase(pr_upds_.begin(), pr_upds_.begin() + n_to_send);
+  pending_upds_.erase(pending_upds_.begin(), pending_upds_.begin() + n_to_send);
 
   // record the current time
-  previous_ts_ = curr_ts;
+  last_upd_ts_= curr_ts;
 }
 
 void manager::poll( bool do_wait )
@@ -958,8 +958,8 @@ price *manager::get_price( const pub_key& acc )
 
 void manager::add_dirty_price(price* sptr)
 {
-  if( std::find(pr_upds_.begin(), pr_upds_.end(), sptr) == pr_upds_.end() ) {
-    pr_upds_.emplace_back( sptr );
+  if( std::find(pending_upds_.begin(), pending_upds_.end(), sptr) == pending_upds_.end() ) {
+    pending_upds_.emplace_back( sptr );
   }
 }
 

--- a/pc/manager.hpp
+++ b/pc/manager.hpp
@@ -264,6 +264,12 @@ namespace pc
     rpc::get_recent_block_hash breq_[1]; // block hash request
     rpc::program_subscribe     preq_[1]; // program account subscription
     rpc::get_program_accounts  areq_[1]; // alternative to program_subscribe
+
+    // price updates to be sent as part of the next batch
+    std::vector<price*> pr_upds_;
+
+    // Timestamp of the last batch
+    int64_t previous_ts_ = 0;
   };
 
   inline bool manager::get_is_tx_connect() const

--- a/pc/manager.hpp
+++ b/pc/manager.hpp
@@ -224,8 +224,10 @@ namespace pc
     void poll_schedule();
     void reset_status( int );
 
-    // sends pending updates if the previous send was more than PC_FLUSH_INTERVAL ago
-    // or there is >= get_max_batch_size() pending updates
+    // send a batch of pending price updates. This function eagerly sends any complete batches.
+    // It also sends partial batches that have not been completed within a short interval of time.
+    // At most one complete batch will be sent. Additional price updates remain queued until the next
+    // time this function is invoked.
     void send_pending_ups();
 
     net_loop     nl_;       // epoll loop
@@ -272,11 +274,11 @@ namespace pc
     rpc::program_subscribe     preq_[1]; // program account subscription
     rpc::get_program_accounts  areq_[1]; // alternative to program_subscribe
 
-    // price updates to be sent as part of the next batch
-    std::vector<price*> pr_upds_;
+    // price updates that have not been sent yet
+    std::vector<price*> pending_upds_;
 
     // Timestamp of the last batch
-    int64_t previous_ts_ = 0;
+    int64_t last_upd_ts_= 0;
   };
 
   inline bool manager::get_is_tx_connect() const

--- a/pc/manager.hpp
+++ b/pc/manager.hpp
@@ -135,6 +135,9 @@ namespace pc
     product *get_product( const pub_key& );
     price   *get_price( const pub_key& );
 
+    // adds dirty price to pending updates buffer
+    void add_dirty_price(price* sptr);
+
     // submit pyth client api request
     void submit( request * );
     void submit( net_wtr& );

--- a/pc/manager.hpp
+++ b/pc/manager.hpp
@@ -224,6 +224,10 @@ namespace pc
     void poll_schedule();
     void reset_status( int );
 
+    // sends pending updates if the previous send was more than PC_FLUSH_INTERVAL ago
+    // or there is >= get_max_batch_size() pending updates
+    void send_pending_ups();
+
     net_loop     nl_;       // epoll loop
     tcp_connect  hconn_;    // rpc http connection
     ws_connect  *wconn_;    // rpc websocket sonnection

--- a/pc/user.cpp
+++ b/pc/user.cpp
@@ -13,8 +13,6 @@
 #define PC_JSON_MISSING_PERMS   -32001
 #define PC_JSON_NOT_READY       -32002
 #define PC_BATCH_SEND_FAILED    -32010
-// Flush partial batches if not completed within 400 ms.
-#define PC_FLUSH_INTERVAL       (400L*PC_NSECS_IN_MSEC)
 
 using namespace pc;
 
@@ -36,7 +34,6 @@ user::user()
   hsvr_.set_net_connect( this );
   hsvr_.set_ws_parser( this );
   set_net_parser( &hsvr_ );
-  last_upd_ts_ = get_now();
 }
 
 void user::set_rpc_client( rpc_client *rptr )
@@ -211,9 +208,9 @@ void user::parse_upd_price( uint32_t tok, uint32_t itok )
 
     // Add the updated price to the pending updates
     sptr->update_no_send( price, conf, stype, false );
-    if( std::find(pending_vec_.begin(), pending_vec_.end(), sptr) == pending_vec_.end() ) {
-      pending_vec_.emplace_back( sptr );
-    }
+
+    // pass the updated price to manager
+    sptr_->add_dirty_price(sptr);
 
     // Send the result back
     add_header();
@@ -331,45 +328,6 @@ void user::parse_get_product( uint32_t tok, uint32_t itok )
   prod->dump_json( jw_ );
   jw_.pop();
   add_tail( itok );
-}
-
-void user::get_pending_upds(std::vector<price*>* upd_ptr)
-{
-  if (!upd_ptr)
-    return;
-
-  uint32_t n_to_send = 0;
-  int64_t curr_ts = get_now();
-  if (curr_ts - last_upd_ts_ > PC_FLUSH_INTERVAL) {
-    n_to_send = pending_vec_.size();
-  }
-
-  if (n_to_send == 0) {
-    return;
-  }
-
-  for(size_t idx = 0; idx < n_to_send; ++idx)
-  {
-    upd_ptr->push_back(pending_vec_[idx]);
-  }
-
-  pending_vec_.erase(pending_vec_.begin(), pending_vec_.begin() + n_to_send);
-  last_upd_ts_ = curr_ts;
-}
-
-void user::add_batch_send_failed()
-{
-  add_error( 0, PC_BATCH_SEND_FAILED, "batch send failed - please check the pyth logs" );
-}
-
-void user::set_incl_price_batch(bool i_incl_price_batch)
-{
-  incl_price_batch_ = i_incl_price_batch;
-}
-
-bool user::get_incl_price_batch() const
-{
-  return incl_price_batch_;
 }
 
 void user::parse_get_all_products( uint32_t itok )

--- a/pc/user.hpp
+++ b/pc/user.hpp
@@ -43,11 +43,25 @@ namespace pc
     // symbol price schedule callback
     void on_response( price_sched *, uint64_t ) override;
 
-    // send a batch of pending price updates. This function eagerly sends any complete batches.
-    // It also sends partial batches that have not been completed within a short interval of time.
-    // At most one complete batch will be sent. Additional price updates remain queued until the next
+    // get a batch of pending price updates. This function eagerly gets any complete batches.
+    // It also gets partial batches that have not been completed within a short interval of time.
+    // All complete batches will be sent. Additional price updates remain queued until the next
     // time this function is invoked.
-    void send_pending_upds();
+    // is nullptr is given then it does nothing
+    void get_pending_upds(std::vector<price*>*);
+
+    // notify the user about bath send failed error
+    void add_batch_send_failed();
+
+    // set info if the user participated in manager::poll price batch
+    // used to store batch in between manager::poll invocations
+    // and notify the user in case of error while sending to the oracle
+    void set_incl_price_batch(bool);
+
+    // get info if the user participated in manager::poll price batch
+    // used to store batch in between manager::poll invocations
+    // and notify the user in case of error while sending to the oracle
+    bool get_incl_price_batch() const;
 
   private:
 
@@ -89,6 +103,10 @@ namespace pc
     request_sub_set psub_;        // price subscriptions
     pending_vec_t   pending_vec_; // prices with pending updates
     int64_t         last_upd_ts_; // timestamp of last price update transaction
+    // was the user included in manager::poll price update
+    // used to store batch in between manager::poll invocations
+    // and notify the user in case of error while sending to the oracle
+    bool            incl_price_batch_ = false;
   };
 
 }

--- a/pc/user.hpp
+++ b/pc/user.hpp
@@ -43,26 +43,6 @@ namespace pc
     // symbol price schedule callback
     void on_response( price_sched *, uint64_t ) override;
 
-    // get a batch of pending price updates. This function eagerly gets any complete batches.
-    // It also gets partial batches that have not been completed within a short interval of time.
-    // All complete batches will be sent. Additional price updates remain queued until the next
-    // time this function is invoked.
-    // is nullptr is given then it does nothing
-    void get_pending_upds(std::vector<price*>*);
-
-    // notify the user about bath send failed error
-    void add_batch_send_failed();
-
-    // set info if the user participated in manager::poll price batch
-    // used to store batch in between manager::poll invocations
-    // and notify the user in case of error while sending to the oracle
-    void set_incl_price_batch(bool);
-
-    // get info if the user participated in manager::poll price batch
-    // used to store batch in between manager::poll invocations
-    // and notify the user in case of error while sending to the oracle
-    bool get_incl_price_batch() const;
-
   private:
 
     // http-only request parsing
@@ -77,7 +57,6 @@ namespace pc
     };
 
     typedef std::vector<deferred_sub> def_vec_t;
-    typedef std::vector<price*> pending_vec_t;
 
     void parse_request( uint32_t );
     void parse_get_product_list( uint32_t );
@@ -101,12 +80,6 @@ namespace pc
     json_wtr        jw_;          // json writer
     def_vec_t       dvec_;        // deferred subscriptions
     request_sub_set psub_;        // price subscriptions
-    pending_vec_t   pending_vec_; // prices with pending updates
-    int64_t         last_upd_ts_; // timestamp of last price update transaction
-    // was the user included in manager::poll price update
-    // used to store batch in between manager::poll invocations
-    // and notify the user in case of error while sending to the oracle
-    bool            incl_price_batch_ = false;
   };
 
 }


### PR DESCRIPTION
Expand batching to apply to all JRPC clients. This allows publishers to push prices from different systems and still benefit from the massive gas savings batching can provide.

~`price::send()` never returns false, so the logic to track which users participated in a batch could be removed without much impact.~