### PR TITLE
Check exponent range

### DIFF
--- a/program/src/oracle/oracle.h
+++ b/program/src/oracle/oracle.h
@@ -20,7 +20,9 @@ extern "C" {
 #define PC_PUBKEY_SIZE_64   (PC_PUBKEY_SIZE/sizeof(uint64_t))
 #define PC_MAP_TABLE_SIZE   640
 #define PC_COMP_SIZE         32
-#define PC_MAX_NUM_DECIMALS  16
+// Bound on the range of the exponent in price accounts. This number is set such that the
+// PD-based EMA computation does not lose too much precision.
+#define PC_MAX_NUM_DECIMALS   8
 #define PC_PROD_ACC_SIZE    512
 #define PC_EXP_DECAY         -9
 // If ci > price / PC_MAX_CI_DIVISOR, set publisher status to unknown.


### PR DESCRIPTION
Bound the range on price account exponents `8 >= expo >= -8` such the the EMA computation can't lose too much precision. 