### PR TITLE
add logging to upd_price and upd_aggregate

### DIFF
--- a/program/c/src/oracle/oracle.c
+++ b/program/c/src/oracle/oracle.c
@@ -529,11 +529,9 @@ static uint64_t upd_price( SolParameters *prm, SolAccountInfo *ka )
   // update aggregate price as necessary
   if ( sptr->slot_ > pptr->agg_.pub_slot_ ) {
     upd_aggregate( pptr, sptr->slot_, sptr->unix_timestamp_ );
-    if (pptr->agg_.status_ == PC_STATUS_TRADING) {
-      sol_log("agg_price, agg_conf, status, pub_slot");
-      // last value is 0 because sol_log_64() takes in 5 args
-      sol_log_64(pptr->agg_.price_, pptr->agg_.conf_, pptr->agg_.status_, pptr->last_slot_, 0);
-    }
+    sol_log("agg_price, agg_conf, status, pub_slot");
+    // last value is 0 because sol_log_64() takes in 5 args
+    sol_log_64(pptr->agg_.price_, pptr->agg_.conf_, pptr->agg_.status_, pptr->last_slot_, 0);
   }
 
   // update component price if required

--- a/program/c/src/oracle/oracle.c
+++ b/program/c/src/oracle/oracle.c
@@ -510,6 +510,9 @@ static uint64_t upd_price( SolParameters *prm, SolAccountInfo *ka )
     fptr->conf_     = cptr->conf_;
     fptr->status_   = status;
     fptr->pub_slot_ = cptr->pub_slot_;
+    sol_log("Instruction: UpdatePrice");
+    sol_log("price, conf, status, pub_slot");
+    sol_log_64(fptr->price_ , fptr->conf_, fptr->status_, fptr->pub_slot_, 0);
   }
   return SUCCESS;
 }

--- a/program/c/src/oracle/oracle.c
+++ b/program/c/src/oracle/oracle.c
@@ -7,7 +7,7 @@
 
 
 // Returns the respective log messages given the command.
-static const char* get_log_message( command_t cmd )
+static const char* get_log_message( int32_t cmd )
 {
   switch ( cmd )
   {
@@ -39,6 +39,8 @@ static const char* get_log_message( command_t cmd )
     return "Instruction: SetMinPub";
   case e_cmd_upd_price_no_fail_on_error:
     return "Instruction: UpdatePriceNoFailOnError";
+  default:
+    return "Instruction: Unknown";
   }
 }
 

--- a/program/c/src/oracle/oracle.c
+++ b/program/c/src/oracle/oracle.c
@@ -490,6 +490,9 @@ static uint64_t upd_price( SolParameters *prm, SolAccountInfo *ka )
   // update aggregate price as necessary
   if ( sptr->slot_ > pptr->agg_.pub_slot_ ) {
     upd_aggregate( pptr, sptr->slot_, sptr->unix_timestamp_ );
+    sol_log("Instruction: UpdateAggregatePrice");
+    sol_log("price, conf, status, pub_slot");
+    sol_log_64(pptr->agg_.price_, pptr->agg_.conf_, pptr->agg_.status_, pptr->last_slot_, 0);
   }
 
   // update component price if required

--- a/program/c/src/oracle/upd_aggregate.h
+++ b/program/c/src/oracle/upd_aggregate.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <solana_sdk.h>
 #include "oracle.h"
 #include "model/price_model.h"
 #include "model/price_model.c" /* FIXME: HACK TO DEAL WITH DOCKER LINKAGE ISSUES */

--- a/program/c/src/oracle/upd_aggregate.h
+++ b/program/c/src/oracle/upd_aggregate.h
@@ -231,6 +231,9 @@ static inline void upd_aggregate( pc_price_t *ptr, uint64_t slot, int64_t timest
   ptr->agg_.conf_   = (uint64_t)agg_conf;
 
   upd_twap( ptr, agg_diff, qs );
+  sol_log("Instruction: UpdateAggregatePrice");
+  sol_log("price, conf, status, pub_slot");
+  sol_log_64(ptr->agg_.price_, ptr->agg_.conf_, ptr->agg_.status_, ptr->last_slot_, 0);
 }
 
 #ifdef __cplusplus

--- a/program/c/src/oracle/upd_aggregate.h
+++ b/program/c/src/oracle/upd_aggregate.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <solana_sdk.h>
 #include "oracle.h"
 #include "model/price_model.h"
 #include "model/price_model.c" /* FIXME: HACK TO DEAL WITH DOCKER LINKAGE ISSUES */
@@ -232,9 +231,6 @@ static inline void upd_aggregate( pc_price_t *ptr, uint64_t slot, int64_t timest
   ptr->agg_.conf_   = (uint64_t)agg_conf;
 
   upd_twap( ptr, agg_diff, qs );
-  sol_log("Instruction: UpdateAggregatePrice");
-  sol_log("price, conf, status, pub_slot");
-  sol_log_64(ptr->agg_.price_, ptr->agg_.conf_, ptr->agg_.status_, ptr->last_slot_, 0);
 }
 
 #ifdef __cplusplus

--- a/scripts/solana.patch
+++ b/scripts/solana.patch
@@ -1,5 +1,5 @@
 diff --git a/sdk/bpf/c/bpf.mk b/sdk/bpf/c/bpf.mk
-index 541629ad49..8c2ec94041 100644
+index 541629ad49..31e4f46856 100644
 --- a/sdk/bpf/c/bpf.mk
 +++ b/sdk/bpf/c/bpf.mk
 @@ -14,6 +14,12 @@ TEST_PREFIX ?= test_
@@ -25,19 +25,11 @@ index 541629ad49..8c2ec94041 100644
    -Werror \
    -O2 \
    -fno-builtin \
-@@ -68,6 +77,7 @@ BPF_CXX_FLAGS := \
-   -march=bpfel+solana
- 
- BPF_LLD_FLAGS := \
-+  -z defs \
-   -z notext \
-   -shared \
-   --Bdynamic \
-@@ -245,6 +255,7 @@ define TEST_EXEC_RULE
+@@ -245,6 +254,7 @@ define TEST_EXEC_RULE
  $1: $2
- 	LD_LIBRARY_PATH=$(TESTFRAMEWORK_RPATH) \
- 	$2$(\n)
-+	$2 $(TEST_FLAGS)$(\n)
+        LD_LIBRARY_PATH=$(TESTFRAMEWORK_RPATH) \
+        $2$(\n)
++       $2 $(TEST_FLAGS)$(\n)
  endef
  
  .PHONY: $(INSTALL_SH)

--- a/scripts/solana.patch
+++ b/scripts/solana.patch
@@ -27,9 +27,9 @@ index 541629ad49..31e4f46856 100644
    -fno-builtin \
 @@ -245,6 +254,7 @@ define TEST_EXEC_RULE
  $1: $2
-        LD_LIBRARY_PATH=$(TESTFRAMEWORK_RPATH) \
-        $2$(\n)
-+       $2 $(TEST_FLAGS)$(\n)
+ 	LD_LIBRARY_PATH=$(TESTFRAMEWORK_RPATH) \
+ 	$2$(\n)
++	$2 $(TEST_FLAGS)$(\n)
  endef
  
  .PHONY: $(INSTALL_SH)


### PR DESCRIPTION
This PR adds logging to `upd_price` and `upd_aggregate` price which makes up > 99% of pyth's transactions and hence allows easier parsing for metrics/analytics.

This will help us track certain metrics such as:
- number of daily aggregate prices pushed by pyth
- pyth price feed uptime based on status
- and more

Due to solana C sdk limitations (no libc available: https://github.com/solana-labs/solana/tree/master/sdk/bpf/c#limitations), the chosen approach is to separate the logging of static string and `uint64_t` to multiple lines instead of a single line. `sol_log_64` prints 64 bit values represented in hexadecimal to stdout and hence would have to be converted to decimal while processing the data for metrics/analytics.

Comparison of compute units before and after logging for an `UpdatePrice` instruction:
- Before
```
Transaction executed in slot 1871:
  Signature: 5VJHyZAk5qTb9Va7LEJPeVAD2TZR1eKsVMwoXSSo1DxPg4ELTs2nq3U41oK7y3TMgT4eDYJmDUCX26jqh5VrVP9t
  Status: Ok
  Log Messages:
    Program 2Uy3CybcD5kJVH7vZ4fhFUKyLWJtVZvc2cAdphoNS35M invoke [1]
    Program 2Uy3CybcD5kJVH7vZ4fhFUKyLWJtVZvc2cAdphoNS35M consumed 797 of 200000 compute units
    Program 2Uy3CybcD5kJVH7vZ4fhFUKyLWJtVZvc2cAdphoNS35M success
```

- After
```
Transaction executed in slot 4060:
  Signature: F1PMozoZqSrzmEfTXCHm6dWt5uCThvoFtiP9Pw8MDhH7sFQk28eyk5iTEzy8o6kfAC4n2utmYroZJhi3baoXKyV
  Status: Ok
  Log Messages:
    Program Ci9zRpz2DniZ6myKwc5LCE5bg2hLiuCttB296M2XFgzp invoke [1]
    Program log: Instruction: UpdatePrice
    Program log: price, conf, status, pub_slot
    Program log: 0xa412, 0x3, 0x1, 0xfdb, 0x0
    Program Ci9zRpz2DniZ6myKwc5LCE5bg2hLiuCttB296M2XFgzp consumed 954 of 200000 compute units
    Program Ci9zRpz2DniZ6myKwc5LCE5bg2hLiuCttB296M2XFgzp success
```