### PR TITLE
Update README to reference pythd image tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ You can run the following command to open a shell in a linux docker container wi
 ```
 export PYTH_REPO=/path/to/host/pyth-client
 
-// Use the latest mainnet image from https://hub.docker.com/r/pythfoundation/pyth-client/tags?name=mainnet
+// Use the latest pythd image from https://hub.docker.com/r/pythfoundation/pyth-client/tags?name=pythd
 export IMAGE=...
 
 docker run -it \


### PR DESCRIPTION
We now tag and release `pythd` images seperately to the Oracle program, so users should use `pythd` images going forward.