### PR TITLE
link with c only when target is bpf

### DIFF
--- a/program/rust/src/lib.rs
+++ b/program/rust/src/lib.rs
@@ -2,11 +2,15 @@
 //to reflect the current status of oracle.h
 mod c_oracle_header;
 
+//do not link with C during unit tests (which are built in native architecture, unlike libpyth.o) 
+#[cfg(target_arch = "bpf")]
 #[link(name = "cpyth")]
 extern "C" {
     fn c_entrypoint(input: *mut u8) -> u64;
 }
 
+//do not add an entry point during unit tests (which can't be linked to the C entrypoint as explained above) 
+#[cfg(target_arch = "bpf")]
 #[no_mangle]
 pub extern "C" fn entrypoint(input: *mut u8) -> u64 {
     let c_ret_val = unsafe{c_entrypoint(input)};

--- a/program/rust/src/lib.rs
+++ b/program/rust/src/lib.rs
@@ -9,8 +9,13 @@ extern "C" {
     fn c_entrypoint(input: *mut u8) -> u64;
 }
 
-//do not add an entry point during unit tests (which can't be linked to the C entrypoint as explained above) 
-#[cfg(target_arch = "bpf")]
+//make the C entrypoint a no-op when running cargo test
+#[cfg(not(target_arch = "bpf"))]
+pub extern "C" fn c_entrypoint(input: *mut u8) -> u64{
+    0//SUCCESS value
+}
+
+
 #[no_mangle]
 pub extern "C" fn entrypoint(input: *mut u8) -> u64 {
     let c_ret_val = unsafe{c_entrypoint(input)};

--- a/scripts/build-bpf.sh
+++ b/scripts/build-bpf.sh
@@ -43,11 +43,16 @@ cd "${RUST_DIR}"
 cargo install bindgen
 bindgen ./src/bindings.h -o ./src/c_oracle_header.rs
 cargo clean
+cargo test
+cargo clean
 cargo build-bpf
+
 sha256sum ./target/**/*.so
 rm ./target/**/*-keypair.json
 rm -r $PYTH_DIR/target || true
 mv ./target $PYTH_DIR/target
+
+
 
 
 


### PR DESCRIPTION
Running `Cargo test` compiles the oracle into native (none-bpf) code, which causes a linker error when linking with the bpf C oracle.

This PR makes it so that we do not link on cargo test. I believe this is reasonable because unit tests should not involve FFI calls. It makes more sense to unit test each component in the language it is written in. If we think we want the linking to happen, then we would need to understand how to compile the c oracle into a native architecture as well, and link to that when we run cargo test. That seems like  unnecessary work to me (specially with the issues around solana and libc compatibility), but happy to do it if we believe it's useful. 