### PR TITLE
Make c robust to price account size

### DIFF
--- a/pc/request.cpp
+++ b/pc/request.cpp
@@ -354,7 +354,7 @@ void product::update( T *res )
     return;
   }
   pc_prod_t *prod;
-  size_t plen = std::max( sizeof(pc_price_t), (size_t)PC_PROD_ACC_SIZE );
+  size_t plen = std::max( PRICE_ACCOUNT_SIZE, (size_t)PC_PROD_ACC_SIZE );
   if ( sizeof( pc_prod_t ) > res->get_data_ref( prod, plen ) ||
        prod->magic_ != PC_MAGIC ||
        !init_from_account( prod ) ) {
@@ -464,7 +464,7 @@ price::price( const pub_key& acc, product *prod )
   preq_->set_account( &apub_ );
   areq_->set_sub( this );
   preq_->set_sub( this );
-  size_t tlen = ZSTD_compressBound( sizeof(pc_price_t) );
+  size_t tlen = ZSTD_compressBound( PRICE_ACCOUNT_SIZE );
   pptr_ = (pc_price_t*)new char[tlen];
   __builtin_memset( pptr_, 0, tlen );
 }
@@ -952,7 +952,7 @@ void price::update( T *res )
   }
 
   // get account data
-  size_t tlen = ZSTD_compressBound( sizeof(pc_price_t) );
+  size_t tlen = ZSTD_compressBound( PRICE_ACCOUNT_SIZE );
   res->get_data_val( pptr_, tlen );
   if ( PC_UNLIKELY( pptr_->magic_ != PC_MAGIC ) ) {
     on_error_sub( "bad price account header", this );

--- a/program/c/src/oracle/oracle.c
+++ b/program/c/src/oracle/oracle.c
@@ -5,6 +5,7 @@
 #include "oracle.h"
 #include "upd_aggregate.h"
 
+
 // Returns the minimum number of lamports required to make an account
 // with dlen bytes of data rent exempt. These values were calculated
 // using the getMinimumBalanceForRentExemption RPC call, and are
@@ -19,6 +20,8 @@ static uint64_t rent_exempt_amount( uint64_t dlen )
     return 4454400;
   case sizeof( pc_price_t ):
     return 23942400;
+  case PRICE_ACCOUNT_SIZE:
+    return 36915840;
   default:
     return UINT64_MAX;
   }

--- a/program/c/src/oracle/oracle.h
+++ b/program/c/src/oracle/oracle.h
@@ -190,6 +190,8 @@ typedef struct pc_price
 
 static_assert( sizeof( pc_price_t ) == 3312, "" );
 
+const uint64_t PRICE_ACCOUNT_SIZE = TIME_MACHINE_STRUCT_SIZE + sizeof( pc_price_t );
+
 // command enumeration
 typedef enum {
 

--- a/program/c/src/oracle/oracle.h
+++ b/program/c/src/oracle/oracle.h
@@ -17,6 +17,9 @@ const uint64_t SUCCESSFULLY_UPDATED_AGGREGATE = 1000ULL;
 // Rust portion of the codebase.
 const uint64_t TIME_MACHINE_STRUCT_SIZE = 1864ULL;
 
+const uint64_t EXTRA_PUBLISHER_SPACE = 1000ULL;
+
+
 // magic number at head of account
 #define PC_MAGIC 0xa1b2c3d4
 
@@ -190,7 +193,7 @@ typedef struct pc_price
 
 static_assert( sizeof( pc_price_t ) == 3312, "" );
 
-const uint64_t PRICE_ACCOUNT_SIZE = TIME_MACHINE_STRUCT_SIZE + sizeof( pc_price_t );
+const uint64_t PRICE_ACCOUNT_SIZE = TIME_MACHINE_STRUCT_SIZE + EXTRA_PUBLISHER_SPACE + sizeof( pc_price_t );
 
 // command enumeration
 typedef enum {


### PR DESCRIPTION
We plan on resizing price accounts to fit the Time Machine. This PRs ensures that this does not cause existing C code to fail.
There are two places where the size of price_t not being the same as the account size can cause failures:

1-rent exempt check while validating accounts (oracle.c) 
2-Decompressing the result of the RPC request to Solana requesting to read price contracts (pythd, request.cpp)

(We do not change the default new account size for Pyth-manager because it is helpful to have accounts from the old size in unit tests, and C pyth-manager is no longer used anyway)