### PR TITLE
Only return SUCCESSFULLY_UPDATED_AGGREGATE if upd_twap was called [bug fix]

### DIFF
--- a/program/c/src/oracle/oracle.c
+++ b/program/c/src/oracle/oracle.c
@@ -489,8 +489,7 @@ static uint64_t upd_price( SolParameters *prm, SolAccountInfo *ka )
   bool updated_aggregate = false;
   // update aggregate price as necessary
   if ( sptr->slot_ > pptr->agg_.pub_slot_ ) {
-    upd_aggregate( pptr, sptr->slot_, sptr->unix_timestamp_ );
-    updated_aggregate = true;
+    updated_aggregate = upd_aggregate( pptr, sptr->slot_, sptr->unix_timestamp_ );
   }
 
   // update component price if required

--- a/program/c/src/oracle/test_oracle.c
+++ b/program/c/src/oracle/test_oracle.c
@@ -409,7 +409,7 @@ Test( oracle, upd_price ) {
     .data_len   = sizeof( idata ),
     .program_id = &p_id
   };
-  cr_assert( SUCCESSFULLY_UPDATED_AGGREGATE == dispatch( &prm, acc ) );
+  cr_assert( SUCCESS == dispatch( &prm, acc ) );
   cr_assert( sptr->comp_[0].latest_.price_ == 42L );
   cr_assert( sptr->comp_[0].latest_.conf_ == 2L );
   cr_assert( sptr->comp_[0].latest_.pub_slot_ == 1 );
@@ -478,7 +478,7 @@ Test( oracle, upd_price ) {
   // Crank one more time and aggregate should be unknown
   idata.pub_slot_ = 6;
   cvar.slot_ = 7;
-  cr_assert( SUCCESSFULLY_UPDATED_AGGREGATE == dispatch( &prm, acc ) );
+  cr_assert( SUCCESS == dispatch( &prm, acc ) );
   cr_assert( sptr->agg_.status_ == PC_STATUS_UNKNOWN );
 }
 
@@ -559,7 +559,7 @@ Test( oracle, upd_price_no_fail_on_error ) {
   pc_pub_key_assign( &sptr->comp_[0].pub_, (pc_pub_key_t*)&pkey );
 
   // The update should now succeed, and have an effect.
-  cr_assert( SUCCESSFULLY_UPDATED_AGGREGATE == dispatch( &prm, acc ) );
+  cr_assert( SUCCESS == dispatch( &prm, acc ) );
   cr_assert( sptr->comp_[0].latest_.price_ == 42L );
   cr_assert( sptr->comp_[0].latest_.conf_ == 9L );
   cr_assert( sptr->comp_[0].latest_.pub_slot_ == 1 );

--- a/program/c/src/oracle/upd_aggregate.h
+++ b/program/c/src/oracle/upd_aggregate.h
@@ -141,11 +141,11 @@ static inline void upd_twap(
 }
 
 // update aggregate price
-static inline void upd_aggregate( pc_price_t *ptr, uint64_t slot, int64_t timestamp )
+static inline bool upd_aggregate( pc_price_t *ptr, uint64_t slot, int64_t timestamp )
 {
   // only re-compute aggregate in next slot
   if ( slot <= ptr->agg_.pub_slot_ ) {
-    return;
+    return false;
   }
   pc_qset_t *qs = qset_new( ptr->expo_ );
 
@@ -195,7 +195,7 @@ static inline void upd_aggregate( pc_price_t *ptr, uint64_t slot, int64_t timest
     ptr->num_qt_ = numv;
     if ( numv == 0 || numv < ptr->min_pub_ ) {
       ptr->agg_.status_ = PC_STATUS_UNKNOWN;
-      return;
+      return false;
     }
 
     // evaluate the model to get the p25/p50/p75 prices
@@ -220,7 +220,7 @@ static inline void upd_aggregate( pc_price_t *ptr, uint64_t slot, int64_t timest
     // positive confidences given the current pricing model
     if( agg_conf <= (int64_t)0 ) {
       ptr->agg_.status_ = PC_STATUS_UNKNOWN;
-      return;
+      return false;
     }
   }
 
@@ -231,6 +231,7 @@ static inline void upd_aggregate( pc_price_t *ptr, uint64_t slot, int64_t timest
   ptr->agg_.conf_   = (uint64_t)agg_conf;
 
   upd_twap( ptr, agg_diff, qs );
+  return true;
 }
 
 #ifdef __cplusplus


### PR DESCRIPTION
In an earlier PR we made upd_price in C return SUCCESSFULLY_UPDATED_AGGREGATE when upd_aggregate is called. It turns out, update_aggregate sometimes returns early, this PR  makes upd_aggregate return a bool depending on whether the aggregate was updated