### PR TITLE
Made Price_t member offsets available to Rust

### DIFF
--- a/program/rust/src/bindings.h
+++ b/program/rust/src/bindings.h
@@ -12,3 +12,4 @@ typedef signed long int int64_t;
 typedef unsigned long int uint64_t;
 
 #include "../../c/src/oracle/oracle.h"
+#include "price_t_offsets.h"

--- a/program/rust/src/price_t_offsets.h
+++ b/program/rust/src/price_t_offsets.h
@@ -1,0 +1,13 @@
+//The constans below are used by the rust oracle to efficiently access members in price_t
+//price_t is a big struct, attemting to deserialize all of it directly in borsh causes stack
+//issues on Solana, it is also more efficient to only access the members we need
+#include "../../c/src/oracle/oracle.h"
+#include <stddef.h>
+const size_t PRICE_T_EXPO_OFFSET = offsetof(struct pc_price, expo_);
+const size_t PRICE_T_TIMESTAMP_OFFSET = offsetof(struct pc_price, timestamp_);
+const size_t PRICE_T_CONF_OFFSET = offsetof(struct pc_price, agg_) + offsetof(struct pc_price_info, conf_);
+const size_t PRICE_T_AGGREGATE_OFFSET = offsetof(struct pc_price, agg_) + offsetof(struct pc_price_info, price_);
+const size_t PRICE_T_AGGREGATE_STATUS = offsetof(struct pc_price, agg_) + offsetof(struct pc_price_info, status_);
+const size_t PRICE_T_PREV_TIMESTAMP_OFFSET = offsetof(struct pc_price, prev_timestamp_);
+const size_t PRICE_T_PREV_CONF_OFFSET = offsetof(struct pc_price, prev_conf_);
+const size_t PRICE_T_PREV_AGGREGATE_OFFSET = offsetof(struct pc_price, prev_price_);

--- a/program/rust/src/price_t_offsets.h
+++ b/program/rust/src/price_t_offsets.h
@@ -1,13 +1,13 @@
-//The constans below are used by the rust oracle to efficiently access members in price_t
+//The constants below are used by the rust oracle to efficiently access members in price_t
 //price_t is a big struct, attemting to deserialize all of it directly in borsh causes stack
-//issues on Solana, it is also more efficient to only access the members we need
+//issues on Solana. It is also more efficient to only access the members we need
 #include "../../c/src/oracle/oracle.h"
 #include <stddef.h>
 const size_t PRICE_T_EXPO_OFFSET = offsetof(struct pc_price, expo_);
 const size_t PRICE_T_TIMESTAMP_OFFSET = offsetof(struct pc_price, timestamp_);
-const size_t PRICE_T_CONF_OFFSET = offsetof(struct pc_price, agg_) + offsetof(struct pc_price_info, conf_);
-const size_t PRICE_T_AGGREGATE_OFFSET = offsetof(struct pc_price, agg_) + offsetof(struct pc_price_info, price_);
-const size_t PRICE_T_AGGREGATE_STATUS = offsetof(struct pc_price, agg_) + offsetof(struct pc_price_info, status_);
+const size_t PRICE_T_AGGREGATE_CONF_OFFSET = offsetof(struct pc_price, agg_) + offsetof(struct pc_price_info, conf_);
+const size_t PRICE_T_AGGREGATE_PRICE_OFFSET = offsetof(struct pc_price, agg_) + offsetof(struct pc_price_info, price_);
+const size_t PRICE_T_AGGREGATE_STATUS_OFFSET = offsetof(struct pc_price, agg_) + offsetof(struct pc_price_info, status_);
 const size_t PRICE_T_PREV_TIMESTAMP_OFFSET = offsetof(struct pc_price, prev_timestamp_);
 const size_t PRICE_T_PREV_CONF_OFFSET = offsetof(struct pc_price, prev_conf_);
 const size_t PRICE_T_PREV_AGGREGATE_OFFSET = offsetof(struct pc_price, prev_price_);

--- a/program/rust/src/price_t_offsets.h
+++ b/program/rust/src/price_t_offsets.h
@@ -5,6 +5,7 @@
 #include <stddef.h>
 const size_t PRICE_T_EXPO_OFFSET = offsetof(struct pc_price, expo_);
 const size_t PRICE_T_TIMESTAMP_OFFSET = offsetof(struct pc_price, timestamp_);
+const size_t PRICE_T_AGGREGATE_OFFSET = offsetof(struct pc_price, agg_);
 const size_t PRICE_T_AGGREGATE_CONF_OFFSET = offsetof(struct pc_price, agg_) + offsetof(struct pc_price_info, conf_);
 const size_t PRICE_T_AGGREGATE_PRICE_OFFSET = offsetof(struct pc_price, agg_) + offsetof(struct pc_price_info, price_);
 const size_t PRICE_T_AGGREGATE_STATUS_OFFSET = offsetof(struct pc_price, agg_) + offsetof(struct pc_price_info, status_);


### PR DESCRIPTION
Deserializing the entirety of price_t in rust is inefficient when we only need a few members (atleast until we migrate price update logic to rust), and it might cause issues with Solana's limited stack.

In this PR, I add the offsets of the relevant members of price_t to the bindings generated by bindgen. This is done in a way that is robust to changes in the layout of price_t. I am debating whether it is cleaner to write a macro that generates offsets for all members, but I am feeling like this is cleaner for the time being since we only need these few members.