### PR TITLE
Intercepting price updates

### DIFF
--- a/program/c/src/oracle/oracle.h
+++ b/program/c/src/oracle/oracle.h
@@ -6,6 +6,7 @@
 extern "C" {
 #endif
 
+
 //A return value indicating that the aggregate price was updated
 //this triggers SMA trackers to update
 //values 0-14 are defined in solana_sdk.h (v1.10.31 )

--- a/program/c/src/oracle/oracle.h
+++ b/program/c/src/oracle/oracle.h
@@ -264,6 +264,12 @@ typedef enum {
   // key[1] price account         [writable]
   // key[2] sysvar_clock account  [readable]
   e_cmd_upd_price_no_fail_on_error,
+
+  // performs migation logic on the upgraded account. (resizes price accounts)
+  // key[0] funding account       [signer writable]
+  // key[1] upgraded account      [writable]
+  // key[2] system program        [readable]
+  e_cmd_upd_account_version,
 } command_t;
 
 typedef struct cmd_hdr

--- a/program/c/src/oracle/oracle.h
+++ b/program/c/src/oracle/oracle.h
@@ -6,7 +6,6 @@
 extern "C" {
 #endif
 
-
 //A return value indicating that the aggregate price was updated
 //this triggers SMA trackers to update
 //values 0-14 are defined in solana_sdk.h (v1.10.31 )

--- a/program/rust/build.rs
+++ b/program/rust/build.rs
@@ -1,7 +1,6 @@
 mod build_utils;
 use bindgen::Builder;
 
-
 fn main() {
     println!("cargo:rustc-link-search=../c/target");
 
@@ -13,7 +12,6 @@ fn main() {
     parser.register_traits("pc_acc", borsh_derives.to_vec());
     parser.register_traits("pc_price_info", borsh_derives.to_vec());
     parser.register_traits("cmd_upd_price", borsh_derives.to_vec());
-
 
     //generate and write bindings
     let bindings = Builder::default()

--- a/program/rust/build.rs
+++ b/program/rust/build.rs
@@ -5,9 +5,6 @@ use bindgen::Builder;
 fn main() {
     println!("cargo:rustc-link-search=../c/target");
 
-    let borsh_derives: Vec<String> =
-        vec!["BorshSerialize".to_string(), "BorshDeserialize".to_string()];
-
     let borsh_derives = ["BorshSerialize".to_string(), "BorshDeserialize".to_string()];
 
     //make a parser and to it type, traits pairs
@@ -16,6 +13,7 @@ fn main() {
     parser.register_traits("pc_acc", borsh_derives.to_vec());
     parser.register_traits("pc_price_info", borsh_derives.to_vec());
     parser.register_traits("cmd_upd_price", borsh_derives.to_vec());
+
 
     //generate and write bindings
     let bindings = Builder::default()

--- a/program/rust/build.rs
+++ b/program/rust/build.rs
@@ -1,6 +1,7 @@
 mod build_utils;
 use bindgen::Builder;
 
+
 fn main() {
     println!("cargo:rustc-link-search=../c/target");
 

--- a/program/rust/build.rs
+++ b/program/rust/build.rs
@@ -14,7 +14,6 @@ fn main() {
     parser.register_traits("pc_price_info", borsh_derives.to_vec());
     parser.register_traits("cmd_upd_price", borsh_derives.to_vec());
 
-
     //generate and write bindings
     let bindings = Builder::default()
         .header("./src/bindings.h")

--- a/program/rust/build.rs
+++ b/program/rust/build.rs
@@ -5,6 +5,9 @@ use bindgen::Builder;
 fn main() {
     println!("cargo:rustc-link-search=../c/target");
 
+    let borsh_derives: Vec<String> =
+        vec!["BorshSerialize".to_string(), "BorshDeserialize".to_string()];
+
     let borsh_derives = ["BorshSerialize".to_string(), "BorshDeserialize".to_string()];
 
     //make a parser and to it type, traits pairs

--- a/program/rust/build.rs
+++ b/program/rust/build.rs
@@ -14,7 +14,6 @@ fn main() {
     parser.register_traits("cmd_upd_price", borsh_derives.to_vec());
 
 
-
     //generate and write bindings
     let bindings = Builder::default()
         .header("./src/bindings.h")

--- a/program/rust/build_utils.rs
+++ b/program/rust/build_utils.rs
@@ -1,7 +1,6 @@
 use bindgen::callbacks::ParseCallbacks;
 use std::collections::HashMap;
 use std::panic::UnwindSafe;
-use std::panic::UnwindSafe;
 
 ///This type stores a hashmap from structnames
 ///to vectors of trait names, and ensures

--- a/program/rust/build_utils.rs
+++ b/program/rust/build_utils.rs
@@ -1,6 +1,7 @@
 use bindgen::callbacks::ParseCallbacks;
 use std::collections::HashMap;
 use std::panic::UnwindSafe;
+
 ///This type stores a hashmap from structnames
 ///to vectors of trait names, and ensures
 ///that the traits of each struct are added to its

--- a/program/rust/build_utils.rs
+++ b/program/rust/build_utils.rs
@@ -1,6 +1,7 @@
 use bindgen::callbacks::ParseCallbacks;
 use std::collections::HashMap;
 use std::panic::UnwindSafe;
+use std::panic::UnwindSafe;
 
 ///This type stores a hashmap from structnames
 ///to vectors of trait names, and ensures

--- a/program/rust/build_utils.rs
+++ b/program/rust/build_utils.rs
@@ -24,17 +24,6 @@ impl<'a> DeriveAdderParserCallback<'a> {
     }
 }
 
-impl<'a> DeriveAdderParserCallback<'a> {
-    ///create a parser that does not add any traits
-    pub fn new() -> Self {
-        Default::default()
-    }
-    //add pairs of types and their desired traits
-    pub fn register_traits(&mut self, type_name: &'a str, traits: Vec<String>) {
-        self.types_to_traits.insert(&type_name, traits);
-    }
-}
-
 //this is required to implement the callback trait
 impl UnwindSafe for DeriveAdderParserCallback<'_> {}
 

--- a/program/rust/build_utils.rs
+++ b/program/rust/build_utils.rs
@@ -24,6 +24,17 @@ impl<'a> DeriveAdderParserCallback<'a> {
     }
 }
 
+impl<'a> DeriveAdderParserCallback<'a> {
+    ///create a parser that does not add any traits
+    pub fn new() -> Self {
+        Default::default()
+    }
+    //add pairs of types and their desired traits
+    pub fn register_traits(&mut self, type_name: &'a str, traits: Vec<String>) {
+        self.types_to_traits.insert(&type_name, traits);
+    }
+}
+
 //this is required to implement the callback trait
 impl UnwindSafe for DeriveAdderParserCallback<'_> {}
 

--- a/program/rust/src/error.rs
+++ b/program/rust/src/error.rs
@@ -1,7 +1,10 @@
 //! Error types
 
 use solana_program::program_error::ProgramError;
+use std::result::Result;
 use thiserror::Error;
+// similar to ProgramResult but allows for multiple success values
+pub type OracleResult = Result<u64, ProgramError>;
 
 /// Errors that may be returned by the oracle program
 #[derive(Clone, Debug, Eq, Error, PartialEq)]
@@ -9,6 +12,9 @@ pub enum OracleError {
     /// Generic catch all error
     #[error("Generic")]
     Generic = 600,
+    /// integer casting error
+    #[error("IntegerCasting")]
+    IntegerCastingError = 601,
 }
 
 impl From<OracleError> for ProgramError {

--- a/program/rust/src/error.rs
+++ b/program/rust/src/error.rs
@@ -1,5 +1,4 @@
 //! Error types
-
 use solana_program::program_error::ProgramError;
 use std::result::Result;
 use thiserror::Error;
@@ -13,8 +12,14 @@ pub enum OracleError {
     #[error("Generic")]
     Generic = 600,
     /// integer casting error
-    #[error("IntegerCasting")]
+    #[error("IntegerCastingError")]
     IntegerCastingError = 601,
+
+    #[error("UnknownCError")]
+    UnknownCError = 602,
+
+    #[error("UnknownCPanic")]
+    UnknownCPanic = 603,
 }
 
 impl From<OracleError> for ProgramError {

--- a/program/rust/src/error.rs
+++ b/program/rust/src/error.rs
@@ -14,12 +14,9 @@ pub enum OracleError {
     /// integer casting error
     #[error("IntegerCastingError")]
     IntegerCastingError = 601,
-
+    /// c_entrypoint returned an unexpected value
     #[error("UnknownCError")]
     UnknownCError = 602,
-
-    #[error("UnknownCPanic")]
-    UnknownCPanic = 603,
 }
 
 impl From<OracleError> for ProgramError {

--- a/program/rust/src/lib.rs
+++ b/program/rust/src/lib.rs
@@ -8,8 +8,6 @@ use crate::log::{post_log, pre_log};
 use solana_program::entrypoint::deserialize;
 use borsh::{BorshDeserialize, BorshSerialize};
 use solana_program::entrypoint::deserialize;
-use solana_program::pubkey::Pubkey;
-use solana_program::sysvar::slot_history::AccountInfo;
 
 
 //Below is a high lever description of the rust/c setup.

--- a/program/rust/src/lib.rs
+++ b/program/rust/src/lib.rs
@@ -51,7 +51,10 @@ pub extern "C" fn entrypoint(input: *mut u8) -> u64 {
         _ => {}
     }
 
-    let c_ret_val = process_instruction(program_id, &accounts, instruction_data, input);
+    let c_ret_val = match process_instruction(program_id, &accounts, instruction_data, input) {
+        Err(error) => error.into(),
+        Ok(success_status) => success_status,
+    };
 
     match post_log(c_ret_val, &accounts) {
         Err(error) => return error.into(),

--- a/program/rust/src/lib.rs
+++ b/program/rust/src/lib.rs
@@ -1,19 +1,16 @@
 pub mod c_oracle_header;
 mod rust_oracle;
 mod time_machine_types;
-<<<<<<< HEAD
 mod error;
 mod log;
 
 use crate::log::{post_log, pre_log};
 use solana_program::entrypoint::deserialize;
-=======
 use borsh::{BorshDeserialize, BorshSerialize};
 use solana_program::entrypoint::deserialize;
 use solana_program::pubkey::Pubkey;
 use solana_program::sysvar::slot_history::AccountInfo;
 
->>>>>>> 4656a2b (add a new insctruction and interecepted update price calls)
 
 //Below is a high lever description of the rust/c setup.
 
@@ -59,7 +56,8 @@ pub extern "C" fn entrypoint(input: *mut u8) -> u64 {
         panic!("insufficient data, could not parse instruction");
     }
 
-    let cmd_data = c_oracle_header::cmd_hdr::try_from_slice(&instruction_data[..cmd_hdr_size]).unwrap();
+    let cmd_data =
+        c_oracle_header::cmd_hdr::try_from_slice(&instruction_data[..cmd_hdr_size]).unwrap();
 
     if cmd_data.ver_ != c_oracle_header::PC_VERSION {
         //FIXME: I am not sure what's best to do here (this is copied from C)

--- a/program/rust/src/lib.rs
+++ b/program/rust/src/lib.rs
@@ -1,14 +1,13 @@
 pub mod c_oracle_header;
-mod rust_oracle;
-mod time_machine_types;
 mod error;
 mod log;
+mod rust_oracle;
+mod time_machine_types;
 
 use crate::log::{post_log, pre_log};
-use solana_program::entrypoint::deserialize;
 use borsh::{BorshDeserialize, BorshSerialize};
 use solana_program::entrypoint::deserialize;
-
+use solana_program::entrypoint::deserialize;
 
 //Below is a high lever description of the rust/c setup.
 
@@ -44,7 +43,7 @@ pub extern "C" fn c_entrypoint(input: *mut u8) -> u64 {
 pub extern "C" fn entrypoint(input: *mut u8) -> u64 {
     let (_program_id, accounts, instruction_data) = unsafe { deserialize(input) };
 
-    match pre_log(&accounts,instruction_data) {
+    match pre_log(&accounts, instruction_data) {
         Err(error) => return error.into(),
         _ => {}
     }
@@ -74,7 +73,7 @@ pub extern "C" fn entrypoint(input: *mut u8) -> u64 {
             rust_oracle::update_version(program_id, accounts, instruction_data)
         }
         _ => unsafe { return c_entrypoint(input) },
-    }
+    };
 
     match post_log(c_ret_val, &accounts) {
         Err(error) => return error.into(),

--- a/program/rust/src/lib.rs
+++ b/program/rust/src/lib.rs
@@ -1,16 +1,16 @@
 mod c_oracle_header;
 mod error;
 mod log;
+mod processor;
 mod rust_oracle;
 mod time_machine_types;
-mod processor;
 
 use crate::c_oracle_header::SUCCESSFULLY_UPDATED_AGGREGATE;
 use crate::log::{post_log, pre_log};
-use solana_program::{custom_heap_default, custom_panic_default, entrypoint::deserialize};
 use processor::process_instruction;
 use solana_program::pubkey::Pubkey;
 use solana_program::sysvar::slot_history::AccountInfo;
+use solana_program::{custom_heap_default, custom_panic_default, entrypoint::deserialize};
 
 //Below is a high lever description of the rust/c setup.
 
@@ -51,12 +51,7 @@ pub extern "C" fn entrypoint(input: *mut u8) -> u64 {
         _ => {}
     }
 
-    let c_ret_val = process_instruction(
-        program_id,
-        &accounts, 
-        instruction_data,  
-        input
-    );
+    let c_ret_val = process_instruction(program_id, &accounts, instruction_data, input);
 
     match post_log(c_ret_val, &accounts) {
         Err(error) => return error.into(),

--- a/program/rust/src/lib.rs
+++ b/program/rust/src/lib.rs
@@ -55,10 +55,6 @@ pub extern "C" fn entrypoint(input: *mut u8) -> u64 {
     }
 
     let cmd_hdr_size = size_of::<cmd_hdr>();
-    if instruction_data.len() < cmd_hdr_size {
-        panic!("insufficient data, could not parse instruction");
-    }
-
     let cmd_data = cmd_hdr::try_from_slice(&instruction_data[..cmd_hdr_size]).unwrap();
 
     if cmd_data.ver_ != PC_VERSION {

--- a/program/rust/src/lib.rs
+++ b/program/rust/src/lib.rs
@@ -3,17 +3,14 @@ mod error;
 mod log;
 mod rust_oracle;
 mod time_machine_types;
+mod processor;
 
-use crate::c_oracle_header::{
-    cmd_hdr, command_t_e_cmd_agg_price, command_t_e_cmd_upd_account_version,
-    command_t_e_cmd_upd_price, command_t_e_cmd_upd_price_no_fail_on_error, PC_VERSION,
-    SUCCESSFULLY_UPDATED_AGGREGATE,
-};
+use crate::c_oracle_header::SUCCESSFULLY_UPDATED_AGGREGATE;
 use crate::log::{post_log, pre_log};
-use crate::rust_oracle::{update_price, update_version};
-use ::std::mem::size_of;
-use borsh::{BorshDeserialize, BorshSerialize};
 use solana_program::{custom_heap_default, custom_panic_default, entrypoint::deserialize};
+use processor::process_instruction;
+use solana_program::pubkey::Pubkey;
+use solana_program::sysvar::slot_history::AccountInfo;
 
 //Below is a high lever description of the rust/c setup.
 
@@ -54,27 +51,12 @@ pub extern "C" fn entrypoint(input: *mut u8) -> u64 {
         _ => {}
     }
 
-    let cmd_hdr_size = size_of::<cmd_hdr>();
-    let cmd_data = cmd_hdr::try_from_slice(&instruction_data[..cmd_hdr_size]).unwrap();
-
-    if cmd_data.ver_ != PC_VERSION {
-        //FIXME: I am not sure what's best to do here (this is copied from C)
-        // it seems to me like we should not break when version numbers change
-        //instead we should log a message that asks users to call update_version
-        panic!("incorrect version numbers");
-    }
-
-    let c_ret_val = match cmd_data.cmd_ as u32 {
-        command_t_e_cmd_upd_price
-        | command_t_e_cmd_upd_price_no_fail_on_error
-        | command_t_e_cmd_agg_price => {
-            update_price(program_id, &accounts, &instruction_data, input)
-        }
-        command_t_e_cmd_upd_account_version => {
-            update_version(program_id, &accounts, &instruction_data)
-        }
-        _ => unsafe { return c_entrypoint(input) },
-    };
+    let c_ret_val = process_instruction(
+        program_id,
+        &accounts, 
+        instruction_data,  
+        input
+    );
 
     match post_log(c_ret_val, &accounts) {
         Err(error) => return error.into(),

--- a/program/rust/src/lib.rs
+++ b/program/rust/src/lib.rs
@@ -10,10 +10,7 @@ use crate::error::{OracleError, OracleResult};
 use crate::log::{post_log, pre_log};
 use processor::process_instruction;
 use solana_program::program_error::ProgramError;
-use solana_program::pubkey::Pubkey;
-use solana_program::sysvar::slot_history::AccountInfo;
 use solana_program::{custom_heap_default, custom_panic_default, entrypoint::deserialize};
-use std::panic::catch_unwind;
 
 //Below is a high lever description of the rust/c setup.
 

--- a/program/rust/src/lib.rs
+++ b/program/rust/src/lib.rs
@@ -60,8 +60,7 @@ pub extern "C" fn entrypoint(input: *mut u8) -> u64 {
     if cmd_data.ver_ != c_oracle_header::PC_VERSION {
         //FIXME: I am not sure what's best to do here (this is copied from C)
         // it seems to me like we should not break when version numbers change
-        //instead we should maintain the update logic accross version in the
-        //upd_account_version command
+        //instead we should log a message that asks users to call update_version
         panic!("incorrect version numbers");
     }
 

--- a/program/rust/src/lib.rs
+++ b/program/rust/src/lib.rs
@@ -7,7 +7,6 @@ mod time_machine_types;
 use crate::log::{post_log, pre_log};
 use borsh::{BorshDeserialize, BorshSerialize};
 use solana_program::entrypoint::deserialize;
-use solana_program::entrypoint::deserialize;
 
 //Below is a high lever description of the rust/c setup.
 
@@ -41,7 +40,7 @@ pub extern "C" fn c_entrypoint(input: *mut u8) -> u64 {
 
 #[no_mangle]
 pub extern "C" fn entrypoint(input: *mut u8) -> u64 {
-    let (_program_id, accounts, instruction_data) = unsafe { deserialize(input) };
+    let (program_id, accounts, instruction_data) = unsafe { deserialize(input) };
 
     match pre_log(&accounts, instruction_data) {
         Err(error) => return error.into(),
@@ -67,10 +66,10 @@ pub extern "C" fn entrypoint(input: *mut u8) -> u64 {
         c_oracle_header::command_t_e_cmd_upd_price
         | c_oracle_header::command_t_e_cmd_upd_price_no_fail_on_error
         | c_oracle_header::command_t_e_cmd_agg_price => {
-            rust_oracle::update_price(program_id, accounts, instruction_data, input)
+            rust_oracle::update_price(program_id, &accounts, &instruction_data, input)
         }
         c_oracle_header::command_t_e_cmd_upd_account_version => {
-            rust_oracle::update_version(program_id, accounts, instruction_data)
+            rust_oracle::update_version(program_id, &accounts, &instruction_data)
         }
         _ => unsafe { return c_entrypoint(input) },
     };

--- a/program/rust/src/lib.rs
+++ b/program/rust/src/lib.rs
@@ -4,6 +4,7 @@ mod log;
 mod rust_oracle;
 mod time_machine_types;
 
+use ::std::mem::size_of;
 use crate::log::{post_log, pre_log};
 use borsh::{BorshDeserialize, BorshSerialize};
 use solana_program::entrypoint::deserialize;
@@ -47,7 +48,7 @@ pub extern "C" fn entrypoint(input: *mut u8) -> u64 {
         _ => {}
     }
 
-    let cmd_hdr_size = ::std::mem::size_of::<c_oracle_header::cmd_hdr>();
+    let cmd_hdr_size = size_of::<c_oracle_header::cmd_hdr>();
     if instruction_data.len() < cmd_hdr_size {
         panic!("insufficient data, could not parse instruction");
     }

--- a/program/rust/src/lib.rs
+++ b/program/rust/src/lib.rs
@@ -1,13 +1,19 @@
-pub mod c_oracle_header;
+mod c_oracle_header;
 mod error;
 mod log;
 mod rust_oracle;
 mod time_machine_types;
 
-use ::std::mem::size_of;
+use crate::c_oracle_header::{
+    cmd_hdr, command_t_e_cmd_agg_price, command_t_e_cmd_upd_account_version,
+    command_t_e_cmd_upd_price, command_t_e_cmd_upd_price_no_fail_on_error, PC_VERSION,
+    SUCCESSFULLY_UPDATED_AGGREGATE,
+};
 use crate::log::{post_log, pre_log};
+use crate::rust_oracle::{update_price, update_version};
+use ::std::mem::size_of;
 use borsh::{BorshDeserialize, BorshSerialize};
-use solana_program::entrypoint::deserialize;
+use solana_program::{custom_heap_default, custom_panic_default, entrypoint::deserialize};
 
 //Below is a high lever description of the rust/c setup.
 
@@ -48,15 +54,14 @@ pub extern "C" fn entrypoint(input: *mut u8) -> u64 {
         _ => {}
     }
 
-    let cmd_hdr_size = size_of::<c_oracle_header::cmd_hdr>();
+    let cmd_hdr_size = size_of::<cmd_hdr>();
     if instruction_data.len() < cmd_hdr_size {
         panic!("insufficient data, could not parse instruction");
     }
 
-    let cmd_data =
-        c_oracle_header::cmd_hdr::try_from_slice(&instruction_data[..cmd_hdr_size]).unwrap();
+    let cmd_data = cmd_hdr::try_from_slice(&instruction_data[..cmd_hdr_size]).unwrap();
 
-    if cmd_data.ver_ != c_oracle_header::PC_VERSION {
+    if cmd_data.ver_ != PC_VERSION {
         //FIXME: I am not sure what's best to do here (this is copied from C)
         // it seems to me like we should not break when version numbers change
         //instead we should log a message that asks users to call update_version
@@ -64,13 +69,13 @@ pub extern "C" fn entrypoint(input: *mut u8) -> u64 {
     }
 
     let c_ret_val = match cmd_data.cmd_ as u32 {
-        c_oracle_header::command_t_e_cmd_upd_price
-        | c_oracle_header::command_t_e_cmd_upd_price_no_fail_on_error
-        | c_oracle_header::command_t_e_cmd_agg_price => {
-            rust_oracle::update_price(program_id, &accounts, &instruction_data, input)
+        command_t_e_cmd_upd_price
+        | command_t_e_cmd_upd_price_no_fail_on_error
+        | command_t_e_cmd_agg_price => {
+            update_price(program_id, &accounts, &instruction_data, input)
         }
-        c_oracle_header::command_t_e_cmd_upd_account_version => {
-            rust_oracle::update_version(program_id, &accounts, &instruction_data)
+        command_t_e_cmd_upd_account_version => {
+            update_version(program_id, &accounts, &instruction_data)
         }
         _ => unsafe { return c_entrypoint(input) },
     };
@@ -80,7 +85,7 @@ pub extern "C" fn entrypoint(input: *mut u8) -> u64 {
         _ => {}
     }
 
-    if c_ret_val == c_oracle_header::SUCCESSFULLY_UPDATED_AGGREGATE {
+    if c_ret_val == SUCCESSFULLY_UPDATED_AGGREGATE {
         //0 is the SUCCESS value for solana
         return 0;
     } else {
@@ -88,5 +93,5 @@ pub extern "C" fn entrypoint(input: *mut u8) -> u64 {
     }
 }
 
-solana_program::custom_heap_default!();
-solana_program::custom_panic_default!();
+custom_heap_default!();
+custom_panic_default!();

--- a/program/rust/src/log.rs
+++ b/program/rust/src/log.rs
@@ -6,7 +6,7 @@ use solana_program::entrypoint::ProgramResult;
 use solana_program::msg;
 use std::mem::size_of;
 
-pub fn pre_log(accounts : &[AccountInfo], instruction_data: &[u8]) -> ProgramResult {
+pub fn pre_log(accounts: &[AccountInfo], instruction_data: &[u8]) -> ProgramResult {
     msg!("Pyth oracle contract");
 
     let instruction_header: cmd_hdr = cmd_hdr::try_from_slice(&instruction_data[..8])?;
@@ -15,7 +15,7 @@ pub fn pre_log(accounts : &[AccountInfo], instruction_data: &[u8]) -> ProgramRes
         .try_into()
         .map_err(|_| OracleError::Generic)?;
     match instruction_id {
-        command_t_e_cmd_upd_price | command_t_e_cmd_agg_price=> {
+        command_t_e_cmd_upd_price | command_t_e_cmd_agg_price => {
             let instruction: cmd_upd_price = cmd_upd_price::try_from_slice(instruction_data)?;
             msg!(
                 "UpdatePrice: publisher={:}, price_account={:}, price={:}, conf={:}, status={:}, slot={:}",
@@ -29,7 +29,7 @@ pub fn pre_log(accounts : &[AccountInfo], instruction_data: &[u8]) -> ProgramRes
                 instruction.pub_slot_
             );
         }
-        command_t_e_cmd_upd_price_no_fail_on_error=> {
+        command_t_e_cmd_upd_price_no_fail_on_error => {
             let instruction: cmd_upd_price = cmd_upd_price::try_from_slice(instruction_data)?;
             msg!(
                 "UpdatePriceNoFailOnError: publisher={:}, price_account={:}, price={:}, conf={:}, status={:}, slot={:}",
@@ -93,8 +93,7 @@ pub fn post_log(c_ret_val: u64, accounts: &[AccountInfo]) -> ProgramResult {
         )?;
         msg!(
             "UpdateAggregate : price_account={:}, price={:}, conf={:}, status={:}, slot={:}",
-            accounts.get(1)
-            .ok_or(OracleError::Generic)?.key,
+            accounts.get(1).ok_or(OracleError::Generic)?.key,
             aggregate_price_info.price_,
             aggregate_price_info.conf_,
             aggregate_price_info.status_,

--- a/program/rust/src/processor.rs
+++ b/program/rust/src/processor.rs
@@ -9,7 +9,7 @@ use ::std::mem::size_of;
 use borsh::{BorshDeserialize, BorshSerialize};
 use solana_program::pubkey::Pubkey;
 use solana_program::sysvar::slot_history::AccountInfo;
-
+///dispatch to the right instruction in the oracle
 pub fn process_instruction(
     program_id: &Pubkey,
     accounts: &Vec<AccountInfo>,

--- a/program/rust/src/processor.rs
+++ b/program/rust/src/processor.rs
@@ -1,0 +1,41 @@
+use crate::c_oracle_header::{
+    cmd_hdr, command_t_e_cmd_agg_price, command_t_e_cmd_upd_account_version,
+    command_t_e_cmd_upd_price, command_t_e_cmd_upd_price_no_fail_on_error, PC_VERSION
+};
+use crate::c_entrypoint;
+use crate::rust_oracle::{update_price, update_version};
+use ::std::mem::size_of;
+use borsh::{BorshDeserialize, BorshSerialize};
+use solana_program::pubkey::Pubkey;
+use solana_program::sysvar::slot_history::AccountInfo;
+
+
+pub fn process_instruction(
+    program_id: &Pubkey,
+    accounts: &Vec<AccountInfo>, 
+    instruction_data: &[u8],  
+    input: *mut u8
+) -> u64 {
+
+    let cmd_hdr_size = size_of::<cmd_hdr>();
+    let cmd_data = cmd_hdr::try_from_slice(&instruction_data[..cmd_hdr_size]).unwrap();
+
+    if cmd_data.ver_ != PC_VERSION {
+        //FIXME: I am not sure what's best to do here (this is copied from C)
+        // it seems to me like we should not break when version numbers change
+        //instead we should log a message that asks users to call update_version
+        panic!("incorrect version numbers");
+    }
+
+    match cmd_data.cmd_ as u32 {
+        command_t_e_cmd_upd_price
+        | command_t_e_cmd_upd_price_no_fail_on_error
+        | command_t_e_cmd_agg_price => {
+            update_price(program_id, &accounts, &instruction_data, input)
+        }
+        command_t_e_cmd_upd_account_version => {
+            update_version(program_id, &accounts, &instruction_data)
+        }
+        _ => unsafe { return c_entrypoint(input) },
+    }
+}

--- a/program/rust/src/processor.rs
+++ b/program/rust/src/processor.rs
@@ -17,7 +17,7 @@ pub fn process_instruction(
     input: *mut u8,
 ) -> OracleResult {
     let cmd_hdr_size = size_of::<cmd_hdr>();
-    let cmd_data = cmd_hdr::try_from_slice(&instruction_data[..cmd_hdr_size]).unwrap();
+    let cmd_data = cmd_hdr::try_from_slice(&instruction_data[..cmd_hdr_size])?;
 
     if cmd_data.ver_ != PC_VERSION {
         //FIXME: I am not sure what's best to do here (this is copied from C)

--- a/program/rust/src/processor.rs
+++ b/program/rust/src/processor.rs
@@ -1,22 +1,20 @@
+use crate::c_entrypoint;
 use crate::c_oracle_header::{
     cmd_hdr, command_t_e_cmd_agg_price, command_t_e_cmd_upd_account_version,
-    command_t_e_cmd_upd_price, command_t_e_cmd_upd_price_no_fail_on_error, PC_VERSION
+    command_t_e_cmd_upd_price, command_t_e_cmd_upd_price_no_fail_on_error, PC_VERSION,
 };
-use crate::c_entrypoint;
 use crate::rust_oracle::{update_price, update_version};
 use ::std::mem::size_of;
 use borsh::{BorshDeserialize, BorshSerialize};
 use solana_program::pubkey::Pubkey;
 use solana_program::sysvar::slot_history::AccountInfo;
 
-
 pub fn process_instruction(
     program_id: &Pubkey,
-    accounts: &Vec<AccountInfo>, 
-    instruction_data: &[u8],  
-    input: *mut u8
+    accounts: &Vec<AccountInfo>,
+    instruction_data: &[u8],
+    input: *mut u8,
 ) -> u64 {
-
     let cmd_hdr_size = size_of::<cmd_hdr>();
     let cmd_data = cmd_hdr::try_from_slice(&instruction_data[..cmd_hdr_size]).unwrap();
 

--- a/program/rust/src/processor.rs
+++ b/program/rust/src/processor.rs
@@ -6,7 +6,7 @@ use crate::c_oracle_header::{
 use crate::error::{OracleError, OracleResult};
 use crate::rust_oracle::{update_price, update_version};
 use ::std::mem::size_of;
-use borsh::{BorshDeserialize, BorshSerialize};
+use borsh::BorshDeserialize;
 use solana_program::pubkey::Pubkey;
 use solana_program::sysvar::slot_history::AccountInfo;
 ///dispatch to the right instruction in the oracle

--- a/program/rust/src/processor.rs
+++ b/program/rust/src/processor.rs
@@ -1,4 +1,4 @@
-use crate::c_entrypoint;
+use crate::c_entrypoint_wrapper;
 use crate::c_oracle_header::{
     cmd_hdr, command_t_e_cmd_agg_price, command_t_e_cmd_upd_account_version,
     command_t_e_cmd_upd_price, command_t_e_cmd_upd_price_no_fail_on_error, PC_VERSION,
@@ -39,6 +39,6 @@ pub fn process_instruction(
         command_t_e_cmd_upd_account_version => {
             update_version(program_id, &accounts, &instruction_data)
         }
-        _ => Ok(unsafe { c_entrypoint(input) }),
+        _ => c_entrypoint_wrapper(input),
     }
 }

--- a/program/rust/src/rust_oracle.rs
+++ b/program/rust/src/rust_oracle.rs
@@ -1,6 +1,5 @@
 use super::c_entrypoint_wrapper;
-use super::c_oracle_header;
-use crate::error::{OracleError, OracleResult};
+use crate::error::OracleResult;
 use solana_program::pubkey::Pubkey;
 use solana_program::sysvar::slot_history::AccountInfo;
 

--- a/program/rust/src/rust_oracle.rs
+++ b/program/rust/src/rust_oracle.rs
@@ -1,4 +1,4 @@
-use super::c_entrypoint;
+use super::c_entrypoint_wrapper;
 use super::c_oracle_header;
 use crate::error::{OracleError, OracleResult};
 use solana_program::pubkey::Pubkey;
@@ -13,7 +13,7 @@ pub fn update_price(
 ) -> OracleResult {
     //For now, we did not change the behavior of this. this is just to show the proposed structure of the
     //program
-    Ok(unsafe { c_entrypoint(input) })
+    c_entrypoint_wrapper(input)
 }
 /// has version number/ account type dependant logic to make sure the given account is compatible
 /// with the current version

--- a/program/rust/src/rust_oracle.rs
+++ b/program/rust/src/rust_oracle.rs
@@ -6,7 +6,7 @@ use solana_program::sysvar::slot_history::AccountInfo;
 ///Calls the c oracle update_price, and updates the Time Machine if needed
 pub fn update_price(
     program_id: &Pubkey,
-    accounts: Vec<AccountInfo>,
+    accounts: &Vec<AccountInfo>,
     instruction_data: &[u8],
     input: *mut u8,
 ) -> u64 {
@@ -25,7 +25,7 @@ pub fn update_price(
 /// updates the version number for all accounts, and resizes price accounts
 pub fn update_version(
     program_id: &Pubkey,
-    accounts: Vec<AccountInfo>,
+    accounts: &Vec<AccountInfo>,
     instruction_data: &[u8],
 ) -> u64 {
     panic!("Need to merge fix to pythd in order to implement this");

--- a/program/rust/src/rust_oracle.rs
+++ b/program/rust/src/rust_oracle.rs
@@ -12,13 +12,7 @@ pub fn update_price(
 ) -> u64 {
     //For now, we did not change the behavior of this. this is just to show the proposed structure of the
     //program
-    let c_ret_val = unsafe { c_entrypoint(input) };
-    if c_ret_val == c_oracle_header::SUCCESSFULLY_UPDATED_AGGREGATE {
-        //0 is the SUCCESS value for solana
-        return 0;
-    } else {
-        return c_ret_val;
-    }
+    unsafe { c_entrypoint(input) }
 }
 /// has version number/ account type dependant logic to make sure the given account is compatible
 /// with the current version

--- a/program/rust/src/rust_oracle.rs
+++ b/program/rust/src/rust_oracle.rs
@@ -1,5 +1,6 @@
 use super::c_entrypoint;
 use super::c_oracle_header;
+use crate::error::{OracleError, OracleResult};
 use solana_program::pubkey::Pubkey;
 use solana_program::sysvar::slot_history::AccountInfo;
 
@@ -9,10 +10,10 @@ pub fn update_price(
     accounts: &Vec<AccountInfo>,
     instruction_data: &[u8],
     input: *mut u8,
-) -> u64 {
+) -> OracleResult {
     //For now, we did not change the behavior of this. this is just to show the proposed structure of the
     //program
-    unsafe { c_entrypoint(input) }
+    Ok(unsafe { c_entrypoint(input) })
 }
 /// has version number/ account type dependant logic to make sure the given account is compatible
 /// with the current version
@@ -21,7 +22,7 @@ pub fn update_version(
     program_id: &Pubkey,
     accounts: &Vec<AccountInfo>,
     instruction_data: &[u8],
-) -> u64 {
+) -> OracleResult {
     panic!("Need to merge fix to pythd in order to implement this");
-    0 //SUCCESS
+    Ok(0) //SUCCESS
 }

--- a/program/rust/src/rust_oracle.rs
+++ b/program/rust/src/rust_oracle.rs
@@ -1,0 +1,33 @@
+use super::c_entrypoint;
+use super::c_oracle_header;
+use solana_program::pubkey::Pubkey;
+use solana_program::sysvar::slot_history::AccountInfo;
+
+///Calls the c oracle update_price, and updates the Time Machine if needed
+pub fn update_price(
+    program_id: &Pubkey,
+    accounts: Vec<AccountInfo>,
+    instruction_data: &[u8],
+    input: *mut u8,
+) -> u64 {
+    //For now, we did not change the behavior of this. this is just to show the proposed structure of the
+    //program
+    let c_ret_val = unsafe { c_entrypoint(input) };
+    if c_ret_val == c_oracle_header::SUCCESSFULLY_UPDATED_AGGREGATE {
+        //0 is the SUCCESS value for solana
+        return 0;
+    } else {
+        return c_ret_val;
+    }
+}
+/// has version number/ account type dependant logic to make sure the given account is compatible
+/// with the current version
+/// updates the version number for all accounts, and resizes price accounts
+pub fn update_version(
+    program_id: &Pubkey,
+    accounts: Vec<AccountInfo>,
+    instruction_data: &[u8],
+) -> u64 {
+    panic!("Need to merge fix to pythd in order to implement this");
+    0 //SUCCESS
+}

--- a/program/rust/src/time_machine_types.rs
+++ b/program/rust/src/time_machine_types.rs
@@ -1,4 +1,5 @@
-use super::c_oracle_header;
+use super::c_oracle_header::TIME_MACHINE_STRUCT_SIZE;
+use ::std::mem::size_of;
 #[derive(Debug, Clone)]
 #[repr(C)]
 /// this wraps multiple SMA and tick trackers, and includes all the state
@@ -13,10 +14,10 @@ pub struct TimeMachineWrapper {
 ///defined in Rust
 fn c_time_machine_size_is_correct() {
     assert_eq!(
-        ::std::mem::size_of::<TimeMachineWrapper>(),
-        c_oracle_header::TIME_MACHINE_STRUCT_SIZE.try_into().unwrap(),
+        size_of::<TimeMachineWrapper>(),
+        TIME_MACHINE_STRUCT_SIZE.try_into().unwrap(),
         "expected TIME_MACHINE_STRUCT_SIZE ({}) in oracle.h to the same as the size of TimeMachineWrapper ({})",
-        c_oracle_header::TIME_MACHINE_STRUCT_SIZE,
-        ::std::mem::size_of::<TimeMachineWrapper>()
+        TIME_MACHINE_STRUCT_SIZE,
+        size_of::<TimeMachineWrapper>()
     );
 }

--- a/program/rust/src/time_machine_types.rs
+++ b/program/rust/src/time_machine_types.rs
@@ -15,6 +15,8 @@ fn c_time_machine_size_is_correct() {
     assert_eq!(
         ::std::mem::size_of::<TimeMachineWrapper>(),
         c_oracle_header::TIME_MACHINE_STRUCT_SIZE.try_into().unwrap(),
-        "expected TIME_MACHINE_STRUCT_SIZE in oracle.h to the same as the size of TimeMachineWrapper"
+        "expected TIME_MACHINE_STRUCT_SIZE ({}) in oracle.h to the same as the size of TimeMachineWrapper ({})",
+        c_oracle_header::TIME_MACHINE_STRUCT_SIZE,
+        ::std::mem::size_of::<TimeMachineWrapper>()
     );
 }


### PR DESCRIPTION
Our design involves rersizing price accounts, as well as intercepting calls to instructions that update_the price in order to do the SMA tracking. 

In this PR:
1. We intercept the add_price calls (but we do not change their behavior yet)
2. We add a no-op update_account_version instruction that is meant to update the version number of a given account, and resize price accounts.

The purpose of this is to get feedback on the structure of the program.

It also addressed two other issues:

1. added panic and heap definitions. (These are usually added in the entrpoint! macro is solana sdk, code won't compile without them once we start using anything that code panic like arrays, etc) 
2. Updated the error message in the size of time machine assert so that it prints the correct size for better developer experience
