### PR TITLE
Publish binary at release

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,6 +15,9 @@ env:
     startsWith( github.ref, 'refs/tags/devnet-' ) ||
     startsWith( github.ref, 'refs/tags/testnet-' ) ||
     startsWith( github.ref, 'refs/tags/mainnet-' ) }}
+  IS_DEVNET_RELEASE: ${{
+    startsWith( github.ref, 'refs/tags/devnet-' ) }}
+
 
 jobs:
   build:
@@ -61,7 +64,7 @@ jobs:
 
       - name : Publish binary
         if : env.IS_RELEASE == 'true'
-        uses: svenstaro/upload-release-action@v2
+        uses: svenstaro/upload-release-action@133984371c30d34e38222a64855679a414cb7575
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: ./pyth_oracle.so

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -51,6 +51,24 @@ jobs:
             docker image push "${PUB_IMAGE}"
           }
           echo "${{ secrets.DOCKER_IO_PASS }}" | publish
+
+      - name : Get binary from docker
+        if : env.IS_RELEASE == 'true'
+        run : |
+            docker create -ti --name container "${DOCKER_IMAGE}" bash
+            docker cp container:/home/pyth/pyth-client/target/deploy/pyth_oracle.so .
+            docker rm -f container
+
+      - name : Publish binary
+        if : env.IS_RELEASE == 'true'
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: ./pyth_oracle.so
+          asset_name: pyth_oracle.so
+          tag: ${{ github.ref }}
+          overwrite: true
+
   pinning:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -67,7 +67,6 @@ jobs:
           file: ./pyth_oracle.so
           asset_name: pyth_oracle.so
           tag: ${{ github.ref }}
-          overwrite: true
 
   pinning:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -56,14 +56,14 @@ jobs:
           echo "${{ secrets.DOCKER_IO_PASS }}" | publish
 
       - name : Get binary from docker
-        if : env.IS_RELEASE == 'true'
+        if : env.IS_DEVNET_RELEASE == 'true'
         run : |
             docker create -ti --name container "${DOCKER_IMAGE}" bash
             docker cp container:/home/pyth/pyth-client/target/deploy/pyth_oracle.so .
             docker rm -f container
 
       - name : Publish binary
-        if : env.IS_RELEASE == 'true'
+        if : env.IS_DEVNET_RELEASE == 'true'
         uses: svenstaro/upload-release-action@133984371c30d34e38222a64855679a414cb7575
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Releases will now release the compiled oracle program. This will make it easier to know which version is onchain by byte comparison. It should make the process of deploying less error prone.