### PR TITLE
Traits

### DIFF
--- a/program/rust/src/lib.rs
+++ b/program/rust/src/lib.rs
@@ -95,7 +95,6 @@ pub extern "C" fn entrypoint(input: *mut u8) -> u64 {
         return error.into();
     }
 
-
     if c_ret_val == SUCCESSFULLY_UPDATED_AGGREGATE {
         //0 is the SUCCESS value for solana
         0

--- a/program/rust/src/log.rs
+++ b/program/rust/src/log.rs
@@ -93,7 +93,6 @@ pub fn pre_log(accounts: &[AccountInfo], instruction_data: &[u8]) -> ProgramResu
     Ok(())
 }
 
-
 pub fn post_log(c_ret_val: u64, accounts: &[AccountInfo]) -> ProgramResult {
     if c_ret_val == SUCCESSFULLY_UPDATED_AGGREGATE {
         // We trust that the C oracle has properly checked account 1, we can only get here through

--- a/program/rust/src/tests/test_add_mapping.rs
+++ b/program/rust/src/tests/test_add_mapping.rs
@@ -10,7 +10,6 @@ use crate::deserialize::load_account_as_mut;
 use crate::rust_oracle::{
     add_mapping,
     clear_account,
-    initialize_mapping_account,
     pubkey_assign,
     PythAccount,
 };
@@ -22,7 +21,6 @@ use solana_program::program_error::ProgramError;
 use solana_program::pubkey::Pubkey;
 use solana_program::rent::Rent;
 use solana_program::system_program;
-use std::cell::RefMut;
 use std::mem::size_of;
 
 #[test]
@@ -66,11 +64,10 @@ fn test_add_mapping() {
         Epoch::default(),
     );
 
-    initialize_mapping_account(&cur_mapping, PC_VERSION).unwrap();
+    pc_map_table_t::initialize(&cur_mapping, PC_VERSION).unwrap();
 
     {
-        let mut cur_mapping_data: RefMut<pc_map_table_t> =
-            PythAccount::load(&cur_mapping, PC_VERSION).unwrap();
+        let mut cur_mapping_data = pc_map_table_t::load(&cur_mapping, PC_VERSION).unwrap();
         cur_mapping_data.num_ = PC_MAP_TABLE_SIZE;
     }
 
@@ -101,10 +98,8 @@ fn test_add_mapping() {
     .is_ok());
 
     {
-        let next_mapping_data: RefMut<pc_map_table_t> =
-            PythAccount::load(&next_mapping, PC_VERSION).unwrap();
-        let mut cur_mapping_data: RefMut<pc_map_table_t> =
-            PythAccount::load(&cur_mapping, PC_VERSION).unwrap();
+        let next_mapping_data = pc_map_table_t::load(&next_mapping, PC_VERSION).unwrap();
+        let mut cur_mapping_data = pc_map_table_t::load(&cur_mapping, PC_VERSION).unwrap();
 
         assert!(unsafe {
             cur_mapping_data
@@ -135,8 +130,7 @@ fn test_add_mapping() {
     );
 
     {
-        let mut cur_mapping_data: RefMut<pc_map_table_t> =
-            PythAccount::load(&cur_mapping, PC_VERSION).unwrap();
+        let mut cur_mapping_data = pc_map_table_t::load(&cur_mapping, PC_VERSION).unwrap();
         assert!(unsafe { cur_mapping_data.next_.k8_.iter().all(|x| *x == 0) });
         cur_mapping_data.num_ = PC_MAP_TABLE_SIZE;
         cur_mapping_data.magic_ = 0;

--- a/program/rust/src/tests/test_add_mapping.rs
+++ b/program/rust/src/tests/test_add_mapping.rs
@@ -11,8 +11,8 @@ use crate::rust_oracle::{
     add_mapping,
     clear_account,
     initialize_mapping_account,
-    load_mapping_account_mut,
     pubkey_assign,
+    PythAccount,
 };
 use bytemuck::bytes_of;
 use solana_program::account_info::AccountInfo;
@@ -22,6 +22,7 @@ use solana_program::program_error::ProgramError;
 use solana_program::pubkey::Pubkey;
 use solana_program::rent::Rent;
 use solana_program::system_program;
+use std::cell::RefMut;
 use std::mem::size_of;
 
 #[test]
@@ -68,7 +69,8 @@ fn test_add_mapping() {
     initialize_mapping_account(&cur_mapping, PC_VERSION).unwrap();
 
     {
-        let mut cur_mapping_data = load_mapping_account_mut(&cur_mapping, PC_VERSION).unwrap();
+        let mut cur_mapping_data: RefMut<pc_map_table_t> =
+            PythAccount::load(&cur_mapping, PC_VERSION).unwrap();
         cur_mapping_data.num_ = PC_MAP_TABLE_SIZE;
     }
 
@@ -99,8 +101,10 @@ fn test_add_mapping() {
     .is_ok());
 
     {
-        let next_mapping_data = load_mapping_account_mut(&next_mapping, PC_VERSION).unwrap();
-        let mut cur_mapping_data = load_mapping_account_mut(&cur_mapping, PC_VERSION).unwrap();
+        let next_mapping_data: RefMut<pc_map_table_t> =
+            PythAccount::load(&next_mapping, PC_VERSION).unwrap();
+        let mut cur_mapping_data: RefMut<pc_map_table_t> =
+            PythAccount::load(&cur_mapping, PC_VERSION).unwrap();
 
         assert!(unsafe {
             cur_mapping_data
@@ -131,7 +135,8 @@ fn test_add_mapping() {
     );
 
     {
-        let mut cur_mapping_data = load_mapping_account_mut(&cur_mapping, PC_VERSION).unwrap();
+        let mut cur_mapping_data: RefMut<pc_map_table_t> =
+            PythAccount::load(&cur_mapping, PC_VERSION).unwrap();
         assert!(unsafe { cur_mapping_data.next_.k8_.iter().all(|x| *x == 0) });
         cur_mapping_data.num_ = PC_MAP_TABLE_SIZE;
         cur_mapping_data.magic_ = 0;

--- a/program/rust/src/tests/test_add_product.rs
+++ b/program/rust/src/tests/test_add_product.rs
@@ -17,7 +17,6 @@ use crate::deserialize::load_account_as;
 use crate::rust_oracle::{
     add_product,
     clear_account,
-    initialize_mapping_account,
     PythAccount,
 };
 use bytemuck::{
@@ -30,7 +29,6 @@ use solana_program::native_token::LAMPORTS_PER_SOL;
 use solana_program::pubkey::Pubkey;
 use solana_program::rent::Rent;
 use solana_program::system_program;
-use std::cell::RefMut;
 
 #[test]
 fn test_add_product() {
@@ -116,8 +114,7 @@ fn test_add_product() {
 
     {
         let product_data = load_account_as::<pc_prod_t>(&product_account).unwrap();
-        let mapping_data: RefMut<pc_map_table_t> =
-            PythAccount::load(&mapping_account, PC_VERSION).unwrap();
+        let mapping_data = pc_map_table_t::load(&mapping_account, PC_VERSION).unwrap();
 
         assert_eq!(product_data.magic_, PC_MAGIC);
         assert_eq!(product_data.ver_, PC_VERSION);
@@ -141,8 +138,7 @@ fn test_add_product() {
     )
     .is_ok());
     {
-        let mapping_data: RefMut<pc_map_table_t> =
-            PythAccount::load(&mapping_account, PC_VERSION).unwrap();
+        let mapping_data = pc_map_table_t::load(&mapping_account, PC_VERSION).unwrap();
         assert_eq!(mapping_data.num_, 2);
         assert!(pubkey_equal(
             &mapping_data.prod_[1],
@@ -177,7 +173,7 @@ fn test_add_product() {
 
     // test fill up of mapping table
     clear_account(&mapping_account).unwrap();
-    initialize_mapping_account(&mapping_account, PC_VERSION).unwrap();
+    pc_map_table_t::initialize(&mapping_account, PC_VERSION).unwrap();
 
     for i in 0..PC_MAP_TABLE_SIZE {
         clear_account(&product_account).unwrap();
@@ -192,8 +188,7 @@ fn test_add_product() {
             instruction_data
         )
         .is_ok());
-        let mapping_data: RefMut<pc_map_table_t> =
-            PythAccount::load(&mapping_account, PC_VERSION).unwrap();
+        let mapping_data = pc_map_table_t::load(&mapping_account, PC_VERSION).unwrap();
         assert_eq!(mapping_data.num_, i + 1);
     }
 
@@ -210,8 +205,7 @@ fn test_add_product() {
     )
     .is_err());
 
-    let mapping_data: RefMut<pc_map_table_t> =
-        PythAccount::load(&mapping_account, PC_VERSION).unwrap();
+    let mapping_data = pc_map_table_t::load(&mapping_account, PC_VERSION).unwrap();
     assert_eq!(mapping_data.num_, PC_MAP_TABLE_SIZE);
 }
 

--- a/program/rust/src/tests/test_add_product.rs
+++ b/program/rust/src/tests/test_add_product.rs
@@ -1,16 +1,5 @@
 use std::mem::size_of;
 
-use bytemuck::{
-    bytes_of,
-    Zeroable,
-};
-use solana_program::account_info::AccountInfo;
-use solana_program::clock::Epoch;
-use solana_program::native_token::LAMPORTS_PER_SOL;
-use solana_program::pubkey::Pubkey;
-use solana_program::rent::Rent;
-use solana_program::system_program;
-
 use crate::c_oracle_header::{
     cmd_hdr_t,
     command_t_e_cmd_add_product,
@@ -29,8 +18,19 @@ use crate::rust_oracle::{
     add_product,
     clear_account,
     initialize_mapping_account,
-    load_mapping_account_mut,
+    PythAccount,
 };
+use bytemuck::{
+    bytes_of,
+    Zeroable,
+};
+use solana_program::account_info::AccountInfo;
+use solana_program::clock::Epoch;
+use solana_program::native_token::LAMPORTS_PER_SOL;
+use solana_program::pubkey::Pubkey;
+use solana_program::rent::Rent;
+use solana_program::system_program;
+use std::cell::RefMut;
 
 #[test]
 fn test_add_product() {
@@ -116,7 +116,8 @@ fn test_add_product() {
 
     {
         let product_data = load_account_as::<pc_prod_t>(&product_account).unwrap();
-        let mapping_data = load_mapping_account_mut(&mapping_account, PC_VERSION).unwrap();
+        let mapping_data: RefMut<pc_map_table_t> =
+            PythAccount::load(&mapping_account, PC_VERSION).unwrap();
 
         assert_eq!(product_data.magic_, PC_MAGIC);
         assert_eq!(product_data.ver_, PC_VERSION);
@@ -140,7 +141,8 @@ fn test_add_product() {
     )
     .is_ok());
     {
-        let mapping_data = load_mapping_account_mut(&mapping_account, PC_VERSION).unwrap();
+        let mapping_data: RefMut<pc_map_table_t> =
+            PythAccount::load(&mapping_account, PC_VERSION).unwrap();
         assert_eq!(mapping_data.num_, 2);
         assert!(pubkey_equal(
             &mapping_data.prod_[1],
@@ -190,7 +192,8 @@ fn test_add_product() {
             instruction_data
         )
         .is_ok());
-        let mapping_data = load_mapping_account_mut(&mapping_account, PC_VERSION).unwrap();
+        let mapping_data: RefMut<pc_map_table_t> =
+            PythAccount::load(&mapping_account, PC_VERSION).unwrap();
         assert_eq!(mapping_data.num_, i + 1);
     }
 
@@ -207,7 +210,8 @@ fn test_add_product() {
     )
     .is_err());
 
-    let mapping_data = load_mapping_account_mut(&mapping_account, PC_VERSION).unwrap();
+    let mapping_data: RefMut<pc_map_table_t> =
+        PythAccount::load(&mapping_account, PC_VERSION).unwrap();
     assert_eq!(mapping_data.num_, PC_MAP_TABLE_SIZE);
 }
 


### PR DESCRIPTION
This PR aims to create a trait `PythAccount` that will allow sharing code between `pc_map_table_t`, `pc_prod_t` and `pc_price_t`.

This 3 accounts share similar headers and a lots of checks will be the same for initializing or loading one of these accounts.
