### PR TITLE
Specifying account check errors

### DIFF
--- a/program/rust/src/error.rs
+++ b/program/rust/src/error.rs
@@ -20,6 +20,16 @@ pub enum OracleError {
     UnknownCError           = 602,
     #[error("UnrecognizedInstruction")]
     UnrecognizedInstruction = 603,
+    #[error("InvalidFundingAccount")]
+    InvalidFundingAccount   = 604,
+    #[error("InvalidSignableAccount")]
+    InvalidSignableAccount  = 605,
+    #[error("InvalidSystemAccount")]
+    InvalidSystemAccount    = 606,
+    #[error("InvalidWritableAccount")]
+    InvalidWritableAccount  = 607,
+    #[error("InvalidWritableAccount")]
+    InvalidFreshAccount     = 608,
 }
 
 impl From<OracleError> for ProgramError {

--- a/program/rust/src/rust_oracle.rs
+++ b/program/rust/src/rust_oracle.rs
@@ -356,7 +356,7 @@ fn valid_funding_account(account: &AccountInfo) -> bool {
 fn check_valid_funding_account(account: &AccountInfo) -> Result<(), ProgramError> {
     pyth_assert(
         valid_funding_account(account),
-        ProgramError::InvalidArgument,
+        OracleError::InvalidFundingAccount.into(),
     )
 }
 
@@ -375,7 +375,7 @@ fn check_valid_signable_account(
 ) -> Result<(), ProgramError> {
     pyth_assert(
         valid_signable_account(program_id, account, minimum_size),
-        ProgramError::InvalidArgument,
+        OracleError::InvalidSignableAccount.into(),
     )
 }
 
@@ -390,7 +390,10 @@ fn valid_fresh_account(account: &AccountInfo) -> bool {
 }
 
 fn check_valid_fresh_account(account: &AccountInfo) -> Result<(), ProgramError> {
-    pyth_assert(valid_fresh_account(account), ProgramError::InvalidArgument)
+    pyth_assert(
+        valid_fresh_account(account),
+        OracleError::InvalidFreshAccount.into(),
+    )
 }
 
 /// Sets the data of account to all-zero

--- a/program/rust/src/tests/test_add_price.rs
+++ b/program/rust/src/tests/test_add_price.rs
@@ -1,3 +1,4 @@
+use crate::error::OracleError;
 use crate::tests::test_utils::AccountSetup;
 use bytemuck::bytes_of;
 use solana_program::program_error::ProgramError;
@@ -146,7 +147,7 @@ fn test_add_price() {
             ],
             instruction_data_add_price
         ),
-        Err(ProgramError::InvalidArgument)
+        Err(OracleError::InvalidFreshAccount.into())
     );
 
     clear_account(&price_account).unwrap();
@@ -195,7 +196,7 @@ fn test_add_price() {
             ],
             instruction_data_add_price
         ),
-        Err(ProgramError::InvalidArgument)
+        Err(OracleError::InvalidSignableAccount.into())
     );
 
     // Fresh product account

--- a/program/rust/src/tests/test_add_product.rs
+++ b/program/rust/src/tests/test_add_product.rs
@@ -1,5 +1,6 @@
 use std::mem::size_of;
 
+use crate::error::OracleError;
 use crate::tests::test_utils::AccountSetup;
 use bytemuck::bytes_of;
 use solana_program::account_info::AccountInfo;
@@ -123,7 +124,7 @@ fn test_add_product() {
             ],
             instruction_data
         ),
-        Err(ProgramError::InvalidArgument)
+        Err(OracleError::InvalidSignableAccount.into())
     );
 
     // test fill up of mapping table

--- a/program/rust/src/tests/test_add_publisher.rs
+++ b/program/rust/src/tests/test_add_publisher.rs
@@ -23,6 +23,7 @@ use crate::rust_oracle::{
     load_checked,
     pubkey_equal,
 };
+use crate::OracleError;
 
 #[test]
 fn test_add_publisher() {
@@ -53,7 +54,7 @@ fn test_add_publisher() {
             &[funding_account.clone(), price_account.clone(),],
             instruction_data
         ),
-        Err(ProgramError::InvalidArgument)
+        Err(OracleError::InvalidSignableAccount.into())
     );
 
     // Now give the price account enough lamports to be rent exempt

--- a/program/rust/src/tests/test_init_mapping.rs
+++ b/program/rust/src/tests/test_init_mapping.rs
@@ -7,6 +7,7 @@ use crate::c_oracle_header::{
     PC_VERSION,
 };
 use crate::deserialize::load_account_as;
+use crate::error::OracleError;
 use crate::rust_oracle::{
     clear_account,
     init_mapping,
@@ -57,7 +58,7 @@ fn test_init_mapping() {
             &[funding_account.clone(), mapping_account.clone()],
             instruction_data
         ),
-        Err(ProgramError::InvalidArgument)
+        Err(OracleError::InvalidFreshAccount.into())
     );
 
     clear_account(&mapping_account).unwrap();
@@ -75,7 +76,7 @@ fn test_init_mapping() {
             &[funding_account.clone(), mapping_account.clone()],
             instruction_data
         ),
-        Err(ProgramError::InvalidArgument)
+        Err(OracleError::InvalidFundingAccount.into())
     );
 
     funding_account.is_signer = true;
@@ -87,7 +88,7 @@ fn test_init_mapping() {
             &[funding_account.clone(), mapping_account.clone()],
             instruction_data
         ),
-        Err(ProgramError::InvalidArgument)
+        Err(OracleError::InvalidSignableAccount.into())
     );
 
     mapping_account.is_signer = true;
@@ -99,7 +100,7 @@ fn test_init_mapping() {
             &[funding_account.clone(), mapping_account.clone()],
             instruction_data
         ),
-        Err(ProgramError::InvalidArgument)
+        Err(OracleError::InvalidFundingAccount.into())
     );
 
     funding_account.is_writable = true;
@@ -111,7 +112,7 @@ fn test_init_mapping() {
             &[funding_account.clone(), mapping_account.clone()],
             instruction_data
         ),
-        Err(ProgramError::InvalidArgument)
+        Err(OracleError::InvalidSignableAccount.into())
     );
 
     mapping_account.is_writable = true;
@@ -123,7 +124,7 @@ fn test_init_mapping() {
             &[funding_account.clone(), mapping_account.clone()],
             instruction_data
         ),
-        Err(ProgramError::InvalidArgument)
+        Err(OracleError::InvalidSignableAccount.into())
     );
 
     mapping_account.owner = &program_id;
@@ -136,7 +137,7 @@ fn test_init_mapping() {
             &[funding_account.clone(), mapping_account.clone()],
             instruction_data
         ),
-        Err(ProgramError::InvalidArgument)
+        Err(OracleError::InvalidSignableAccount.into())
     );
 
     mapping_account.data = prev_data;

--- a/program/rust/src/tests/test_upd_product.rs
+++ b/program/rust/src/tests/test_upd_product.rs
@@ -1,5 +1,6 @@
 use std::mem::size_of;
 
+use crate::rust_oracle::try_convert;
 use crate::tests::test_utils::AccountSetup;
 use solana_program::account_info::AccountInfo;
 use solana_program::program_error::ProgramError;
@@ -19,7 +20,6 @@ use crate::rust_oracle::{
     initialize_checked,
     load_checked,
     read_pc_str_t,
-    try_convert,
     upd_product,
 };
 


### PR DESCRIPTION
It's a little hard to debug when all account checks return InvalidArgument, so I specified the error dpending on which check failed