### PR TITLE
Move to utils

### DIFF
--- a/program/rust/src/deserialize.rs
+++ b/program/rust/src/deserialize.rs
@@ -79,7 +79,7 @@ pub fn load_checked<'a, T: PythAccount>(
     load_account_as_mut::<T>(account)
 }
 
-pub fn initialize_checked<'a, T: PythAccount>(
+pub fn initialize_pyth_account_checked<'a, T: PythAccount>(
     account: &'a AccountInfo,
     version: u32,
 ) -> Result<RefMut<'a, T>, ProgramError> {

--- a/program/rust/src/deserialize.rs
+++ b/program/rust/src/deserialize.rs
@@ -6,13 +6,21 @@ use bytemuck::{
     Pod,
 };
 
+use crate::c_oracle_header::{
+    pc_acc,
+    PythAccount,
+    PC_MAGIC,
+};
+use crate::utils::{
+    clear_account,
+    pyth_assert,
+};
+use solana_program::account_info::AccountInfo;
+use solana_program::program_error::ProgramError;
 use std::cell::{
     Ref,
     RefMut,
 };
-
-use solana_program::account_info::AccountInfo;
-use solana_program::program_error::ProgramError;
 
 /// Interpret the bytes in `data` as a value of type `T`
 pub fn load<T: Pod>(data: &[u8]) -> Result<&T, ProgramError> {
@@ -52,4 +60,38 @@ pub fn load_account_as_mut<'a, T: Pod>(
     Ok(RefMut::map(data, |data| {
         bytemuck::from_bytes_mut(&mut data[0..size_of::<T>()])
     }))
+}
+
+pub fn load_checked<'a, T: PythAccount>(
+    account: &'a AccountInfo,
+    version: u32,
+) -> Result<RefMut<'a, T>, ProgramError> {
+    {
+        let account_header = load_account_as::<pc_acc>(account)?;
+        pyth_assert(
+            account_header.magic_ == PC_MAGIC
+                && account_header.ver_ == version
+                && account_header.type_ == T::ACCOUNT_TYPE,
+            ProgramError::InvalidArgument,
+        )?;
+    }
+
+    load_account_as_mut::<T>(account)
+}
+
+pub fn initialize_checked<'a, T: PythAccount>(
+    account: &'a AccountInfo,
+    version: u32,
+) -> Result<RefMut<'a, T>, ProgramError> {
+    clear_account(account)?;
+
+    {
+        let mut account_header = load_account_as_mut::<pc_acc>(account)?;
+        account_header.magic_ = PC_MAGIC;
+        account_header.ver_ = version;
+        account_header.type_ = T::ACCOUNT_TYPE;
+        account_header.size_ = T::INITIAL_SIZE;
+    }
+
+    load_account_as_mut::<T>(account)
 }

--- a/program/rust/src/rust_oracle.rs
+++ b/program/rust/src/rust_oracle.rs
@@ -47,7 +47,8 @@ use crate::c_oracle_header::{
     SUCCESSFULLY_UPDATED_AGGREGATE,
 };
 use crate::deserialize::{
-    initialize_checked, //TODO: This has a confusingly similar name to a Solana sdk function
+    initialize_pyth_account_checked, /* TODO: This has a confusingly similar name to a Solana
+                                      * sdk function */
     load,
     load_account_as_mut,
     load_checked,
@@ -193,7 +194,7 @@ pub fn init_mapping(
 
     // Initialize by setting to zero again (just in case) and populating the account header
     let hdr = load::<cmd_hdr_t>(instruction_data)?;
-    initialize_checked::<pc_map_table_t>(fresh_mapping_account, hdr.ver_)?;
+    initialize_pyth_account_checked::<pc_map_table_t>(fresh_mapping_account, hdr.ver_)?;
 
     Ok(SUCCESS)
 }
@@ -220,7 +221,7 @@ pub fn add_mapping(
         ProgramError::InvalidArgument,
     )?;
 
-    initialize_checked::<pc_map_table_t>(next_mapping, hdr.ver_)?;
+    initialize_pyth_account_checked::<pc_map_table_t>(next_mapping, hdr.ver_)?;
     pubkey_assign(&mut cur_mapping.next_, &next_mapping.key.to_bytes());
 
     Ok(SUCCESS)
@@ -256,7 +257,8 @@ pub fn add_price(
 
     let mut product_data = load_checked::<pc_prod_t>(product_account, cmd_args.ver_)?;
 
-    let mut price_data = initialize_checked::<pc_price_t>(price_account, cmd_args.ver_)?;
+    let mut price_data =
+        initialize_pyth_account_checked::<pc_price_t>(price_account, cmd_args.ver_)?;
     price_data.expo_ = cmd_args.expo_;
     price_data.ptype_ = cmd_args.ptype_;
     pubkey_assign(&mut price_data.prod_, &product_account.key.to_bytes());
@@ -456,7 +458,7 @@ pub fn add_product(
         ProgramError::InvalidArgument,
     )?;
 
-    initialize_checked::<pc_prod_t>(new_product_account, hdr.ver_)?;
+    initialize_pyth_account_checked::<pc_prod_t>(new_product_account, hdr.ver_)?;
 
     let current_index: usize = try_convert(mapping_data.num_)?;
     pubkey_assign(

--- a/program/rust/src/tests/test_add_mapping.rs
+++ b/program/rust/src/tests/test_add_mapping.rs
@@ -7,7 +7,7 @@ use crate::c_oracle_header::{
     PC_VERSION,
 };
 use crate::deserialize::{
-    initialize_checked,
+    initialize_pyth_account_checked,
     load_account_as_mut,
     load_checked,
 };
@@ -39,7 +39,7 @@ fn test_add_mapping() {
 
     let mut curr_mapping_setup = AccountSetup::new::<pc_map_table_t>(&program_id);
     let cur_mapping = curr_mapping_setup.to_account_info();
-    initialize_checked::<pc_map_table_t>(&cur_mapping, PC_VERSION).unwrap();
+    initialize_pyth_account_checked::<pc_map_table_t>(&cur_mapping, PC_VERSION).unwrap();
 
     let mut next_mapping_setup = AccountSetup::new::<pc_map_table_t>(&program_id);
     let next_mapping = next_mapping_setup.to_account_info();

--- a/program/rust/src/tests/test_add_mapping.rs
+++ b/program/rust/src/tests/test_add_mapping.rs
@@ -6,17 +6,20 @@ use crate::c_oracle_header::{
     PC_MAP_TABLE_SIZE,
     PC_VERSION,
 };
-use crate::deserialize::load_account_as_mut;
-use crate::rust_oracle::{
-    add_mapping,
-    clear_account,
+use crate::deserialize::{
     initialize_checked,
+    load_account_as_mut,
     load_checked,
+};
+
+use crate::rust_oracle::add_mapping;
+use crate::tests::test_utils::AccountSetup;
+use crate::utils::{
+    clear_account,
     pubkey_assign,
     pubkey_equal,
     pubkey_is_zero,
 };
-use crate::tests::test_utils::AccountSetup;
 use bytemuck::bytes_of;
 use solana_program::program_error::ProgramError;
 use solana_program::pubkey::Pubkey;

--- a/program/rust/src/tests/test_add_price.rs
+++ b/program/rust/src/tests/test_add_price.rs
@@ -15,7 +15,7 @@ use crate::c_oracle_header::{
     PC_VERSION,
 };
 use crate::deserialize::{
-    initialize_checked,
+    initialize_pyth_account_checked,
     load_checked,
 };
 use crate::rust_oracle::{
@@ -51,7 +51,7 @@ fn test_add_price() {
 
     let mut mapping_setup = AccountSetup::new::<pc_map_table_t>(&program_id);
     let mapping_account = mapping_setup.to_account_info();
-    initialize_checked::<pc_map_table_t>(&mapping_account, PC_VERSION).unwrap();
+    initialize_pyth_account_checked::<pc_map_table_t>(&mapping_account, PC_VERSION).unwrap();
 
     let mut product_setup = AccountSetup::new::<pc_prod_t>(&program_id);
     let product_account = product_setup.to_account_info();

--- a/program/rust/src/tests/test_add_price.rs
+++ b/program/rust/src/tests/test_add_price.rs
@@ -14,12 +14,16 @@ use crate::c_oracle_header::{
     pc_prod_t,
     PC_VERSION,
 };
+use crate::deserialize::{
+    initialize_checked,
+    load_checked,
+};
 use crate::rust_oracle::{
     add_price,
     add_product,
+};
+use crate::utils::{
     clear_account,
-    initialize_checked,
-    load_checked,
     pubkey_equal,
     pubkey_is_zero,
 };

--- a/program/rust/src/tests/test_add_product.rs
+++ b/program/rust/src/tests/test_add_product.rs
@@ -22,7 +22,7 @@ use crate::c_oracle_header::{
     PC_VERSION,
 };
 use crate::deserialize::{
-    initialize_checked,
+    initialize_pyth_account_checked,
     load_account_as,
     load_checked,
 };
@@ -48,7 +48,7 @@ fn test_add_product() {
 
     let mut mapping_setup = AccountSetup::new::<pc_map_table_t>(&program_id);
     let mapping_account = mapping_setup.to_account_info();
-    initialize_checked::<pc_map_table_t>(&mapping_account, PC_VERSION).unwrap();
+    initialize_pyth_account_checked::<pc_map_table_t>(&mapping_account, PC_VERSION).unwrap();
 
     let mut product_setup = AccountSetup::new::<pc_prod_t>(&program_id);
     let product_account = product_setup.to_account_info();
@@ -132,7 +132,7 @@ fn test_add_product() {
 
     // test fill up of mapping table
     clear_account(&mapping_account).unwrap();
-    initialize_checked::<pc_map_table_t>(&mapping_account, PC_VERSION).unwrap();
+    initialize_pyth_account_checked::<pc_map_table_t>(&mapping_account, PC_VERSION).unwrap();
 
     for i in 0..PC_MAP_TABLE_SIZE {
         clear_account(&product_account).unwrap();

--- a/program/rust/src/tests/test_add_product.rs
+++ b/program/rust/src/tests/test_add_product.rs
@@ -21,14 +21,17 @@ use crate::c_oracle_header::{
     PC_PROD_ACC_SIZE,
     PC_VERSION,
 };
-use crate::deserialize::load_account_as;
-use crate::rust_oracle::{
-    add_product,
-    clear_account,
+use crate::deserialize::{
     initialize_checked,
+    load_account_as,
     load_checked,
+};
+use crate::utils::{
+    clear_account,
     pubkey_equal,
 };
+
+use crate::rust_oracle::add_product;
 
 #[test]
 fn test_add_product() {

--- a/program/rust/src/tests/test_add_publisher.rs
+++ b/program/rust/src/tests/test_add_publisher.rs
@@ -17,7 +17,7 @@ use crate::c_oracle_header::{
 use std::mem::size_of;
 
 use crate::deserialize::{
-    initialize_checked,
+    initialize_pyth_account_checked,
     load_checked,
 };
 use crate::rust_oracle::add_publisher;
@@ -44,7 +44,7 @@ fn test_add_publisher() {
 
     let mut price_setup = AccountSetup::new::<pc_price_t>(&program_id);
     let price_account = price_setup.to_account_info();
-    initialize_checked::<pc_price_t>(&price_account, PC_VERSION).unwrap();
+    initialize_pyth_account_checked::<pc_price_t>(&price_account, PC_VERSION).unwrap();
 
 
     **price_account.try_borrow_mut_lamports().unwrap() = 100;
@@ -106,7 +106,7 @@ fn test_add_publisher() {
         Err(ProgramError::InvalidArgument)
     );
 
-    initialize_checked::<pc_price_t>(&price_account, PC_VERSION).unwrap();
+    initialize_pyth_account_checked::<pc_price_t>(&price_account, PC_VERSION).unwrap();
 
     //Fill up price node
     for i in 0..PC_COMP_SIZE {

--- a/program/rust/src/tests/test_add_publisher.rs
+++ b/program/rust/src/tests/test_add_publisher.rs
@@ -16,11 +16,13 @@ use crate::c_oracle_header::{
 };
 use std::mem::size_of;
 
-use crate::rust_oracle::{
-    add_publisher,
-    clear_account,
+use crate::deserialize::{
     initialize_checked,
     load_checked,
+};
+use crate::rust_oracle::add_publisher;
+use crate::utils::{
+    clear_account,
     pubkey_equal,
 };
 use crate::OracleError;

--- a/program/rust/src/tests/test_del_publisher.rs
+++ b/program/rust/src/tests/test_del_publisher.rs
@@ -1,5 +1,5 @@
 use crate::deserialize::{
-    initialize_checked,
+    initialize_pyth_account_checked,
     load_checked,
     load_mut,
 };
@@ -59,7 +59,7 @@ fn test_del_publisher() {
 
     let mut price_setup = AccountSetup::new::<pc_price_t>(&program_id);
     let price_account = price_setup.to_account_info();
-    initialize_checked::<pc_price_t>(&price_account, PC_VERSION).unwrap();
+    initialize_pyth_account_checked::<pc_price_t>(&price_account, PC_VERSION).unwrap();
     {
         let mut price_data = load_checked::<pc_price_t>(&price_account, PC_VERSION).unwrap();
         price_data.num_ = 1;

--- a/program/rust/src/tests/test_del_publisher.rs
+++ b/program/rust/src/tests/test_del_publisher.rs
@@ -1,9 +1,9 @@
-use crate::deserialize::load_mut;
-use crate::rust_oracle::{
-    del_publisher,
-    pubkey_assign,
-    pubkey_is_zero,
+use crate::deserialize::{
+    initialize_checked,
+    load_checked,
+    load_mut,
 };
+use crate::rust_oracle::del_publisher;
 use crate::tests::test_utils::AccountSetup;
 use bytemuck::bytes_of;
 use solana_program::pubkey::Pubkey;
@@ -19,13 +19,12 @@ use crate::c_oracle_header::{
     PC_STATUS_TRADING,
     PC_VERSION,
 };
-use std::mem::size_of;
-
-use crate::rust_oracle::{
-    initialize_checked,
-    load_checked,
+use crate::utils::{
+    pubkey_assign,
     pubkey_equal,
+    pubkey_is_zero,
 };
+use std::mem::size_of;
 
 #[test]
 fn test_del_publisher() {

--- a/program/rust/src/tests/test_init_mapping.rs
+++ b/program/rust/src/tests/test_init_mapping.rs
@@ -8,11 +8,9 @@ use crate::c_oracle_header::{
 };
 use crate::deserialize::load_account_as;
 use crate::error::OracleError;
-use crate::rust_oracle::{
-    clear_account,
-    init_mapping,
-};
+use crate::rust_oracle::init_mapping;
 use crate::tests::test_utils::AccountSetup;
+use crate::utils::clear_account;
 use bytemuck::bytes_of;
 use solana_program::program_error::ProgramError;
 use solana_program::pubkey::Pubkey;

--- a/program/rust/src/tests/test_init_price.rs
+++ b/program/rust/src/tests/test_init_price.rs
@@ -10,14 +10,16 @@ use crate::c_oracle_header::{
     PC_MAX_NUM_DECIMALS,
     PC_VERSION,
 };
-use crate::rust_oracle::{
-    init_price,
+use crate::deserialize::{
     initialize_checked,
     load_checked,
+};
+use crate::rust_oracle::init_price;
+use crate::tests::test_utils::AccountSetup;
+use crate::utils::{
     pubkey_assign,
     pubkey_equal,
 };
-use crate::tests::test_utils::AccountSetup;
 use crate::OracleError;
 
 #[test]

--- a/program/rust/src/tests/test_init_price.rs
+++ b/program/rust/src/tests/test_init_price.rs
@@ -11,7 +11,7 @@ use crate::c_oracle_header::{
     PC_VERSION,
 };
 use crate::deserialize::{
-    initialize_checked,
+    initialize_pyth_account_checked,
     load_checked,
 };
 use crate::rust_oracle::init_price;
@@ -57,7 +57,7 @@ fn test_init_price() {
         Err(ProgramError::InvalidArgument)
     );
 
-    initialize_checked::<pc_price_t>(&price_account, PC_VERSION).unwrap();
+    initialize_pyth_account_checked::<pc_price_t>(&price_account, PC_VERSION).unwrap();
     {
         let mut price_data = load_checked::<pc_price_t>(&price_account, PC_VERSION).unwrap();
         price_data.ptype_ = ptype;

--- a/program/rust/src/tests/test_set_min_pub.rs
+++ b/program/rust/src/tests/test_set_min_pub.rs
@@ -11,7 +11,7 @@ use crate::c_oracle_header::{
     PC_VERSION,
 };
 use crate::deserialize::{
-    initialize_checked,
+    initialize_pyth_account_checked,
     load_checked,
     load_mut,
 };
@@ -29,7 +29,7 @@ fn test_set_min_pub() {
 
     let mut price_setup = AccountSetup::new::<pc_price_t>(&program_id);
     let price_account = price_setup.to_account_info();
-    initialize_checked::<pc_price_t>(&price_account, PC_VERSION).unwrap();
+    initialize_pyth_account_checked::<pc_price_t>(&price_account, PC_VERSION).unwrap();
 
     assert_eq!(get_min_pub(&price_account), Ok(0));
 

--- a/program/rust/src/tests/test_set_min_pub.rs
+++ b/program/rust/src/tests/test_set_min_pub.rs
@@ -10,12 +10,12 @@ use crate::c_oracle_header::{
     pc_price_t,
     PC_VERSION,
 };
-use crate::deserialize::load_mut;
-use crate::rust_oracle::{
+use crate::deserialize::{
     initialize_checked,
     load_checked,
-    set_min_pub,
+    load_mut,
 };
+use crate::rust_oracle::set_min_pub;
 use crate::tests::test_utils::AccountSetup;
 
 #[test]

--- a/program/rust/src/tests/test_upd_product.rs
+++ b/program/rust/src/tests/test_upd_product.rs
@@ -19,7 +19,7 @@ use crate::c_oracle_header::{
     PC_VERSION,
 };
 use crate::deserialize::{
-    initialize_checked,
+    initialize_pyth_account_checked,
     load_checked,
     load_mut,
 };
@@ -37,7 +37,7 @@ fn test_upd_product() {
     let mut product_setup = AccountSetup::new::<pc_prod_t>(&program_id);
     let product_account = product_setup.to_account_info();
 
-    initialize_checked::<pc_prod_t>(&product_account, PC_VERSION).unwrap();
+    initialize_pyth_account_checked::<pc_prod_t>(&product_account, PC_VERSION).unwrap();
 
     let kvs = ["foo", "barz"];
     let size = populate_instruction(&mut instruction_data, &kvs);

--- a/program/rust/src/tests/test_upd_product.rs
+++ b/program/rust/src/tests/test_upd_product.rs
@@ -1,7 +1,10 @@
 use std::mem::size_of;
 
-use crate::rust_oracle::try_convert;
 use crate::tests::test_utils::AccountSetup;
+use crate::utils::{
+    read_pc_str_t,
+    try_convert,
+};
 use solana_program::account_info::AccountInfo;
 use solana_program::program_error::ProgramError;
 use solana_program::pubkey::Pubkey;
@@ -15,13 +18,12 @@ use crate::c_oracle_header::{
     PC_PROD_ACC_SIZE,
     PC_VERSION,
 };
-use crate::deserialize::load_mut;
-use crate::rust_oracle::{
+use crate::deserialize::{
     initialize_checked,
     load_checked,
-    read_pc_str_t,
-    upd_product,
+    load_mut,
 };
+use crate::rust_oracle::upd_product;
 
 #[test]
 fn test_upd_product() {

--- a/program/rust/src/utils.rs
+++ b/program/rust/src/utils.rs
@@ -1,9 +1,125 @@
+use crate::c_oracle_header::{
+    pc_acc,
+    pc_pub_key_t,
+    PC_MAX_NUM_DECIMALS,
+};
+use crate::deserialize::load_account_as;
+use crate::OracleError;
+use solana_program::account_info::AccountInfo;
 use solana_program::program_error::ProgramError;
+use solana_program::program_memory::sol_memset;
+use solana_program::pubkey::Pubkey;
+use solana_program::sysvar::rent::Rent;
+use std::borrow::BorrowMut;
+
 
 pub fn pyth_assert(condition: bool, error_code: ProgramError) -> Result<(), ProgramError> {
     if !condition {
         Result::Err(error_code)
     } else {
         Result::Ok(())
+    }
+}
+
+/// Sets the data of account to all-zero
+pub fn clear_account(account: &AccountInfo) -> Result<(), ProgramError> {
+    let mut data = account
+        .try_borrow_mut_data()
+        .map_err(|_| ProgramError::InvalidArgument)?;
+    let length = data.len();
+    sol_memset(data.borrow_mut(), 0, length);
+    Ok(())
+}
+
+pub fn valid_funding_account(account: &AccountInfo) -> bool {
+    account.is_signer && account.is_writable
+}
+
+pub fn check_valid_funding_account(account: &AccountInfo) -> Result<(), ProgramError> {
+    pyth_assert(
+        valid_funding_account(account),
+        OracleError::InvalidFundingAccount.into(),
+    )
+}
+
+pub fn valid_signable_account(
+    program_id: &Pubkey,
+    account: &AccountInfo,
+    minimum_size: usize,
+) -> bool {
+    account.is_signer
+        && account.is_writable
+        && account.owner == program_id
+        && account.data_len() >= minimum_size
+        && Rent::default().is_exempt(account.lamports(), account.data_len())
+}
+
+pub fn check_valid_signable_account(
+    program_id: &Pubkey,
+    account: &AccountInfo,
+    minimum_size: usize,
+) -> Result<(), ProgramError> {
+    pyth_assert(
+        valid_signable_account(program_id, account, minimum_size),
+        OracleError::InvalidSignableAccount.into(),
+    )
+}
+
+/// Returns `true` if the `account` is fresh, i.e., its data can be overwritten.
+/// Use this check to prevent accidentally overwriting accounts whose data is already populated.
+pub fn valid_fresh_account(account: &AccountInfo) -> bool {
+    let pyth_acc = load_account_as::<pc_acc>(account);
+    match pyth_acc {
+        Ok(pyth_acc) => pyth_acc.magic_ == 0 && pyth_acc.ver_ == 0,
+        Err(_) => false,
+    }
+}
+
+pub fn check_valid_fresh_account(account: &AccountInfo) -> Result<(), ProgramError> {
+    pyth_assert(
+        valid_fresh_account(account),
+        OracleError::InvalidFreshAccount.into(),
+    )
+}
+
+// Check that an exponent is within the range of permitted exponents for price accounts.
+pub fn check_exponent_range(expo: i32) -> Result<(), ProgramError> {
+    pyth_assert(
+        expo >= -(PC_MAX_NUM_DECIMALS as i32) && expo <= PC_MAX_NUM_DECIMALS as i32,
+        ProgramError::InvalidArgument,
+    )
+}
+
+// Assign pubkey bytes from source to target, fails if source is not 32 bytes
+pub fn pubkey_assign(target: &mut pc_pub_key_t, source: &[u8]) {
+    unsafe { target.k1_.copy_from_slice(source) }
+}
+
+pub fn pubkey_is_zero(key: &pc_pub_key_t) -> bool {
+    return unsafe { key.k8_.iter().all(|x| *x == 0) };
+}
+
+pub fn pubkey_equal(target: &pc_pub_key_t, source: &[u8]) -> bool {
+    unsafe { target.k1_ == *source }
+}
+
+/// Convert `x: T` into a `U`, returning the appropriate `OracleError` if the conversion fails.
+pub fn try_convert<T, U: TryFrom<T>>(x: T) -> Result<U, OracleError> {
+    // Note: the error here assumes we're only applying this function to integers right now.
+    U::try_from(x).map_err(|_| OracleError::IntegerCastingError)
+}
+
+/// Read a `pc_str_t` from the beginning of `source`. Returns a slice of `source` containing
+/// the bytes of the `pc_str_t`.
+pub fn read_pc_str_t(source: &[u8]) -> Result<&[u8], ProgramError> {
+    if source.is_empty() {
+        Err(ProgramError::InvalidArgument)
+    } else {
+        let tag_len: usize = try_convert(source[0])?;
+        if tag_len + 1 > source.len() {
+            Err(ProgramError::InvalidArgument)
+        } else {
+            Ok(&source[..(1 + tag_len)])
+        }
     }
 }


### PR DESCRIPTION
There were lots of helper function in rust_oracle. I moved them to deserialize, and utils. I think that the sooner we do this the better, as you can see doing it now caused a lot of files to change.

There was also a method that had the same name as a solana sdk method, so I renamed to another name (in a separate commit )
