### PR TITLE
Export upd_aggregate

### DIFF
--- a/program/c/makefile
+++ b/program/c/makefile
@@ -7,6 +7,6 @@ cpyth:
 	bash -c "ar rcs target/libcpyth.a target/**/*.o"
 cpythtest:
 #   Compile C code to system architecture for use by rust's cargo test
-	gcc -c ./src/oracle/for_cargo_test/cpyth_test.c -o ./target/cpyth_test.o
+	$(CC) -c ./src/oracle/for_cargo_test/cpyth_test.c -o ./target/cpyth_test.o
 #   Bundle C code compiled to system architecture for use by rust's cargo test
 	ar rcs target/libcpythtest.a ./target/cpyth_test.o

--- a/program/c/makefile
+++ b/program/c/makefile
@@ -3,3 +3,6 @@ SOLANA := ../../../solana
 include $(SOLANA)/sdk/bpf/c/bpf.mk
 cpyth:
 	bash -c "ar rcs target/libcpyth.a target/**/*.o"
+cpythtest:
+	gcc -c ./src/oracle/for_cargo_test/cpyth_test.c -o ./target/cpyth_test.o
+	ar rcs target/libcpythtest.a ./target/cpyth_test.o

--- a/program/c/makefile
+++ b/program/c/makefile
@@ -1,8 +1,12 @@
 OUT_DIR := ./target
 SOLANA := ../../../solana
 include $(SOLANA)/sdk/bpf/c/bpf.mk
+
 cpyth:
+#   Bundle C code compiled to bpf for use by rust
 	bash -c "ar rcs target/libcpyth.a target/**/*.o"
 cpythtest:
+#   Compile C code to system architecture for use by rust's cargo test
 	gcc -c ./src/oracle/for_cargo_test/cpyth_test.c -o ./target/cpyth_test.o
+#   Bundle C code compiled to system architecture for use by rust's cargo test
 	ar rcs target/libcpythtest.a ./target/cpyth_test.o

--- a/program/c/src/oracle/for_cargo_test/cpyth_test.c
+++ b/program/c/src/oracle/for_cargo_test/cpyth_test.c
@@ -1,0 +1,23 @@
+/// The goal of this file is to provide the upd_aggregate function to local rust tests
+
+/// The heap address is different on solana runtime and locally, so here we need to allocate some heap space
+/// In compilation to bpf, PC_HEAP_START is provided by <solana.h>
+char heap_start[8192];
+#define PC_HEAP_START (heap_start)
+#define static_assert _Static_assert
+
+typedef signed char int8_t;
+typedef unsigned char uint8_t;
+typedef signed short int16_t;
+typedef unsigned short uint16_t;
+typedef signed int int32_t;
+typedef unsigned int uint32_t;
+typedef signed long int int64_t;
+typedef unsigned long int uint64_t;
+
+#include <stdlib.h>
+#include "../upd_aggregate.h"
+
+extern bool c_upd_aggregate( pc_price_t *ptr, uint64_t slot, int64_t timestamp ){
+  return upd_aggregate(ptr, slot, timestamp );
+}

--- a/program/c/src/oracle/for_cargo_test/cpyth_test.c
+++ b/program/c/src/oracle/for_cargo_test/cpyth_test.c
@@ -1,7 +1,7 @@
 /// The goal of this file is to provide the upd_aggregate function to local rust tests
 
-/// The heap address is different on solana runtime and locally, so here we need to allocate some heap space
-/// In compilation to bpf, PC_HEAP_START is provided by <solana.h>
+/// The heap address PC_HEAP_START is different on solana runtime and locally, so here we need to allocate some heap space
+/// When compiling to bpf, PC_HEAP_START is provided by <solana.h>
 char heap_start[8192];
 #define PC_HEAP_START (heap_start)
 #define static_assert _Static_assert
@@ -15,7 +15,6 @@ typedef unsigned int uint32_t;
 typedef signed long int int64_t;
 typedef unsigned long int uint64_t;
 
-#include <stdlib.h>
 #include "../upd_aggregate.h"
 
 extern bool c_upd_aggregate( pc_price_t *ptr, uint64_t slot, int64_t timestamp ){

--- a/program/c/src/oracle/for_cargo_test/cpyth_test.c
+++ b/program/c/src/oracle/for_cargo_test/cpyth_test.c
@@ -1,7 +1,7 @@
 /// The goal of this file is to provide the upd_aggregate function to local rust tests
 
-/// The heap address PC_HEAP_START is different on solana runtime and locally, so here we need to allocate some heap space
-/// When compiling to bpf, PC_HEAP_START is provided by <solana.h>
+/// We need to allocate some heap space for upd_aggregate
+/// When compiling for the solana runtime, the heap space is preallocated and PC_HEAP_START is provided by <solana.h>
 char heap_start[8192];
 #define PC_HEAP_START (heap_start)
 #define static_assert _Static_assert

--- a/program/c/src/oracle/oracle.c
+++ b/program/c/src/oracle/oracle.c
@@ -171,3 +171,7 @@ extern uint64_t c_entrypoint(const uint8_t *input)
   }
   return dispatch( prm, ka );
 }
+
+extern bool c_upd_aggregate( pc_price_t *ptr, uint64_t slot, int64_t timestamp ){
+  return upd_aggregate(ptr, slot, timestamp );
+}

--- a/scripts/build-bpf.sh
+++ b/scripts/build-bpf.sh
@@ -30,13 +30,14 @@ export V="${V:-1}"
 make clean 
 make  "${@:2}" 
 make cpyth 
+make cpythtest
 rm ./target/*-keypair.json
 
 
 #build Rust and link it with C
 cd "${PYTH_DIR}"
 cargo clean
-cargo test
+cargo test-bpf
 cargo clean
 cargo build-bpf
 


### PR DESCRIPTION
For one of the latest steps of the migration we're going to restrict the C code to the aggregation logic.
This requires exporting the function `upd_aggregate` from C to Rust. We're doing similar logic to exporting the c_entrypoint from `oracle.c`.

A subtle difficulty is that `cargo test` runs in the system architecture, so we need to compile `upd_aggregate` to this target as well. That's the goal of `for_cargo_test/cpyth_test.c`. This will allow using `upd_aggregate` in the tests.

Of course there's danger that our rust tests pass but our production code fails because they're compiling to different targets but this problem already existed with `test_oracle.c` which is also getting compiled to the system's target. Integration tests (currently pytest) should pick this up.