### PR TITLE
Run aggregation tests in CI

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -70,6 +70,8 @@ RUN ./pyth-client/scripts/patch-solana.sh
 
 # Build and test the oracle program.
 RUN cd pyth-client && ./scripts/build-bpf.sh .
+# Run aggregation logic tests
+RUN cd pyth-client && ./scripts/run-aggregation-tests.sh
 RUN /bin/bash -l -c "pytest-3 --pyargs pyth"
 
 ENTRYPOINT []

--- a/program/c/src/oracle/model/run_tests
+++ b/program/c/src/oracle/model/run_tests
@@ -1,8 +1,5 @@
 #!/bin/sh
 
-module purge          || exit 1
-module load gcc-9.3.0 || exit 1
-
 ./clean       || exit 1
 mkdir -pv bin || exit 1
 

--- a/program/c/src/oracle/sort/run_tests
+++ b/program/c/src/oracle/sort/run_tests
@@ -1,8 +1,5 @@
 #!/bin/sh
 
-module purge          || exit 1
-module load gcc-9.3.0 || exit 1
-
 ./clean       || exit 1
 mkdir -pv bin || exit 1
 

--- a/program/c/src/oracle/util/run_tests
+++ b/program/c/src/oracle/util/run_tests
@@ -1,8 +1,5 @@
 #!/bin/sh
 
-module purge          || exit 1
-module load gcc-9.3.0 || exit 1
-
 ./clean       || exit 1
 mkdir -pv bin || exit 1
 

--- a/scripts/run-aggregation-tests.sh
+++ b/scripts/run-aggregation-tests.sh
@@ -1,0 +1,15 @@
+set -eux
+
+PYTH_DIR=$( cd "${1:-.}" && pwd)
+
+#find the makefile in pyth-client
+#ASSUMES THAT there is only one makefile there 
+C_DIR="$( find $PYTH_DIR | grep makefile)"
+C_DIR=$(dirname $C_DIR)
+
+cd "${C_DIR}/src/oracle/model"
+./run_tests
+cd "${C_DIR}/src/oracle/sort"
+./run_tests
+cd "${C_DIR}/src/oracle/util"
+./run_tests


### PR DESCRIPTION
I unearthed some tests for the aggregation logic components. They take <2min so I thought we can add them to CI. 
These tests originally imported modules that don't exist in our current setup, so I deleted those lines.