### PR TITLE
Make it build on macs

### DIFF
--- a/program/c/src/oracle/native/upd_aggregate.c
+++ b/program/c/src/oracle/native/upd_aggregate.c
@@ -6,15 +6,6 @@ char heap_start[8192];
 #define PC_HEAP_START (heap_start)
 #define static_assert _Static_assert
 
-typedef signed char int8_t;
-typedef unsigned char uint8_t;
-typedef signed short int16_t;
-typedef unsigned short uint16_t;
-typedef signed int int32_t;
-typedef unsigned int uint32_t;
-typedef signed long int int64_t;
-typedef unsigned long int uint64_t;
-
 #include "../upd_aggregate.h"
 
 extern bool c_upd_aggregate( pc_price_t *ptr, uint64_t slot, int64_t timestamp ){

--- a/program/c/src/oracle/oracle.h
+++ b/program/c/src/oracle/oracle.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <stdbool.h>
+#include "util/compat_stdint.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/program/rust/build.rs
+++ b/program/rust/build.rs
@@ -9,6 +9,7 @@ fn main() {
 
     //generate and write bindings
     let bindings = Builder::default()
+        .clang_arg("-I../../../solana/sdk/bpf/c/inc/")
         .header("./src/bindings.h")
         .parse_callbacks(Box::new(parser))
         .rustfmt_bindings(true)

--- a/program/rust/src/bindings.h
+++ b/program/rust/src/bindings.h
@@ -2,15 +2,6 @@
 
 #define static_assert _Static_assert
 
-typedef signed char int8_t;
-typedef unsigned char uint8_t;
-typedef signed short int16_t;
-typedef unsigned short uint16_t;
-typedef signed int int32_t;
-typedef unsigned int uint32_t;
-typedef signed long int int64_t;
-typedef unsigned long int uint64_t;
-
 #include <stddef.h>
 #include "../../c/src/oracle/oracle.h"
 


### PR DESCRIPTION
the cargo build (and `./scripts/build-bpf.sh`) used were failing because we were defining these integer types multiple times. It turns out that we already have a solution to this problem in `compat_stdint.h` which  selects between the system stdint.h and the definitions in the solana sdk. 

Note that the repo still expects to be placed adjacent to a `solana` directory. I'll fix that next.