### PR TITLE
Add example triton1 pythnet nginx configuration

### DIFF
--- a/doc/example-nginx-triton1.conf
+++ b/doc/example-nginx-triton1.conf
@@ -14,19 +14,44 @@ http {
 
   client_max_body_size 0;
 
-  upstream backend {
-    server YOUR_NODE.rpcpool.com:443;
+  # Pythnet, listening on ports 7799:7800
+  upstream pythnet_backend {
+    server YOUR_PYTHNET_NODE.rpcpool.com:443;
     keepalive 4;
   }
+  server {
+    listen 7800;
+    location / {
+      proxy_http_version 1.1;
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection "Upgrade";
+      proxy_pass https://pythnet_backend/YOUR_PYTHNET_AUTH_TOKEN_HERE/;
+      proxy_set_header Host YOUR_PYTHNET_NODE.rpcpool.com;
+    }
+  }
+  server {
+    listen 7799;
+    location / {
+      proxy_http_version 1.1;
+      proxy_set_header Connection "";
+      proxy_pass https://pythnet_backend/YOUR_PYTHNET_AUTH_TOKEN_HERE/;
+      proxy_set_header Host YOUR_PYTHNET_NODE.rpcpool.com;
+    }
+  }
 
+  # Solana Mainnet, listening on ports 7899:7900
+  upstream mainnet_backend {
+    server YOUR_MAINNET_NODE.rpcpool.com:443;
+    keepalive 4;
+  }
   server {
     listen 7900;
     location / {
       proxy_http_version 1.1;
       proxy_set_header Upgrade $http_upgrade;
       proxy_set_header Connection "Upgrade";
-      proxy_pass https://backend/YOUR_AUTH_TOKEN_HERE/;
-      proxy_set_header Host YOUR_NODE.rpcpool.com;
+      proxy_pass https://mainnet_backend/YOUR_MAINNET_AUTH_TOKEN_HERE/;
+      proxy_set_header Host YOUR_MAINNET_NODE.rpcpool.com;
     }
   }
   server {
@@ -34,8 +59,8 @@ http {
     location / {
       proxy_http_version 1.1;
       proxy_set_header Connection "";
-      proxy_pass https://backend/YOUR_AUTH_TOKEN_HERE/;
-      proxy_set_header Host YOUR_NODE.rpcpool.com;
+      proxy_pass https://mainnet_backend/YOUR_MAINNET_AUTH_TOKEN_HERE/;
+      proxy_set_header Host YOUR_MAINNET_NODE.rpcpool.com;
     }
   }
 }


### PR DESCRIPTION
To connect nginx to Pythnet, a completely orthogonal, seperate configuration should be used. This should use seperate `server` and `upstream` stanzas.