### PR TITLE
Move compilation warnings to CI

### DIFF
--- a/.github/workflows/rust-ci-checks.yml
+++ b/.github/workflows/rust-ci-checks.yml
@@ -1,4 +1,4 @@
-name: Check Formatting
+name: Rust CI Checks
 
 on:
   pull_request:
@@ -6,7 +6,7 @@ on:
     branches: [main]
 
 jobs:
-  pre-commit:
+  rust-ci-checks:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -17,3 +17,9 @@ jobs:
         toolchain: nightly
         components: rustfmt, clippy
     - uses: pre-commit/action@v2.0.3
+    - name: Build
+      run: RUSTFLAGS="-D warnings" cargo build
+    - name: Test
+      run: |
+         cargo test
+         cargo test-bpf

--- a/program/rust/src/lib.rs
+++ b/program/rust/src/lib.rs
@@ -1,4 +1,3 @@
-#![deny(warnings)]
 // Allow non upper case globals from C
 #![allow(non_upper_case_globals)]
 // Allow using the solana_program::entrypoint::deserialize function


### PR DESCRIPTION
`#![deny(warnings)]` reduces development speed because you have to fix all this stuff in order to build/run tests. This makes it harder to iterate on bug fixes, e.g., to quickly change something in your code to see if it fixes a test. It's also bad practice for rust because it can break the build when something in rust changes (see https://rust-unofficial.github.io/patterns/anti_patterns/deny-warnings.html  ).

This PR moves the warning check to CI.