### PR TITLE
 Create rust structs and replace bindgen structs

### DIFF
--- a/program/rust/src/c_oracle_header.rs
+++ b/program/rust/src/c_oracle_header.rs
@@ -34,94 +34,137 @@ pub trait PythAccount: Pod {
     }
 }
 
-impl PythAccount for pc_map_table_t {
+impl PythAccount for MappingAccount {
     const ACCOUNT_TYPE: u32 = PC_ACCTYPE_MAPPING;
     const INITIAL_SIZE: u32 = PC_MAP_TABLE_T_PROD_OFFSET as u32;
 }
 
-impl PythAccount for pc_prod_t {
+impl PythAccount for ProductAccount {
     const ACCOUNT_TYPE: u32 = PC_ACCTYPE_PRODUCT;
-    const INITIAL_SIZE: u32 = size_of::<pc_prod_t>() as u32;
+    const INITIAL_SIZE: u32 = size_of::<ProductAccount>() as u32;
     fn minimum_size() -> usize {
         PC_PROD_ACC_SIZE as usize
     }
 }
 
-impl PythAccount for pc_price_t {
+impl PythAccount for PriceAccount {
     const ACCOUNT_TYPE: u32 = PC_ACCTYPE_PRICE;
     const INITIAL_SIZE: u32 = PC_PRICE_T_COMP_OFFSET as u32;
 }
 
-#[cfg(target_endian = "little")]
-unsafe impl Zeroable for pc_acc {
+#[repr(C)]
+#[derive(Copy, Clone, Pod, Zeroable)]
+pub struct PriceAccount {
+    pub magic_:          u32,
+    pub ver_:            u32,
+    pub type_:           u32,
+    pub size_:           u32,
+    pub ptype_:          u32,      // Type of the price account
+    pub expo_:           i32,      // Exponent for the published prices
+    pub num_:            u32,      // Current number of authorized publishers
+    pub num_qt_:         u32,      // Number of valid quotes for the last aggregation
+    pub last_slot_:      u64,      // Last slot with a succesful aggregation (status : TRADING)
+    pub valid_slot_:     u64,      // Second to last slot where aggregation was attempted
+    pub twap_:           PriceEma, // Ema for price
+    pub twac_:           PriceEma, // Ema for confidence
+    pub timestamp_:      i64,      // Last time aggregation was attempted
+    pub min_pub_:        u8,       // Minimum valid publisher quotes for a succesful aggregation
+    pub unused_1_:       i8,
+    pub unused_2_:       i16,
+    pub unused_3_:       i32,
+    pub prod_:           CPubkey, // Corresponding mapping account
+    pub next_:           CPubkey, // Next price account in the list
+    pub prev_slot_:      u64,     /* Second to last slot where aggregation was succesful
+                                   * (status : TRADING) */
+    pub prev_price_:     i64,       // Aggregate price at prev_slot_
+    pub prev_conf_:      u64,       // Confidence interval at prev_slot_
+    pub prev_timestamp_: i64,       // Timestamp of prev_slot_
+    pub agg_:            PriceInfo, // Last attempted aggregate results
+    pub comp_:           [PriceComponent; 32usize], // Publisher's price components
 }
 
-#[cfg(target_endian = "little")]
-unsafe impl Pod for pc_acc {
+#[repr(C)]
+#[derive(Copy, Clone, Pod, Zeroable)]
+pub struct PriceComponent {
+    pub pub_:    CPubkey,
+    pub agg_:    PriceInfo,
+    pub latest_: PriceInfo,
 }
 
-#[cfg(target_endian = "little")]
-unsafe impl Zeroable for pc_map_table {
+#[repr(C)]
+#[derive(Debug, Copy, Clone, Pod, Zeroable)]
+pub struct PriceInfo {
+    pub price_:           i64,
+    pub conf_:            u64,
+    pub status_:          u32,
+    pub corp_act_status_: u32,
+    pub pub_slot_:        u64,
 }
 
-#[cfg(target_endian = "little")]
-unsafe impl Pod for pc_map_table {
+#[repr(C)]
+#[derive(Debug, Copy, Clone, Pod, Zeroable)]
+pub struct PriceEma {
+    pub val_:   i64,
+    pub numer_: i64,
+    pub denom_: i64,
 }
 
-#[cfg(target_endian = "little")]
-unsafe impl Zeroable for pc_prod {
+#[repr(C)]
+#[derive(Copy, Clone, Zeroable, Pod)]
+pub struct AccountHeader {
+    pub magic_: u32,
+    pub ver_:   u32,
+    pub type_:  u32,
+    pub size_:  u32,
 }
 
-#[cfg(target_endian = "little")]
-unsafe impl Pod for pc_prod {
+#[repr(C)]
+#[derive(Copy, Clone, Pod, Zeroable)]
+pub struct ProductAccount {
+    pub magic_:  u32,
+    pub ver_:    u32,
+    pub type_:   u32,
+    pub size_:   u32,
+    pub px_acc_: CPubkey,
 }
 
-#[cfg(target_endian = "little")]
-unsafe impl Zeroable for pc_price {
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct MappingAccount {
+    pub magic_:  u32,
+    pub ver_:    u32,
+    pub type_:   u32,
+    pub size_:   u32,
+    pub num_:    u32,
+    pub unused_: u32,
+    pub next_:   CPubkey,
+    pub prod_:   [CPubkey; 640usize],
 }
 
-#[cfg(target_endian = "little")]
-unsafe impl Pod for pc_price {
+// Unsafe impl because CPubkey is a union
+unsafe impl Pod for CPubkey {
 }
-
-#[cfg(target_endian = "little")]
-unsafe impl Zeroable for pc_price_info {
-}
-
-#[cfg(target_endian = "little")]
-unsafe impl Pod for pc_price_info {
-}
-
-#[cfg(target_endian = "little")]
-unsafe impl Zeroable for pc_ema {
-}
-
-#[cfg(target_endian = "little")]
-unsafe impl Pod for pc_ema {
-}
-
-
-#[cfg(target_endian = "little")]
-unsafe impl Zeroable for pc_pub_key_t {
-}
-
-#[cfg(target_endian = "little")]
-unsafe impl Pod for pc_pub_key_t {
+unsafe impl Zeroable for CPubkey {
 }
 
 
-#[cfg(target_endian = "little")]
-unsafe impl Zeroable for pc_price_comp_t {
+// Unsafe impl because product_list is of size 640 and there's no derived trait for this size
+unsafe impl Pod for MappingAccount {
+}
+unsafe impl Zeroable for MappingAccount {
 }
 
-#[cfg(target_endian = "little")]
-unsafe impl Pod for pc_price_comp_t {
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union CPubkey {
+    pub k1_: [u8; 32usize],
+    pub k8_: [u64; 4usize],
 }
 
-impl pc_pub_key_t {
-    pub fn new_unique() -> pc_pub_key_t {
+impl CPubkey {
+    pub fn new_unique() -> CPubkey {
         let solana_unique = Pubkey::new_unique();
-        pc_pub_key_t {
+        CPubkey {
             k1_: solana_unique.to_bytes(),
         }
     }

--- a/program/rust/src/c_oracle_header.rs
+++ b/program/rust/src/c_oracle_header.rs
@@ -36,6 +36,7 @@ pub trait PythAccount: Pod {
 
 impl PythAccount for MappingAccount {
     const ACCOUNT_TYPE: u32 = PC_ACCTYPE_MAPPING;
+    /// Equal to the offset of `prod_` in `MappingAccount`, see the trait comment for more detail
     const INITIAL_SIZE: u32 = PC_MAP_TABLE_T_PROD_OFFSET as u32;
 }
 
@@ -49,6 +50,7 @@ impl PythAccount for ProductAccount {
 
 impl PythAccount for PriceAccount {
     const ACCOUNT_TYPE: u32 = PC_ACCTYPE_PRICE;
+    /// Equal to the offset of `comp_` in `PriceAccount`, see the trait comment for more detail
     const INITIAL_SIZE: u32 = PC_PRICE_T_COMP_OFFSET as u32;
 }
 
@@ -59,28 +61,45 @@ pub struct PriceAccount {
     pub ver_:            u32,
     pub type_:           u32,
     pub size_:           u32,
-    pub ptype_:          u32,      // Type of the price account
-    pub expo_:           i32,      // Exponent for the published prices
-    pub num_:            u32,      // Current number of authorized publishers
-    pub num_qt_:         u32,      // Number of valid quotes for the last aggregation
-    pub last_slot_:      u64,      // Last slot with a succesful aggregation (status : TRADING)
-    pub valid_slot_:     u64,      // Second to last slot where aggregation was attempted
-    pub twap_:           PriceEma, // Ema for price
-    pub twac_:           PriceEma, // Ema for confidence
-    pub timestamp_:      i64,      // Last time aggregation was attempted
-    pub min_pub_:        u8,       // Minimum valid publisher quotes for a succesful aggregation
+    /// Type of the price account
+    pub ptype_:          u32,
+    /// Exponent for the published prices
+    pub expo_:           i32,
+    /// Current number of authorized publishers
+    pub num_:            u32,
+    /// Number of valid quotes for the last aggregation
+    pub num_qt_:         u32,
+    /// Last slot with a succesful aggregation (status : TRADING)
+    pub last_slot_:      u64,
+    /// Second to last slot where aggregation was attempted
+    pub valid_slot_:     u64,
+    /// Ema for price
+    pub twap_:           PriceEma,
+    /// Ema for confidence
+    pub twac_:           PriceEma,
+    /// Last time aggregation was attempted
+    pub timestamp_:      i64,
+    /// Minimum valid publisher quotes for a succesful aggregation
+    pub min_pub_:        u8,
     pub unused_1_:       i8,
     pub unused_2_:       i16,
     pub unused_3_:       i32,
-    pub prod_:           CPubkey, // Corresponding mapping account
-    pub next_:           CPubkey, // Next price account in the list
-    pub prev_slot_:      u64,     /* Second to last slot where aggregation was succesful
-                                   * (status : TRADING) */
-    pub prev_price_:     i64,       // Aggregate price at prev_slot_
-    pub prev_conf_:      u64,       // Confidence interval at prev_slot_
-    pub prev_timestamp_: i64,       // Timestamp of prev_slot_
-    pub agg_:            PriceInfo, // Last attempted aggregate results
-    pub comp_:           [PriceComponent; 32usize], // Publisher's price components
+    /// Corresponding product account
+    pub prod_:           CPubkey,
+    /// Next price account in the list
+    pub next_:           CPubkey,
+    /// Second to last slot where aggregation was succesful (i.e. status : TRADING)
+    pub prev_slot_:      u64,
+    /// Aggregate price at prev_slot_
+    pub prev_price_:     i64,
+    /// Confidence interval at prev_slot_
+    pub prev_conf_:      u64,
+    /// Timestamp of prev_slot_
+    pub prev_timestamp_: i64,
+    /// Last attempted aggregate results
+    pub agg_:            PriceInfo,
+    /// Publishers' price components
+    pub comp_:           [PriceComponent; PC_COMP_SIZE as usize],
 }
 
 #[repr(C)]
@@ -138,7 +157,7 @@ pub struct MappingAccount {
     pub num_:    u32,
     pub unused_: u32,
     pub next_:   CPubkey,
-    pub prod_:   [CPubkey; 640usize],
+    pub prod_:   [CPubkey; PC_MAP_TABLE_SIZE as usize],
 }
 
 // Unsafe impl because CPubkey is a union

--- a/program/rust/src/deserialize.rs
+++ b/program/rust/src/deserialize.rs
@@ -7,7 +7,7 @@ use bytemuck::{
 };
 
 use crate::c_oracle_header::{
-    pc_acc,
+    AccountHeader,
     PythAccount,
     PC_MAGIC,
 };
@@ -71,7 +71,7 @@ pub fn load_checked<'a, T: PythAccount>(
     version: u32,
 ) -> Result<RefMut<'a, T>, ProgramError> {
     {
-        let account_header = load_account_as::<pc_acc>(account)?;
+        let account_header = load_account_as::<AccountHeader>(account)?;
         pyth_assert(
             account_header.magic_ == PC_MAGIC
                 && account_header.ver_ == version
@@ -90,7 +90,7 @@ pub fn initialize_pyth_account_checked<'a, T: PythAccount>(
     clear_account(account)?;
 
     {
-        let mut account_header = load_account_as_mut::<pc_acc>(account)?;
+        let mut account_header = load_account_as_mut::<AccountHeader>(account)?;
         account_header.magic_ = PC_MAGIC;
         account_header.ver_ = version;
         account_header.type_ = T::ACCOUNT_TYPE;

--- a/program/rust/src/instruction.rs
+++ b/program/rust/src/instruction.rs
@@ -1,5 +1,5 @@
 use crate::c_oracle_header::{
-    pc_pub_key_t,
+    CPubkey,
     PC_VERSION,
 };
 use crate::deserialize::load;
@@ -122,7 +122,7 @@ pub type InitPriceArgs = AddPriceArgs;
 #[derive(Zeroable, Pod, Copy, Clone)]
 pub struct AddPublisherArgs {
     pub header:    CommandHeader,
-    pub publisher: pc_pub_key_t,
+    pub publisher: CPubkey,
 }
 
 pub type DelPublisherArgs = AddPublisherArgs;

--- a/program/rust/src/tests/pyth_simulator.rs
+++ b/program/rust/src/tests/pyth_simulator.rs
@@ -27,8 +27,8 @@ use solana_sdk::signature::{
 use solana_sdk::transaction::Transaction;
 
 use crate::c_oracle_header::{
-    pc_map_table_t,
-    pc_price_t,
+    MappingAccount,
+    PriceAccount,
     PC_PROD_ACC_SIZE,
     PC_PTYPE_PRICE,
 };
@@ -112,7 +112,7 @@ impl PythSimulator {
     /// Initialize a mapping account (using the init_mapping instruction), returning the keypair
     /// associated with the newly-created account.
     pub async fn init_mapping(&mut self) -> Result<Keypair, BanksClientError> {
-        let mapping_keypair = self.create_pyth_account(size_of::<pc_map_table_t>()).await;
+        let mapping_keypair = self.create_pyth_account(size_of::<MappingAccount>()).await;
 
         let cmd: CommandHeader = OracleCommand::InitMapping.into();
         let instruction = Instruction::new_with_bytes(
@@ -181,7 +181,7 @@ impl PythSimulator {
         product_keypair: &Keypair,
         expo: i32,
     ) -> Result<Keypair, BanksClientError> {
-        let price_keypair = self.create_pyth_account(size_of::<pc_price_t>()).await;
+        let price_keypair = self.create_pyth_account(size_of::<PriceAccount>()).await;
 
         let cmd = AddPriceArgs {
             header:     OracleCommand::AddPrice.into(),

--- a/program/rust/src/tests/test_add_mapping.rs
+++ b/program/rust/src/tests/test_add_mapping.rs
@@ -1,5 +1,5 @@
 use crate::c_oracle_header::{
-    pc_map_table_t,
+    MappingAccount,
     PC_MAGIC,
     PC_MAP_TABLE_SIZE,
     PC_VERSION,
@@ -35,16 +35,16 @@ fn test_add_mapping() {
     let mut funding_setup = AccountSetup::new_funding();
     let funding_account = funding_setup.to_account_info();
 
-    let mut curr_mapping_setup = AccountSetup::new::<pc_map_table_t>(&program_id);
+    let mut curr_mapping_setup = AccountSetup::new::<MappingAccount>(&program_id);
     let cur_mapping = curr_mapping_setup.to_account_info();
-    initialize_pyth_account_checked::<pc_map_table_t>(&cur_mapping, PC_VERSION).unwrap();
+    initialize_pyth_account_checked::<MappingAccount>(&cur_mapping, PC_VERSION).unwrap();
 
-    let mut next_mapping_setup = AccountSetup::new::<pc_map_table_t>(&program_id);
+    let mut next_mapping_setup = AccountSetup::new::<MappingAccount>(&program_id);
     let next_mapping = next_mapping_setup.to_account_info();
 
     {
         let mut cur_mapping_data =
-            load_checked::<pc_map_table_t>(&cur_mapping, PC_VERSION).unwrap();
+            load_checked::<MappingAccount>(&cur_mapping, PC_VERSION).unwrap();
         cur_mapping_data.num_ = PC_MAP_TABLE_SIZE;
     }
 
@@ -60,9 +60,9 @@ fn test_add_mapping() {
     .is_ok());
 
     {
-        let next_mapping_data = load_checked::<pc_map_table_t>(&next_mapping, PC_VERSION).unwrap();
+        let next_mapping_data = load_checked::<MappingAccount>(&next_mapping, PC_VERSION).unwrap();
         let mut cur_mapping_data =
-            load_checked::<pc_map_table_t>(&cur_mapping, PC_VERSION).unwrap();
+            load_checked::<MappingAccount>(&cur_mapping, PC_VERSION).unwrap();
 
         assert!(pubkey_equal(
             &cur_mapping_data.next_,
@@ -90,7 +90,7 @@ fn test_add_mapping() {
 
     {
         let mut cur_mapping_data =
-            load_checked::<pc_map_table_t>(&cur_mapping, PC_VERSION).unwrap();
+            load_checked::<MappingAccount>(&cur_mapping, PC_VERSION).unwrap();
         assert!(pubkey_is_zero(&cur_mapping_data.next_));
         cur_mapping_data.num_ = PC_MAP_TABLE_SIZE;
         cur_mapping_data.magic_ = 0;
@@ -110,7 +110,7 @@ fn test_add_mapping() {
     );
 
     {
-        let mut cur_mapping_data = load_account_as_mut::<pc_map_table_t>(&cur_mapping).unwrap();
+        let mut cur_mapping_data = load_account_as_mut::<MappingAccount>(&cur_mapping).unwrap();
         cur_mapping_data.magic_ = PC_MAGIC;
     }
 

--- a/program/rust/src/tests/test_add_price.rs
+++ b/program/rust/src/tests/test_add_price.rs
@@ -1,7 +1,7 @@
 use crate::c_oracle_header::{
-    pc_map_table_t,
-    pc_price_t,
-    pc_prod_t,
+    MappingAccount,
+    PriceAccount,
+    ProductAccount,
     PC_VERSION,
 };
 use crate::deserialize::{
@@ -42,17 +42,17 @@ fn test_add_price() {
     let mut funding_setup = AccountSetup::new_funding();
     let funding_account = funding_setup.to_account_info();
 
-    let mut mapping_setup = AccountSetup::new::<pc_map_table_t>(&program_id);
+    let mut mapping_setup = AccountSetup::new::<MappingAccount>(&program_id);
     let mapping_account = mapping_setup.to_account_info();
-    initialize_pyth_account_checked::<pc_map_table_t>(&mapping_account, PC_VERSION).unwrap();
+    initialize_pyth_account_checked::<MappingAccount>(&mapping_account, PC_VERSION).unwrap();
 
-    let mut product_setup = AccountSetup::new::<pc_prod_t>(&program_id);
+    let mut product_setup = AccountSetup::new::<ProductAccount>(&program_id);
     let product_account = product_setup.to_account_info();
 
-    let mut price_setup = AccountSetup::new::<pc_price_t>(&program_id);
+    let mut price_setup = AccountSetup::new::<PriceAccount>(&program_id);
     let mut price_account = price_setup.to_account_info();
 
-    let mut price_setup_2 = AccountSetup::new::<pc_price_t>(&program_id);
+    let mut price_setup_2 = AccountSetup::new::<PriceAccount>(&program_id);
     let price_account_2 = price_setup_2.to_account_info();
 
     assert!(process_instruction(
@@ -78,8 +78,8 @@ fn test_add_price() {
     .is_ok());
 
     {
-        let price_data = load_checked::<pc_price_t>(&price_account, PC_VERSION).unwrap();
-        let product_data = load_checked::<pc_prod_t>(&product_account, PC_VERSION).unwrap();
+        let price_data = load_checked::<PriceAccount>(&price_account, PC_VERSION).unwrap();
+        let product_data = load_checked::<ProductAccount>(&product_account, PC_VERSION).unwrap();
         assert_eq!(price_data.expo_, 1);
         assert_eq!(price_data.ptype_, 1);
         assert!(pubkey_equal(
@@ -105,8 +105,8 @@ fn test_add_price() {
     .is_ok());
 
     {
-        let price_data_2 = load_checked::<pc_price_t>(&price_account_2, PC_VERSION).unwrap();
-        let product_data = load_checked::<pc_prod_t>(&product_account, PC_VERSION).unwrap();
+        let price_data_2 = load_checked::<PriceAccount>(&price_account_2, PC_VERSION).unwrap();
+        let product_data = load_checked::<ProductAccount>(&product_account, PC_VERSION).unwrap();
         assert_eq!(price_data_2.expo_, 1);
         assert_eq!(price_data_2.ptype_, 1);
         assert!(pubkey_equal(

--- a/program/rust/src/tests/test_add_product.rs
+++ b/program/rust/src/tests/test_add_product.rs
@@ -1,8 +1,8 @@
 use std::mem::size_of;
 
 use crate::c_oracle_header::{
-    pc_map_table_t,
-    pc_prod_t,
+    MappingAccount,
+    ProductAccount,
     PythAccount,
     PC_ACCTYPE_PRODUCT,
     PC_MAGIC,
@@ -44,14 +44,14 @@ fn test_add_product() {
     let mut funding_setup = AccountSetup::new_funding();
     let funding_account = funding_setup.to_account_info();
 
-    let mut mapping_setup = AccountSetup::new::<pc_map_table_t>(&program_id);
+    let mut mapping_setup = AccountSetup::new::<MappingAccount>(&program_id);
     let mapping_account = mapping_setup.to_account_info();
-    initialize_pyth_account_checked::<pc_map_table_t>(&mapping_account, PC_VERSION).unwrap();
+    initialize_pyth_account_checked::<MappingAccount>(&mapping_account, PC_VERSION).unwrap();
 
-    let mut product_setup = AccountSetup::new::<pc_prod_t>(&program_id);
+    let mut product_setup = AccountSetup::new::<ProductAccount>(&program_id);
     let product_account = product_setup.to_account_info();
 
-    let mut product_setup_2 = AccountSetup::new::<pc_prod_t>(&program_id);
+    let mut product_setup_2 = AccountSetup::new::<ProductAccount>(&program_id);
     let product_account_2 = product_setup_2.to_account_info();
 
     assert!(process_instruction(
@@ -66,15 +66,15 @@ fn test_add_product() {
     .is_ok());
 
     {
-        let product_data = load_account_as::<pc_prod_t>(&product_account).unwrap();
-        let mapping_data = load_checked::<pc_map_table_t>(&mapping_account, PC_VERSION).unwrap();
+        let product_data = load_account_as::<ProductAccount>(&product_account).unwrap();
+        let mapping_data = load_checked::<MappingAccount>(&mapping_account, PC_VERSION).unwrap();
 
         assert_eq!(product_data.magic_, PC_MAGIC);
         assert_eq!(product_data.ver_, PC_VERSION);
         assert_eq!(product_data.type_, PC_ACCTYPE_PRODUCT);
-        assert_eq!(product_data.size_, size_of::<pc_prod_t>() as u32);
+        assert_eq!(product_data.size_, size_of::<ProductAccount>() as u32);
         assert_eq!(mapping_data.num_, 1);
-        assert_eq!(mapping_data.size_, (pc_map_table_t::INITIAL_SIZE + 32));
+        assert_eq!(mapping_data.size_, (MappingAccount::INITIAL_SIZE + 32));
         assert!(pubkey_equal(
             &mapping_data.prod_[0],
             &product_account.key.to_bytes()
@@ -92,9 +92,9 @@ fn test_add_product() {
     )
     .is_ok());
     {
-        let mapping_data = load_checked::<pc_map_table_t>(&mapping_account, PC_VERSION).unwrap();
+        let mapping_data = load_checked::<MappingAccount>(&mapping_account, PC_VERSION).unwrap();
         assert_eq!(mapping_data.num_, 2);
-        assert_eq!(mapping_data.size_, (pc_map_table_t::INITIAL_SIZE + 2 * 32));
+        assert_eq!(mapping_data.size_, (MappingAccount::INITIAL_SIZE + 2 * 32));
         assert!(pubkey_equal(
             &mapping_data.prod_[1],
             &product_account_2.key.to_bytes()
@@ -130,7 +130,7 @@ fn test_add_product() {
 
     // test fill up of mapping table
     clear_account(&mapping_account).unwrap();
-    initialize_pyth_account_checked::<pc_map_table_t>(&mapping_account, PC_VERSION).unwrap();
+    initialize_pyth_account_checked::<MappingAccount>(&mapping_account, PC_VERSION).unwrap();
 
     for i in 0..PC_MAP_TABLE_SIZE {
         clear_account(&product_account).unwrap();
@@ -145,10 +145,10 @@ fn test_add_product() {
             instruction_data
         )
         .is_ok());
-        let mapping_data = load_checked::<pc_map_table_t>(&mapping_account, PC_VERSION).unwrap();
+        let mapping_data = load_checked::<MappingAccount>(&mapping_account, PC_VERSION).unwrap();
         assert_eq!(
             mapping_data.size_,
-            pc_map_table_t::INITIAL_SIZE + (i + 1) * 32
+            MappingAccount::INITIAL_SIZE + (i + 1) * 32
         );
         assert_eq!(mapping_data.num_, i + 1);
     }
@@ -168,6 +168,6 @@ fn test_add_product() {
         Err(ProgramError::InvalidArgument)
     );
 
-    let mapping_data = load_checked::<pc_map_table_t>(&mapping_account, PC_VERSION).unwrap();
+    let mapping_data = load_checked::<MappingAccount>(&mapping_account, PC_VERSION).unwrap();
     assert_eq!(mapping_data.num_, PC_MAP_TABLE_SIZE);
 }

--- a/program/rust/src/tests/test_add_publisher.rs
+++ b/program/rust/src/tests/test_add_publisher.rs
@@ -1,7 +1,7 @@
 use crate::c_oracle_header::{
-    pc_price_comp_t,
-    pc_price_t,
-    pc_pub_key_t,
+    CPubkey,
+    PriceAccount,
+    PriceComponent,
     PythAccount,
     PC_COMP_SIZE,
     PC_VERSION,
@@ -30,7 +30,7 @@ use std::mem::size_of;
 #[test]
 fn test_add_publisher() {
     let program_id = Pubkey::new_unique();
-    let publisher = pc_pub_key_t::new_unique();
+    let publisher = CPubkey::new_unique();
 
     let mut cmd = AddPublisherArgs {
         header: OracleCommand::AddPublisher.into(),
@@ -41,9 +41,9 @@ fn test_add_publisher() {
     let mut funding_setup = AccountSetup::new_funding();
     let funding_account = funding_setup.to_account_info();
 
-    let mut price_setup = AccountSetup::new::<pc_price_t>(&program_id);
+    let mut price_setup = AccountSetup::new::<PriceAccount>(&program_id);
     let price_account = price_setup.to_account_info();
-    initialize_pyth_account_checked::<pc_price_t>(&price_account, PC_VERSION).unwrap();
+    initialize_pyth_account_checked::<PriceAccount>(&price_account, PC_VERSION).unwrap();
 
 
     **price_account.try_borrow_mut_lamports().unwrap() = 100;
@@ -60,7 +60,7 @@ fn test_add_publisher() {
 
     // Now give the price account enough lamports to be rent exempt
     **price_account.try_borrow_mut_lamports().unwrap() =
-        Rent::minimum_balance(&Rent::default(), pc_price_t::minimum_size());
+        Rent::minimum_balance(&Rent::default(), PriceAccount::minimum_size());
 
 
     assert!(process_instruction(
@@ -71,11 +71,11 @@ fn test_add_publisher() {
     .is_ok());
 
     {
-        let price_data = load_checked::<pc_price_t>(&price_account, PC_VERSION).unwrap();
+        let price_data = load_checked::<PriceAccount>(&price_account, PC_VERSION).unwrap();
         assert_eq!(price_data.num_, 1);
         assert_eq!(
             price_data.size_,
-            pc_price_t::INITIAL_SIZE + (size_of::<pc_price_comp_t>() as u32)
+            PriceAccount::INITIAL_SIZE + (size_of::<PriceComponent>() as u32)
         );
         assert!(pubkey_equal(
             &price_data.comp_[0].pub_,
@@ -105,11 +105,11 @@ fn test_add_publisher() {
         Err(ProgramError::InvalidArgument)
     );
 
-    initialize_pyth_account_checked::<pc_price_t>(&price_account, PC_VERSION).unwrap();
+    initialize_pyth_account_checked::<PriceAccount>(&price_account, PC_VERSION).unwrap();
 
     //Fill up price node
     for i in 0..PC_COMP_SIZE {
-        cmd.publisher = pc_pub_key_t::new_unique();
+        cmd.publisher = CPubkey::new_unique();
         instruction_data = bytes_of::<AddPublisherArgs>(&cmd);
         assert!(process_instruction(
             &program_id,
@@ -120,7 +120,7 @@ fn test_add_publisher() {
 
 
         {
-            let price_data = load_checked::<pc_price_t>(&price_account, PC_VERSION).unwrap();
+            let price_data = load_checked::<PriceAccount>(&price_account, PC_VERSION).unwrap();
             assert_eq!(price_data.num_, i + 1);
             assert!(pubkey_equal(
                 &price_data.comp_[i as usize].pub_,
@@ -128,12 +128,12 @@ fn test_add_publisher() {
             ));
             assert_eq!(
                 price_data.size_,
-                pc_price_t::INITIAL_SIZE + (size_of::<pc_price_comp_t>() as u32) * (i + 1)
+                PriceAccount::INITIAL_SIZE + (size_of::<PriceComponent>() as u32) * (i + 1)
             );
         }
     }
 
-    cmd.publisher = pc_pub_key_t::new_unique();
+    cmd.publisher = CPubkey::new_unique();
     instruction_data = bytes_of::<AddPublisherArgs>(&cmd);
     assert_eq!(
         process_instruction(

--- a/program/rust/src/tests/test_del_price.rs
+++ b/program/rust/src/tests/test_del_price.rs
@@ -1,6 +1,6 @@
 use solana_sdk::signer::Signer;
 
-use crate::c_oracle_header::pc_prod_t;
+use crate::c_oracle_header::ProductAccount;
 use crate::tests::pyth_simulator::PythSimulator;
 use crate::utils::pubkey_is_zero;
 
@@ -28,7 +28,7 @@ async fn test_del_price() {
     assert!(sim.get_account(price1.pubkey()).await.is_none());
 
     let product1_data = sim
-        .get_account_data_as::<pc_prod_t>(product1.pubkey())
+        .get_account_data_as::<ProductAccount>(product1.pubkey())
         .await
         .unwrap();
     assert!(pubkey_is_zero(&product1_data.px_acc_));
@@ -44,7 +44,7 @@ async fn test_del_price() {
     assert!(sim.get_account(price2_1.pubkey()).await.is_none());
 
     let product2_data = sim
-        .get_account_data_as::<pc_prod_t>(product2.pubkey())
+        .get_account_data_as::<ProductAccount>(product2.pubkey())
         .await
         .unwrap();
 

--- a/program/rust/src/tests/test_del_product.rs
+++ b/program/rust/src/tests/test_del_product.rs
@@ -7,8 +7,8 @@ use solana_program::pubkey::Pubkey;
 use solana_sdk::signer::Signer;
 
 use crate::c_oracle_header::{
-    pc_map_table_t,
-    pc_pub_key_t,
+    CPubkey,
+    MappingAccount,
 };
 use crate::tests::pyth_simulator::PythSimulator;
 use crate::utils::pubkey_equal;
@@ -43,7 +43,7 @@ async fn test_del_product() {
     assert!(sim.get_account(product2.pubkey()).await.is_none());
 
     let mapping_data = sim
-        .get_account_data_as::<pc_map_table_t>(mapping_keypair.pubkey())
+        .get_account_data_as::<MappingAccount>(mapping_keypair.pubkey())
         .await
         .unwrap();
     assert!(mapping_product_list_equals(
@@ -60,7 +60,7 @@ async fn test_del_product() {
 
     assert!(sim.del_product(&mapping_keypair, &product4).await.is_ok());
     let mapping_data = sim
-        .get_account_data_as::<pc_map_table_t>(mapping_keypair.pubkey())
+        .get_account_data_as::<MappingAccount>(mapping_keypair.pubkey())
         .await
         .unwrap();
 
@@ -72,13 +72,13 @@ async fn test_del_product() {
 
 /// Returns true if the list of products in `mapping_data` contains the keys in `expected` (in the
 /// same order). Also checks `mapping_data.num_` and `size_`.
-fn mapping_product_list_equals(mapping_data: &pc_map_table_t, expected: Vec<Pubkey>) -> bool {
+fn mapping_product_list_equals(mapping_data: &MappingAccount, expected: Vec<Pubkey>) -> bool {
     if mapping_data.num_ != expected.len() as u32 {
         return false;
     }
 
-    let expected_size = (size_of::<pc_map_table_t>() - size_of_val(&mapping_data.prod_)
-        + expected.len() * size_of::<pc_pub_key_t>()) as u32;
+    let expected_size = (size_of::<MappingAccount>() - size_of_val(&mapping_data.prod_)
+        + expected.len() * size_of::<CPubkey>()) as u32;
     if mapping_data.size_ != expected_size {
         return false;
     }

--- a/program/rust/src/tests/test_del_publisher.rs
+++ b/program/rust/src/tests/test_del_publisher.rs
@@ -1,8 +1,8 @@
 use crate::c_oracle_header::{
-    pc_price_comp_t,
-    pc_price_info_t,
-    pc_price_t,
-    pc_pub_key_t,
+    CPubkey,
+    PriceAccount,
+    PriceComponent,
+    PriceInfo,
     PythAccount,
     PC_STATUS_TRADING,
     PC_VERSION,
@@ -29,7 +29,7 @@ use std::mem::size_of;
 
 #[test]
 fn test_del_publisher() {
-    let p1: pc_price_info_t = pc_price_info_t {
+    let p1: PriceInfo = PriceInfo {
         price_:           100,
         conf_:            10,
         status_:          PC_STATUS_TRADING,
@@ -37,7 +37,7 @@ fn test_del_publisher() {
         corp_act_status_: 0,
     };
 
-    let p2: pc_price_info_t = pc_price_info_t {
+    let p2: PriceInfo = PriceInfo {
         price_:           200,
         conf_:            20,
         status_:          PC_STATUS_TRADING,
@@ -46,8 +46,8 @@ fn test_del_publisher() {
     };
 
     let program_id = Pubkey::new_unique();
-    let publisher = pc_pub_key_t::new_unique();
-    let publisher2 = pc_pub_key_t::new_unique();
+    let publisher = CPubkey::new_unique();
+    let publisher2 = CPubkey::new_unique();
 
     let mut instruction_data = [0u8; size_of::<DelPublisherArgs>()];
     let mut hdr = load_mut::<DelPublisherArgs>(&mut instruction_data).unwrap();
@@ -57,11 +57,11 @@ fn test_del_publisher() {
     let mut funding_setup = AccountSetup::new_funding();
     let funding_account = funding_setup.to_account_info();
 
-    let mut price_setup = AccountSetup::new::<pc_price_t>(&program_id);
+    let mut price_setup = AccountSetup::new::<PriceAccount>(&program_id);
     let price_account = price_setup.to_account_info();
-    initialize_pyth_account_checked::<pc_price_t>(&price_account, PC_VERSION).unwrap();
+    initialize_pyth_account_checked::<PriceAccount>(&price_account, PC_VERSION).unwrap();
     {
-        let mut price_data = load_checked::<pc_price_t>(&price_account, PC_VERSION).unwrap();
+        let mut price_data = load_checked::<PriceAccount>(&price_account, PC_VERSION).unwrap();
         price_data.num_ = 1;
         price_data.comp_[0].latest_ = p1;
         pubkey_assign(&mut price_data.comp_[0].pub_, bytes_of(&publisher));
@@ -75,14 +75,14 @@ fn test_del_publisher() {
     .is_ok());
 
     {
-        let mut price_data = load_checked::<pc_price_t>(&price_account, PC_VERSION).unwrap();
+        let mut price_data = load_checked::<PriceAccount>(&price_account, PC_VERSION).unwrap();
         assert_eq!(price_data.num_, 0);
         assert_eq!(price_data.comp_[0].latest_.price_, 0);
         assert_eq!(price_data.comp_[0].latest_.conf_, 0);
         assert_eq!(price_data.comp_[0].latest_.status_, 0);
         assert_eq!(price_data.comp_[0].latest_.pub_slot_, 0);
         assert_eq!(price_data.comp_[0].latest_.corp_act_status_, 0);
-        assert_eq!(price_data.size_, pc_price_t::INITIAL_SIZE);
+        assert_eq!(price_data.size_, PriceAccount::INITIAL_SIZE);
         assert!(pubkey_is_zero(&price_data.comp_[0].pub_));
 
         price_data.num_ = 2;
@@ -101,7 +101,7 @@ fn test_del_publisher() {
     .is_ok());
 
     {
-        let mut price_data = load_checked::<pc_price_t>(&price_account, PC_VERSION).unwrap();
+        let mut price_data = load_checked::<PriceAccount>(&price_account, PC_VERSION).unwrap();
         assert_eq!(price_data.num_, 1);
         assert_eq!(price_data.comp_[0].latest_.price_, p2.price_);
         assert_eq!(price_data.comp_[0].latest_.conf_, p2.conf_);
@@ -118,7 +118,7 @@ fn test_del_publisher() {
         assert_eq!(price_data.comp_[1].latest_.corp_act_status_, 0);
         assert_eq!(
             price_data.size_,
-            pc_price_t::INITIAL_SIZE + (size_of::<pc_price_comp_t>() as u32)
+            PriceAccount::INITIAL_SIZE + (size_of::<PriceComponent>() as u32)
         );
         assert!(pubkey_equal(
             &price_data.comp_[0].pub_,
@@ -142,7 +142,7 @@ fn test_del_publisher() {
     .is_ok());
 
     {
-        let price_data = load_checked::<pc_price_t>(&price_account, PC_VERSION).unwrap();
+        let price_data = load_checked::<PriceAccount>(&price_account, PC_VERSION).unwrap();
         assert_eq!(price_data.num_, 1);
         assert_eq!(price_data.comp_[0].latest_.price_, p2.price_);
         assert_eq!(price_data.comp_[0].latest_.conf_, p2.conf_);
@@ -159,7 +159,7 @@ fn test_del_publisher() {
         assert_eq!(price_data.comp_[1].latest_.corp_act_status_, 0);
         assert_eq!(
             price_data.size_,
-            pc_price_t::INITIAL_SIZE + (size_of::<pc_price_comp_t>() as u32)
+            PriceAccount::INITIAL_SIZE + (size_of::<PriceComponent>() as u32)
         );
         assert!(pubkey_equal(
             &price_data.comp_[0].pub_,

--- a/program/rust/src/tests/test_init_mapping.rs
+++ b/program/rust/src/tests/test_init_mapping.rs
@@ -1,5 +1,5 @@
 use crate::c_oracle_header::{
-    pc_map_table_t,
+    MappingAccount,
     PC_ACCTYPE_MAPPING,
     PC_MAGIC,
     PC_VERSION,
@@ -30,7 +30,7 @@ fn test_init_mapping() {
     let mut funding_setup = AccountSetup::new_funding();
     let mut funding_account = funding_setup.to_account_info();
 
-    let mut mapping_setup = AccountSetup::new::<pc_map_table_t>(&program_id);
+    let mut mapping_setup = AccountSetup::new::<MappingAccount>(&program_id);
     let mut mapping_account = mapping_setup.to_account_info();
 
     assert!(process_instruction(
@@ -41,7 +41,7 @@ fn test_init_mapping() {
     .is_ok());
 
     {
-        let mapping_data = load_account_as::<pc_map_table_t>(&mapping_account).unwrap();
+        let mapping_data = load_account_as::<MappingAccount>(&mapping_account).unwrap();
 
         assert_eq!(mapping_data.ver_, PC_VERSION);
         assert_eq!(mapping_data.magic_, PC_MAGIC);

--- a/program/rust/src/tests/test_init_price.rs
+++ b/program/rust/src/tests/test_init_price.rs
@@ -3,8 +3,8 @@ use solana_program::program_error::ProgramError;
 use solana_program::pubkey::Pubkey;
 
 use crate::c_oracle_header::{
-    pc_price_t,
-    pc_pub_key_t,
+    CPubkey,
+    PriceAccount,
     PC_MAX_NUM_DECIMALS,
     PC_VERSION,
 };
@@ -37,15 +37,15 @@ fn test_init_price() {
     let instruction_data = bytes_of::<InitPriceArgs>(&cmd);
 
     let program_id = Pubkey::new_unique();
-    let publisher = pc_pub_key_t::new_unique();
-    let publisher2 = pc_pub_key_t::new_unique();
-    let product = pc_pub_key_t::new_unique();
-    let next_price = pc_pub_key_t::new_unique();
+    let publisher = CPubkey::new_unique();
+    let publisher2 = CPubkey::new_unique();
+    let product = CPubkey::new_unique();
+    let next_price = CPubkey::new_unique();
 
     let mut funding_setup = AccountSetup::new_funding();
     let funding_account = funding_setup.to_account_info();
 
-    let mut price_setup = AccountSetup::new::<pc_price_t>(&program_id);
+    let mut price_setup = AccountSetup::new::<PriceAccount>(&program_id);
     let mut price_account = price_setup.to_account_info();
 
     // Price account must be initialized
@@ -58,9 +58,9 @@ fn test_init_price() {
         Err(ProgramError::InvalidArgument)
     );
 
-    initialize_pyth_account_checked::<pc_price_t>(&price_account, PC_VERSION).unwrap();
+    initialize_pyth_account_checked::<PriceAccount>(&price_account, PC_VERSION).unwrap();
     {
-        let mut price_data = load_checked::<pc_price_t>(&price_account, PC_VERSION).unwrap();
+        let mut price_data = load_checked::<PriceAccount>(&price_account, PC_VERSION).unwrap();
         price_data.ptype_ = ptype;
         price_data.expo_ = 0;
         price_data.min_pub_ = 7;
@@ -101,7 +101,7 @@ fn test_init_price() {
     .is_ok());
 
     {
-        let price_data = load_checked::<pc_price_t>(&price_account, PC_VERSION).unwrap();
+        let price_data = load_checked::<PriceAccount>(&price_account, PC_VERSION).unwrap();
 
         assert_eq!(price_data.expo_, -2);
         assert_eq!(price_data.ptype_, ptype);

--- a/program/rust/src/tests/test_set_min_pub.rs
+++ b/program/rust/src/tests/test_set_min_pub.rs
@@ -5,7 +5,7 @@ use solana_program::program_error::ProgramError;
 use solana_program::pubkey::Pubkey;
 
 use crate::c_oracle_header::{
-    pc_price_t,
+    PriceAccount,
     PC_VERSION,
 };
 use crate::deserialize::{
@@ -29,9 +29,9 @@ fn test_set_min_pub() {
     let mut funding_setup = AccountSetup::new_funding();
     let funding_account = funding_setup.to_account_info();
 
-    let mut price_setup = AccountSetup::new::<pc_price_t>(&program_id);
+    let mut price_setup = AccountSetup::new::<PriceAccount>(&program_id);
     let price_account = price_setup.to_account_info();
-    initialize_pyth_account_checked::<pc_price_t>(&price_account, PC_VERSION).unwrap();
+    initialize_pyth_account_checked::<PriceAccount>(&price_account, PC_VERSION).unwrap();
 
     assert_eq!(get_min_pub(&price_account), Ok(0));
 
@@ -62,5 +62,5 @@ fn populate_instruction(instruction_data: &mut [u8], min_pub: u8) -> () {
 }
 
 fn get_min_pub(account: &AccountInfo) -> Result<u8, ProgramError> {
-    Ok(load_checked::<pc_price_t>(account, PC_VERSION)?.min_pub_)
+    Ok(load_checked::<PriceAccount>(account, PC_VERSION)?.min_pub_)
 }

--- a/program/rust/src/tests/test_sizes.rs
+++ b/program/rust/src/tests/test_sizes.rs
@@ -1,11 +1,21 @@
 use crate::c_oracle_header::{
-    pc_map_table_t,
-    pc_price_comp_t,
-    pc_price_info_t,
-    pc_price_t,
-    pc_pub_key_t,
+    AccountHeader,
+    CPubkey,
+    MappingAccount,
+    PriceAccount,
+    PriceComponent,
+    PriceEma,
+    PriceInfo,
+    ProductAccount,
+    PythAccount,
     PC_COMP_SIZE,
     PC_MAP_TABLE_SIZE,
+    PC_VERSION,
+    PRICE_ACCOUNT_SIZE,
+};
+use crate::deserialize::{
+    initialize_pyth_account_checked,
+    load_checked,
 };
 use crate::instruction::{
     AddPriceArgs,
@@ -16,26 +26,33 @@ use crate::instruction::{
     SetMinPubArgs,
     UpdPriceArgs,
 };
-use std::mem::size_of;
+use crate::tests::test_utils::AccountSetup;
+use crate::time_machine_types::PriceAccountWrapper;
+use crate::utils::try_convert;
+use solana_program::pubkey::Pubkey;
+use std::mem::{
+    size_of,
+    size_of_val,
+};
 
 #[test]
 fn test_sizes() {
-    assert_eq!(size_of::<pc_pub_key_t>(), 32);
+    assert_eq!(size_of::<CPubkey>(), 32);
     assert_eq!(
-        size_of::<pc_map_table_t>(),
-        24 + (PC_MAP_TABLE_SIZE as usize + 1) * size_of::<pc_pub_key_t>()
+        size_of::<MappingAccount>(),
+        24 + (PC_MAP_TABLE_SIZE as usize + 1) * size_of::<CPubkey>()
     );
-    assert_eq!(size_of::<pc_price_info_t>(), 32);
+    assert_eq!(size_of::<PriceInfo>(), 32);
     assert_eq!(
-        size_of::<pc_price_comp_t>(),
-        size_of::<pc_pub_key_t>() + 2 * size_of::<pc_price_info_t>()
+        size_of::<PriceComponent>(),
+        size_of::<CPubkey>() + 2 * size_of::<PriceInfo>()
     );
     assert_eq!(
-        size_of::<pc_price_t>(),
+        size_of::<PriceAccount>(),
         48 + 8 * size_of::<u64>()
-            + 3 * size_of::<pc_pub_key_t>()
-            + size_of::<pc_price_info_t>()
-            + (PC_COMP_SIZE as usize) * size_of::<pc_price_comp_t>()
+            + 3 * size_of::<CPubkey>()
+            + size_of::<PriceInfo>()
+            + (PC_COMP_SIZE as usize) * size_of::<PriceComponent>()
     );
     assert_eq!(size_of::<CommandHeader>(), 8);
     assert_eq!(size_of::<AddPriceArgs>(), 16);
@@ -44,4 +61,42 @@ fn test_sizes() {
     assert_eq!(size_of::<AddPublisherArgs>(), 40);
     assert_eq!(size_of::<DelPublisherArgs>(), 40);
     assert_eq!(size_of::<UpdPriceArgs>(), 40);
+    assert_eq!(size_of::<CPubkey>(), 32);
+    assert_eq!(size_of::<AccountHeader>(), 16);
+    assert_eq!(size_of::<MappingAccount>(), 20536);
+    assert_eq!(size_of::<ProductAccount>(), 48);
+    assert_eq!(size_of::<PriceComponent>(), 96);
+    assert_eq!(size_of::<PriceEma>(), 24);
+    assert_eq!(size_of::<PriceAccount>(), 3312);
+    assert_eq!(
+        size_of::<PriceAccountWrapper>(),
+        try_convert::<_, usize>(PRICE_ACCOUNT_SIZE).unwrap()
+    );
+}
+
+#[test]
+fn test_offsets() {
+    let program_id = Pubkey::new_unique();
+
+    let mut price_setup = AccountSetup::new::<PriceAccount>(&program_id);
+    let price_account = price_setup.to_account_info();
+
+    initialize_pyth_account_checked::<PriceAccount>(&price_account, PC_VERSION).unwrap();
+    let price_data = load_checked::<PriceAccount>(&price_account, PC_VERSION).unwrap();
+
+    assert_eq!(
+        size_of::<PriceAccount>() - size_of_val(&price_data.comp_),
+        try_convert::<_, usize>(PriceAccount::INITIAL_SIZE).unwrap()
+    );
+
+    let mut mapping_setup = AccountSetup::new::<MappingAccount>(&program_id);
+    let mapping_account = mapping_setup.to_account_info();
+
+    initialize_pyth_account_checked::<MappingAccount>(&mapping_account, PC_VERSION).unwrap();
+    let mapping_data = load_checked::<MappingAccount>(&mapping_account, PC_VERSION).unwrap();
+
+    assert_eq!(
+        size_of::<MappingAccount>() - size_of_val(&mapping_data.prod_),
+        try_convert::<_, usize>(MappingAccount::INITIAL_SIZE).unwrap()
+    );
 }

--- a/program/rust/src/tests/test_upd_aggregate.rs
+++ b/program/rust/src/tests/test_upd_aggregate.rs
@@ -2,8 +2,8 @@ use solana_program::pubkey::Pubkey;
 use std::mem::size_of;
 
 use crate::c_oracle_header::{
-    pc_price_info_t,
-    pc_price_t,
+    PriceAccount,
+    PriceInfo,
     PC_STATUS_TRADING,
     PC_STATUS_UNKNOWN,
     PC_VERSION,
@@ -22,7 +22,7 @@ use crate::rust_oracle::c_upd_aggregate;
 use crate::tests::test_utils::AccountSetup;
 #[test]
 fn test_upd_aggregate() {
-    let p1: pc_price_info_t = pc_price_info_t {
+    let p1: PriceInfo = PriceInfo {
         price_:           100,
         conf_:            10,
         status_:          PC_STATUS_TRADING,
@@ -30,7 +30,7 @@ fn test_upd_aggregate() {
         corp_act_status_: 0,
     };
 
-    let p2: pc_price_info_t = pc_price_info_t {
+    let p2: PriceInfo = PriceInfo {
         price_:           200,
         conf_:            20,
         status_:          PC_STATUS_TRADING,
@@ -38,7 +38,7 @@ fn test_upd_aggregate() {
         corp_act_status_: 0,
     };
 
-    let p3: pc_price_info_t = pc_price_info_t {
+    let p3: PriceInfo = PriceInfo {
         price_:           300,
         conf_:            30,
         status_:          PC_STATUS_TRADING,
@@ -46,7 +46,7 @@ fn test_upd_aggregate() {
         corp_act_status_: 0,
     };
 
-    let p4: pc_price_info_t = pc_price_info_t {
+    let p4: PriceInfo = PriceInfo {
         price_:           400,
         conf_:            40,
         status_:          PC_STATUS_TRADING,
@@ -59,14 +59,14 @@ fn test_upd_aggregate() {
 
     let program_id = Pubkey::new_unique();
 
-    let mut price_setup = AccountSetup::new::<pc_price_t>(&program_id);
+    let mut price_setup = AccountSetup::new::<PriceAccount>(&program_id);
     let mut price_account = price_setup.to_account_info();
     price_account.is_signer = false;
-    initialize_pyth_account_checked::<pc_price_t>(&price_account, PC_VERSION).unwrap();
+    initialize_pyth_account_checked::<PriceAccount>(&price_account, PC_VERSION).unwrap();
 
     // single publisher
     {
-        let mut price_data = load_checked::<pc_price_t>(&price_account, PC_VERSION).unwrap();
+        let mut price_data = load_checked::<PriceAccount>(&price_account, PC_VERSION).unwrap();
         price_data.num_ = 1;
         price_data.last_slot_ = 1000;
         price_data.agg_.pub_slot_ = 1000;
@@ -81,7 +81,7 @@ fn test_upd_aggregate() {
     }
 
     {
-        let price_data = load_checked::<pc_price_t>(&price_account, PC_VERSION).unwrap();
+        let price_data = load_checked::<PriceAccount>(&price_account, PC_VERSION).unwrap();
 
         assert_eq!(price_data.agg_.price_, 100);
         assert_eq!(price_data.agg_.conf_, 10);
@@ -97,7 +97,7 @@ fn test_upd_aggregate() {
 
     // two publishers
     {
-        let mut price_data = load_checked::<pc_price_t>(&price_account, PC_VERSION).unwrap();
+        let mut price_data = load_checked::<PriceAccount>(&price_account, PC_VERSION).unwrap();
 
         price_data.num_ = 2;
         price_data.last_slot_ = 1000;
@@ -115,7 +115,7 @@ fn test_upd_aggregate() {
     }
 
     {
-        let price_data = load_checked::<pc_price_t>(&price_account, PC_VERSION).unwrap();
+        let price_data = load_checked::<PriceAccount>(&price_account, PC_VERSION).unwrap();
 
         assert_eq!(price_data.agg_.price_, 145);
         assert_eq!(price_data.agg_.conf_, 55);
@@ -132,7 +132,7 @@ fn test_upd_aggregate() {
 
     // three publishers
     {
-        let mut price_data = load_checked::<pc_price_t>(&price_account, PC_VERSION).unwrap();
+        let mut price_data = load_checked::<PriceAccount>(&price_account, PC_VERSION).unwrap();
 
         price_data.num_ = 3;
         price_data.last_slot_ = 1000;
@@ -151,7 +151,7 @@ fn test_upd_aggregate() {
     }
 
     {
-        let price_data = load_checked::<pc_price_t>(&price_account, PC_VERSION).unwrap();
+        let price_data = load_checked::<PriceAccount>(&price_account, PC_VERSION).unwrap();
 
         assert_eq!(price_data.agg_.price_, 200);
         assert_eq!(price_data.agg_.conf_, 90);
@@ -167,7 +167,7 @@ fn test_upd_aggregate() {
 
     // four publishers
     {
-        let mut price_data = load_checked::<pc_price_t>(&price_account, PC_VERSION).unwrap();
+        let mut price_data = load_checked::<PriceAccount>(&price_account, PC_VERSION).unwrap();
 
         price_data.num_ = 4;
         price_data.last_slot_ = 1000;
@@ -187,7 +187,7 @@ fn test_upd_aggregate() {
     }
 
     {
-        let price_data = load_checked::<pc_price_t>(&price_account, PC_VERSION).unwrap();
+        let price_data = load_checked::<PriceAccount>(&price_account, PC_VERSION).unwrap();
 
         assert_eq!(price_data.agg_.price_, 245);
         assert_eq!(price_data.agg_.conf_, 85);
@@ -211,7 +211,7 @@ fn test_upd_aggregate() {
     }
 
     {
-        let price_data = load_checked::<pc_price_t>(&price_account, PC_VERSION).unwrap();
+        let price_data = load_checked::<PriceAccount>(&price_account, PC_VERSION).unwrap();
 
         assert_eq!(price_data.agg_.status_, PC_STATUS_TRADING);
         assert_eq!(price_data.last_slot_, 1025);
@@ -232,7 +232,7 @@ fn test_upd_aggregate() {
         ));
     }
     {
-        let price_data = load_checked::<pc_price_t>(&price_account, PC_VERSION).unwrap();
+        let price_data = load_checked::<PriceAccount>(&price_account, PC_VERSION).unwrap();
 
         assert_eq!(price_data.agg_.status_, PC_STATUS_UNKNOWN);
         assert_eq!(price_data.last_slot_, 1025);
@@ -253,7 +253,7 @@ fn test_upd_aggregate() {
     }
 
     {
-        let price_data = load_checked::<pc_price_t>(&price_account, PC_VERSION).unwrap();
+        let price_data = load_checked::<PriceAccount>(&price_account, PC_VERSION).unwrap();
 
         assert_eq!(price_data.agg_.status_, PC_STATUS_UNKNOWN);
         assert_eq!(price_data.last_slot_, 1025);

--- a/program/rust/src/tests/test_upd_price.rs
+++ b/program/rust/src/tests/test_upd_price.rs
@@ -3,7 +3,7 @@ use solana_program::pubkey::Pubkey;
 use std::mem::size_of;
 
 use crate::c_oracle_header::{
-    pc_price_t,
+    PriceAccount,
     PC_STATUS_TRADING,
     PC_STATUS_UNKNOWN,
     PC_VERSION,
@@ -34,13 +34,13 @@ fn test_upd_price() {
     let mut funding_setup = AccountSetup::new_funding();
     let funding_account = funding_setup.to_account_info();
 
-    let mut price_setup = AccountSetup::new::<pc_price_t>(&program_id);
+    let mut price_setup = AccountSetup::new::<PriceAccount>(&program_id);
     let mut price_account = price_setup.to_account_info();
     price_account.is_signer = false;
-    initialize_pyth_account_checked::<pc_price_t>(&price_account, PC_VERSION).unwrap();
+    initialize_pyth_account_checked::<PriceAccount>(&price_account, PC_VERSION).unwrap();
 
     {
-        let mut price_data = load_checked::<pc_price_t>(&price_account, PC_VERSION).unwrap();
+        let mut price_data = load_checked::<PriceAccount>(&price_account, PC_VERSION).unwrap();
         price_data.num_ = 1;
         pubkey_assign(
             &mut price_data.comp_[0].pub_,
@@ -67,7 +67,7 @@ fn test_upd_price() {
     .is_ok());
 
     {
-        let price_data = load_checked::<pc_price_t>(&price_account, PC_VERSION).unwrap();
+        let price_data = load_checked::<PriceAccount>(&price_account, PC_VERSION).unwrap();
         assert_eq!(price_data.comp_[0].latest_.price_, 42);
         assert_eq!(price_data.comp_[0].latest_.conf_, 2);
         assert_eq!(price_data.comp_[0].latest_.pub_slot_, 1);
@@ -95,7 +95,7 @@ fn test_upd_price() {
     );
 
     {
-        let price_data = load_checked::<pc_price_t>(&price_account, PC_VERSION).unwrap();
+        let price_data = load_checked::<PriceAccount>(&price_account, PC_VERSION).unwrap();
         assert_eq!(price_data.comp_[0].latest_.price_, 42);
         assert_eq!(price_data.comp_[0].latest_.conf_, 2);
         assert_eq!(price_data.comp_[0].latest_.pub_slot_, 1);
@@ -122,7 +122,7 @@ fn test_upd_price() {
     .is_ok());
 
     {
-        let price_data = load_checked::<pc_price_t>(&price_account, PC_VERSION).unwrap();
+        let price_data = load_checked::<PriceAccount>(&price_account, PC_VERSION).unwrap();
         assert_eq!(price_data.comp_[0].latest_.price_, 81);
         assert_eq!(price_data.comp_[0].latest_.conf_, 2);
         assert_eq!(price_data.comp_[0].latest_.pub_slot_, 2);
@@ -148,7 +148,7 @@ fn test_upd_price() {
     .is_ok());
 
     {
-        let price_data = load_checked::<pc_price_t>(&price_account, PC_VERSION).unwrap();
+        let price_data = load_checked::<PriceAccount>(&price_account, PC_VERSION).unwrap();
         assert_eq!(price_data.comp_[0].latest_.price_, 81);
         assert_eq!(price_data.comp_[0].latest_.conf_, 2);
         assert_eq!(price_data.comp_[0].latest_.pub_slot_, 3);
@@ -174,7 +174,7 @@ fn test_upd_price() {
     .is_ok());
 
     {
-        let price_data = load_checked::<pc_price_t>(&price_account, PC_VERSION).unwrap();
+        let price_data = load_checked::<PriceAccount>(&price_account, PC_VERSION).unwrap();
         assert_eq!(price_data.comp_[0].latest_.price_, 81);
         assert_eq!(price_data.comp_[0].latest_.conf_, 2);
         assert_eq!(price_data.comp_[0].latest_.pub_slot_, 4);
@@ -202,7 +202,7 @@ fn test_upd_price() {
     );
 
     {
-        let price_data = load_checked::<pc_price_t>(&price_account, PC_VERSION).unwrap();
+        let price_data = load_checked::<PriceAccount>(&price_account, PC_VERSION).unwrap();
         assert_eq!(price_data.comp_[0].latest_.price_, 81);
         assert_eq!(price_data.comp_[0].latest_.conf_, 2);
         assert_eq!(price_data.comp_[0].latest_.pub_slot_, 4);
@@ -220,7 +220,7 @@ fn test_upd_price() {
 
     // check that someone doesn't accidentally break the test.
     {
-        let price_data = load_checked::<pc_price_t>(&price_account, PC_VERSION).unwrap();
+        let price_data = load_checked::<PriceAccount>(&price_account, PC_VERSION).unwrap();
         assert_eq!(price_data.comp_[0].latest_.status_, PC_STATUS_TRADING);
     }
 
@@ -236,7 +236,7 @@ fn test_upd_price() {
     .is_ok());
 
     {
-        let price_data = load_checked::<pc_price_t>(&price_account, PC_VERSION).unwrap();
+        let price_data = load_checked::<PriceAccount>(&price_account, PC_VERSION).unwrap();
         assert_eq!(price_data.comp_[0].latest_.price_, 50);
         assert_eq!(price_data.comp_[0].latest_.conf_, 6);
         assert_eq!(price_data.comp_[0].latest_.pub_slot_, 5);
@@ -263,7 +263,7 @@ fn test_upd_price() {
     .is_ok());
 
     {
-        let price_data = load_checked::<pc_price_t>(&price_account, PC_VERSION).unwrap();
+        let price_data = load_checked::<PriceAccount>(&price_account, PC_VERSION).unwrap();
         assert_eq!(price_data.comp_[0].latest_.price_, 50);
         assert_eq!(price_data.comp_[0].latest_.conf_, 6);
         assert_eq!(price_data.comp_[0].latest_.pub_slot_, 6);

--- a/program/rust/src/tests/test_upd_price_no_fail_on_error.rs
+++ b/program/rust/src/tests/test_upd_price_no_fail_on_error.rs
@@ -3,7 +3,7 @@ use solana_program::pubkey::Pubkey;
 use std::mem::size_of;
 
 use crate::c_oracle_header::{
-    pc_price_t,
+    PriceAccount,
     PC_STATUS_TRADING,
     PC_STATUS_UNKNOWN,
     PC_VERSION,
@@ -33,10 +33,10 @@ fn test_upd_price_no_fail_on_error_no_fail_on_error() {
     let mut funding_setup = AccountSetup::new_funding();
     let funding_account = funding_setup.to_account_info();
 
-    let mut price_setup = AccountSetup::new::<pc_price_t>(&program_id);
+    let mut price_setup = AccountSetup::new::<PriceAccount>(&program_id);
     let mut price_account = price_setup.to_account_info();
     price_account.is_signer = false;
-    initialize_pyth_account_checked::<pc_price_t>(&price_account, PC_VERSION).unwrap();
+    initialize_pyth_account_checked::<PriceAccount>(&price_account, PC_VERSION).unwrap();
 
     let mut clock_setup = AccountSetup::new_clock();
     let mut clock_account = clock_setup.to_account_info();
@@ -80,7 +80,7 @@ fn test_upd_price_no_fail_on_error_no_fail_on_error() {
 
 
     {
-        let mut price_data = load_checked::<pc_price_t>(&price_account, PC_VERSION).unwrap();
+        let mut price_data = load_checked::<PriceAccount>(&price_account, PC_VERSION).unwrap();
         assert_eq!(price_data.comp_[0].latest_.price_, 0);
         assert_eq!(price_data.comp_[0].latest_.conf_, 0);
         assert_eq!(price_data.comp_[0].latest_.pub_slot_, 0);
@@ -111,7 +111,7 @@ fn test_upd_price_no_fail_on_error_no_fail_on_error() {
     .is_ok());
 
     {
-        let price_data = load_checked::<pc_price_t>(&price_account, PC_VERSION).unwrap();
+        let price_data = load_checked::<PriceAccount>(&price_account, PC_VERSION).unwrap();
         assert_eq!(price_data.comp_[0].latest_.price_, 42);
         assert_eq!(price_data.comp_[0].latest_.conf_, 9);
         assert_eq!(price_data.comp_[0].latest_.pub_slot_, 1);
@@ -153,7 +153,7 @@ fn test_upd_price_no_fail_on_error_no_fail_on_error() {
     .is_ok());
 
     {
-        let price_data = load_checked::<pc_price_t>(&price_account, PC_VERSION).unwrap();
+        let price_data = load_checked::<PriceAccount>(&price_account, PC_VERSION).unwrap();
         assert_eq!(price_data.comp_[0].latest_.price_, 42);
         assert_eq!(price_data.comp_[0].latest_.conf_, 9);
         assert_eq!(price_data.comp_[0].latest_.pub_slot_, 1);

--- a/program/rust/src/tests/test_upd_product.rs
+++ b/program/rust/src/tests/test_upd_product.rs
@@ -15,7 +15,7 @@ use solana_program::program_error::ProgramError;
 use solana_program::pubkey::Pubkey;
 
 use crate::c_oracle_header::{
-    pc_prod_t,
+    ProductAccount,
     PythAccount,
     PC_PROD_ACC_SIZE,
     PC_VERSION,
@@ -35,10 +35,10 @@ fn test_upd_product() {
     let mut funding_setup = AccountSetup::new_funding();
     let funding_account = funding_setup.to_account_info();
 
-    let mut product_setup = AccountSetup::new::<pc_prod_t>(&program_id);
+    let mut product_setup = AccountSetup::new::<ProductAccount>(&program_id);
     let product_account = product_setup.to_account_info();
 
-    initialize_pyth_account_checked::<pc_prod_t>(&product_account, PC_VERSION).unwrap();
+    initialize_pyth_account_checked::<ProductAccount>(&product_account, PC_VERSION).unwrap();
 
     let kvs = ["foo", "barz"];
     let size = populate_instruction(&mut instruction_data, &kvs);
@@ -51,8 +51,8 @@ fn test_upd_product() {
     assert!(account_has_key_values(&product_account, &kvs).unwrap_or(false));
 
     {
-        let product_data = load_checked::<pc_prod_t>(&product_account, PC_VERSION).unwrap();
-        assert_eq!(product_data.size_, pc_prod_t::INITIAL_SIZE + 9);
+        let product_data = load_checked::<ProductAccount>(&product_account, PC_VERSION).unwrap();
+        assert_eq!(product_data.size_, ProductAccount::INITIAL_SIZE + 9);
     }
 
     // bad size on the 1st string in the key-value pair list
@@ -77,8 +77,8 @@ fn test_upd_product() {
     .is_ok());
     assert!(account_has_key_values(&product_account, &kvs).unwrap_or(false));
     {
-        let product_data = load_checked::<pc_prod_t>(&product_account, PC_VERSION).unwrap();
-        assert_eq!(product_data.size_, pc_prod_t::INITIAL_SIZE);
+        let product_data = load_checked::<ProductAccount>(&product_account, PC_VERSION).unwrap();
+        assert_eq!(product_data.size_, ProductAccount::INITIAL_SIZE);
     }
 
     // uneven number of keys and values
@@ -126,9 +126,9 @@ fn account_has_key_values(
     expected: &[&str],
 ) -> Result<bool, ProgramError> {
     let account_size: usize =
-        try_convert(load_checked::<pc_prod_t>(product_account, PC_VERSION)?.size_)?;
+        try_convert(load_checked::<ProductAccount>(product_account, PC_VERSION)?.size_)?;
     let mut all_account_data = product_account.try_borrow_mut_data()?;
-    let kv_data = &mut all_account_data[size_of::<pc_prod_t>()..account_size];
+    let kv_data = &mut all_account_data[size_of::<ProductAccount>()..account_size];
     let mut kv_idx = 0;
     let mut expected_idx = 0;
 

--- a/program/rust/src/time_machine_types.rs
+++ b/program/rust/src/time_machine_types.rs
@@ -1,5 +1,5 @@
 use crate::c_oracle_header::{
-    pc_price_t,
+    PriceAccount,
     PythAccount,
     EXTRA_PUBLISHER_SPACE,
     PC_ACCTYPE_PRICE,
@@ -27,7 +27,7 @@ pub struct TimeMachineWrapper {
 /// wraps everything stored in a price account
 pub struct PriceAccountWrapper {
     //an instance of the c price_t type
-    pub price_data:            pc_price_t,
+    pub price_data:            PriceAccount,
     //space for more publishers
     pub extra_publisher_space: [u8; EXTRA_PUBLISHER_SPACE as usize],
     //TimeMachine

--- a/program/rust/src/utils.rs
+++ b/program/rust/src/utils.rs
@@ -1,6 +1,6 @@
 use crate::c_oracle_header::{
-    pc_acc,
-    pc_pub_key_t,
+    AccountHeader,
+    CPubkey,
     PC_MAX_NUM_DECIMALS,
 };
 use crate::deserialize::load_account_as;
@@ -73,7 +73,7 @@ pub fn check_valid_signable_account(
 /// Returns `true` if the `account` is fresh, i.e., its data can be overwritten.
 /// Use this check to prevent accidentally overwriting accounts whose data is already populated.
 pub fn valid_fresh_account(account: &AccountInfo) -> bool {
-    let pyth_acc = load_account_as::<pc_acc>(account);
+    let pyth_acc = load_account_as::<AccountHeader>(account);
     match pyth_acc {
         Ok(pyth_acc) => pyth_acc.magic_ == 0 && pyth_acc.ver_ == 0,
         Err(_) => false,
@@ -96,20 +96,20 @@ pub fn check_exponent_range(expo: i32) -> Result<(), ProgramError> {
 }
 
 // Assign pubkey bytes from source to target, fails if source is not 32 bytes
-pub fn pubkey_assign(target: &mut pc_pub_key_t, source: &[u8]) {
+pub fn pubkey_assign(target: &mut CPubkey, source: &[u8]) {
     unsafe { target.k1_.copy_from_slice(source) }
 }
 
-pub fn pubkey_is_zero(key: &pc_pub_key_t) -> bool {
+pub fn pubkey_is_zero(key: &CPubkey) -> bool {
     return unsafe { key.k8_.iter().all(|x| *x == 0) };
 }
 
-pub fn pubkey_equal(target: &pc_pub_key_t, source: &[u8]) -> bool {
+pub fn pubkey_equal(target: &CPubkey, source: &[u8]) -> bool {
     unsafe { target.k1_ == *source }
 }
 
 /// Zero out the bytes of `key`.
-pub fn pubkey_clear(key: &mut pc_pub_key_t) {
+pub fn pubkey_clear(key: &mut CPubkey) {
     unsafe {
         for i in 0..key.k8_.len() {
             key.k8_[i] = 0;


### PR DESCRIPTION
This PR :
- Creates rust structs in `c_oracle_header.rs` and replaces all the bindgen structs by the new structs.