### PR TITLE
Cleanup resize, remove print staments, add extra check

### DIFF
--- a/program/rust/src/time_machine_types.rs
+++ b/program/rust/src/time_machine_types.rs
@@ -10,7 +10,6 @@ use bytemuck::{
     Pod,
     Zeroable,
 };
-use solana_program::msg;
 
 
 #[derive(Debug, Clone, Copy)]
@@ -35,12 +34,12 @@ pub struct PriceAccountWrapper {
 }
 impl PriceAccountWrapper {
     pub fn initialize_time_machine(&mut self) -> Result<(), OracleError> {
-        msg!("implement me");
+        // TO DO
         Ok(())
     }
 
     pub fn add_price_to_time_machine(&mut self) -> Result<(), OracleError> {
-        msg!("implement me");
+        // TO DO
         Ok(())
     }
 }


### PR DESCRIPTION
This PR:
- Cleans up the comments in `resize_price_account`
- Adds an extra rent exemption check to make sure the lamport transfer worked (paranoid check)
- Removes print statements.