### PR TITLE
Add test for resize instruction

### DIFF
--- a/program/rust/src/tests/mod.rs
+++ b/program/rust/src/tests/mod.rs
@@ -8,6 +8,7 @@ mod test_del_product;
 mod test_del_publisher;
 mod test_init_mapping;
 mod test_init_price;
+mod test_resize_account;
 mod test_set_min_pub;
 mod test_sizes;
 mod test_upd_aggregate;

--- a/program/rust/src/tests/pyth_simulator.rs
+++ b/program/rust/src/tests/pyth_simulator.rs
@@ -228,7 +228,7 @@ impl PythSimulator {
     }
 
     /// Resize a price account (using the resize_price_account
-    /// instruction). Returns the keypair associated with the newly-created account.
+    /// instruction).
     pub async fn resize_price_account(
         &mut self,
         price_keypair: &Keypair,

--- a/program/rust/src/tests/pyth_simulator.rs
+++ b/program/rust/src/tests/pyth_simulator.rs
@@ -11,7 +11,10 @@ use solana_program::instruction::{
 };
 use solana_program::pubkey::Pubkey;
 use solana_program::rent::Rent;
-use solana_program::system_instruction;
+use solana_program::{
+    system_instruction,
+    system_program,
+};
 use solana_program_test::{
     processor,
     BanksClient,
@@ -223,6 +226,27 @@ impl PythSimulator {
         self.process_ix(instruction, &vec![&product_keypair, &price_keypair])
             .await
     }
+
+    /// Resize a price account (using the resize_price_account
+    /// instruction). Returns the keypair associated with the newly-created account.
+    pub async fn resize_price_account(
+        &mut self,
+        price_keypair: &Keypair,
+    ) -> Result<(), BanksClientError> {
+        let cmd: CommandHeader = OracleCommand::ResizePriceAccount.into();
+        let instruction = Instruction::new_with_bytes(
+            self.program_id,
+            bytes_of(&cmd),
+            vec![
+                AccountMeta::new(self.payer.pubkey(), true),
+                AccountMeta::new(price_keypair.pubkey(), true),
+                AccountMeta::new(system_program::id(), false),
+            ],
+        );
+
+        self.process_ix(instruction, &vec![&price_keypair]).await
+    }
+
 
     /// Get the account at `key`. Returns `None` if no such account exists.
     pub async fn get_account(&mut self, key: Pubkey) -> Option<Account> {

--- a/program/rust/src/tests/test_resize_account.rs
+++ b/program/rust/src/tests/test_resize_account.rs
@@ -1,0 +1,31 @@
+use solana_sdk::signer::Signer;
+use std::mem::size_of;
+
+use crate::c_oracle_header::pc_price_t;
+use crate::tests::pyth_simulator::PythSimulator;
+use crate::time_machine_types::PriceAccountWrapper;
+
+
+/// Warning : This test will fail if you run cargo test instead of cargo test-bpf
+#[tokio::test]
+async fn test_resize_account() {
+    let mut sim = PythSimulator::new().await;
+    let mapping_keypair = sim.init_mapping().await.unwrap();
+    let product1 = sim.add_product(&mapping_keypair).await.unwrap();
+    let price1 = sim.add_price(&product1, -8).await.unwrap();
+
+    // Check size after initialization
+    let price1_account = sim.get_account(price1.pubkey()).await.unwrap();
+    assert_eq!(price1_account.data.len(), size_of::<pc_price_t>());
+
+    // Run the instruction once
+    assert!(sim.resize_price_account(&price1).await.is_ok());
+    // Check new size
+    let price1_account = sim.get_account(price1.pubkey()).await.unwrap();
+    assert_eq!(price1_account.data.len(), size_of::<PriceAccountWrapper>());
+
+    // Future calls don't change the size
+    assert!(sim.resize_price_account(&price1).await.is_ok());
+    let price1_account = sim.get_account(price1.pubkey()).await.unwrap();
+    assert_eq!(price1_account.data.len(), size_of::<PriceAccountWrapper>());
+}


### PR DESCRIPTION
Add a new test for the resize instruction. This instruction will enable price account resizing for adding more publishers and the settlement prices.