### PR TITLE
Fix spurious too many unacked price update transactions message

### DIFF
--- a/pc/request.cpp
+++ b/pc/request.cpp
@@ -815,12 +815,12 @@ bool price::send( price *prices[], const unsigned n )
       }
       else {
         p->get_rpc_client()->send( &upds_[ 0 ], upds_.size(), mgr->get_requested_upd_price_cu_units(), mgr->get_requested_upd_price_cu_price() );
+        p->tvec_.emplace_back(
+          std::string( 100, '\0' ), p->preq_->get_sent_time()
+        );
+        p->preq_->get_signature()->enc_base58( p->tvec_.back().first );
         for ( unsigned k = j; k <= i; ++k ) {
           price *const p1 = prices[ k ];
-          p1->tvec_.emplace_back(
-            std::string( 100, '\0' ), p1->preq_->get_sent_time()
-          );
-          p1->preq_->get_signature()->enc_base58( p1->tvec_.back().first );
           PC_LOG_DBG( "sent price update" )
             .add( "secondary", mgr->get_is_secondary() )
             .add( "price_account", *p1->get_account() )

--- a/pc/request.cpp
+++ b/pc/request.cpp
@@ -827,8 +827,8 @@ bool price::send( price *prices[], const unsigned n )
             .add( "product_account", *p1->prod_->get_account() )
             .add( "symbol", p1->get_symbol() )
             .add( "price_type", price_type_to_str( p1->get_price_type() ) )
-            .add( "sig", p1->tvec_.back().first )
-            .add( "pub_slot", p1->preq_->get_slot() )
+            .add( "sig", p->tvec_.back().first )
+            .add( "pub_slot", p->preq_->get_slot() )
             .end();
           if ( PC_UNLIKELY( p1->tvec_.size() >= 100 ) ) {
             PC_LOG_WRN( "too many unacked price update transactions" )


### PR DESCRIPTION
We add an entry to the list of unacked transactions for each price account in a batch. This means that there are more "unacked transactions" tracked then really exist, which results in an unnecessarily high amount of `too many unacked price update transactions` messages being printed. This PR therefore only stores one update per batch.