### PR TITLE
Renames

### DIFF
--- a/program/rust/src/c_oracle_header.rs
+++ b/program/rust/src/c_oracle_header.rs
@@ -57,46 +57,46 @@ impl PythAccount for PriceAccount {
 #[repr(C)]
 #[derive(Copy, Clone, Pod, Zeroable)]
 pub struct PriceAccount {
-    pub header:          AccountHeader,
+    pub header:             AccountHeader,
     /// Type of the price account
-    pub price_type:      u32,
+    pub price_type:         u32,
     /// Exponent for the published prices
-    pub exponent:        i32,
+    pub exponent:           i32,
     /// Current number of authorized publishers
-    pub num_:            u32,
+    pub num_:               u32,
     /// Number of valid quotes for the last aggregation
-    pub num_qt_:         u32,
+    pub num_qt_:            u32,
     /// Last slot with a succesful aggregation (status : TRADING)
-    pub last_slot_:      u64,
+    pub last_slot_:         u64,
     /// Second to last slot where aggregation was attempted
-    pub valid_slot_:     u64,
+    pub valid_slot_:        u64,
     /// Ema for price
-    pub twap_:           PriceEma,
+    pub twap_:              PriceEma,
     /// Ema for confidence
-    pub twac_:           PriceEma,
+    pub twac_:              PriceEma,
     /// Last time aggregation was attempted
-    pub timestamp_:      i64,
+    pub timestamp_:         i64,
     /// Minimum valid publisher quotes for a succesful aggregation
-    pub min_pub_:        u8,
-    pub unused_1_:       i8,
-    pub unused_2_:       i16,
-    pub unused_3_:       i32,
+    pub min_pub_:           u8,
+    pub unused_1_:          i8,
+    pub unused_2_:          i16,
+    pub unused_3_:          i32,
     /// Corresponding product account
-    pub prod_:           CPubkey,
+    pub product_account:    CPubkey,
     /// Next price account in the list
-    pub next_:           CPubkey,
+    pub next_price_account: CPubkey,
     /// Second to last slot where aggregation was succesful (i.e. status : TRADING)
-    pub prev_slot_:      u64,
+    pub prev_slot_:         u64,
     /// Aggregate price at prev_slot_
-    pub prev_price_:     i64,
+    pub prev_price_:        i64,
     /// Confidence interval at prev_slot_
-    pub prev_conf_:      u64,
+    pub prev_conf_:         u64,
     /// Timestamp of prev_slot_
-    pub prev_timestamp_: i64,
+    pub prev_timestamp_:    i64,
     /// Last attempted aggregate results
-    pub agg_:            PriceInfo,
+    pub agg_:               PriceInfo,
     /// Publishers' price components
-    pub comp_:           [PriceComponent; PC_COMP_SIZE as usize],
+    pub comp_:              [PriceComponent; PC_COMP_SIZE as usize],
 }
 
 #[repr(C)]

--- a/program/rust/src/c_oracle_header.rs
+++ b/program/rust/src/c_oracle_header.rs
@@ -57,14 +57,11 @@ impl PythAccount for PriceAccount {
 #[repr(C)]
 #[derive(Copy, Clone, Pod, Zeroable)]
 pub struct PriceAccount {
-    pub magic_:          u32,
-    pub ver_:            u32,
-    pub type_:           u32,
-    pub size_:           u32,
+    pub header:          AccountHeader,
     /// Type of the price account
-    pub ptype_:          u32,
+    pub price_type:      u32,
     /// Exponent for the published prices
-    pub expo_:           i32,
+    pub exponent:        i32,
     /// Current number of authorized publishers
     pub num_:            u32,
     /// Number of valid quotes for the last aggregation
@@ -131,33 +128,27 @@ pub struct PriceEma {
 #[repr(C)]
 #[derive(Copy, Clone, Zeroable, Pod)]
 pub struct AccountHeader {
-    pub magic_: u32,
-    pub ver_:   u32,
-    pub type_:  u32,
-    pub size_:  u32,
+    pub magic_number: u32,
+    pub version:      u32,
+    pub account_type: u32,
+    pub size:         u32,
 }
 
 #[repr(C)]
 #[derive(Copy, Clone, Pod, Zeroable)]
 pub struct ProductAccount {
-    pub magic_:  u32,
-    pub ver_:    u32,
-    pub type_:   u32,
-    pub size_:   u32,
-    pub px_acc_: CPubkey,
+    pub header:              AccountHeader,
+    pub first_price_account: CPubkey,
 }
 
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct MappingAccount {
-    pub magic_:  u32,
-    pub ver_:    u32,
-    pub type_:   u32,
-    pub size_:   u32,
-    pub num_:    u32,
-    pub unused_: u32,
-    pub next_:   CPubkey,
-    pub prod_:   [CPubkey; PC_MAP_TABLE_SIZE as usize],
+    pub header:               AccountHeader,
+    pub number_of_products:   u32,
+    pub unused_:              u32,
+    pub next_mapping_account: CPubkey,
+    pub products_list:        [CPubkey; PC_MAP_TABLE_SIZE as usize],
 }
 
 // Unsafe impl because CPubkey is a union

--- a/program/rust/src/deserialize.rs
+++ b/program/rust/src/deserialize.rs
@@ -73,9 +73,9 @@ pub fn load_checked<'a, T: PythAccount>(
     {
         let account_header = load_account_as::<AccountHeader>(account)?;
         pyth_assert(
-            account_header.magic_ == PC_MAGIC
-                && account_header.ver_ == version
-                && account_header.type_ == T::ACCOUNT_TYPE,
+            account_header.magic_number == PC_MAGIC
+                && account_header.version == version
+                && account_header.account_type == T::ACCOUNT_TYPE,
             ProgramError::InvalidArgument,
         )?;
     }
@@ -91,10 +91,10 @@ pub fn initialize_pyth_account_checked<'a, T: PythAccount>(
 
     {
         let mut account_header = load_account_as_mut::<AccountHeader>(account)?;
-        account_header.magic_ = PC_MAGIC;
-        account_header.ver_ = version;
-        account_header.type_ = T::ACCOUNT_TYPE;
-        account_header.size_ = T::INITIAL_SIZE;
+        account_header.magic_number = PC_MAGIC;
+        account_header.version = version;
+        account_header.account_type = T::ACCOUNT_TYPE;
+        account_header.size = T::INITIAL_SIZE;
     }
 
     load_account_as_mut::<T>(account)

--- a/program/rust/src/rust_oracle.rs
+++ b/program/rust/src/rust_oracle.rs
@@ -208,12 +208,16 @@ pub fn add_mapping(
     let hdr = load::<CommandHeader>(instruction_data)?;
     let mut cur_mapping = load_checked::<MappingAccount>(cur_mapping, hdr.version)?;
     pyth_assert(
-        cur_mapping.num_ == PC_MAP_TABLE_SIZE && pubkey_is_zero(&cur_mapping.next_),
+        cur_mapping.number_of_products == PC_MAP_TABLE_SIZE
+            && pubkey_is_zero(&cur_mapping.next_mapping_account),
         ProgramError::InvalidArgument,
     )?;
 
     initialize_pyth_account_checked::<MappingAccount>(next_mapping, hdr.version)?;
-    pubkey_assign(&mut cur_mapping.next_, &next_mapping.key.to_bytes());
+    pubkey_assign(
+        &mut cur_mapping.next_mapping_account,
+        &next_mapping.key.to_bytes(),
+    );
 
     Ok(())
 }
@@ -363,11 +367,17 @@ pub fn add_price(
 
     let mut price_data =
         initialize_pyth_account_checked::<PriceAccount>(price_account, cmd_args.header.version)?;
-    price_data.expo_ = cmd_args.exponent;
-    price_data.ptype_ = cmd_args.price_type;
+    price_data.exponent = cmd_args.exponent;
+    price_data.price_type = cmd_args.price_type;
     pubkey_assign(&mut price_data.prod_, &product_account.key.to_bytes());
-    pubkey_assign(&mut price_data.next_, bytes_of(&product_data.px_acc_));
-    pubkey_assign(&mut product_data.px_acc_, &price_account.key.to_bytes());
+    pubkey_assign(
+        &mut price_data.next_,
+        bytes_of(&product_data.first_price_account),
+    );
+    pubkey_assign(
+        &mut product_data.first_price_account,
+        &price_account.key.to_bytes(),
+    );
 
     Ok(())
 }
@@ -398,7 +408,10 @@ pub fn del_price(
         let mut product_data = load_checked::<ProductAccount>(product_account, cmd_args.version)?;
         let price_data = load_checked::<PriceAccount>(price_account, cmd_args.version)?;
         pyth_assert(
-            pubkey_equal(&product_data.px_acc_, &price_account.key.to_bytes()),
+            pubkey_equal(
+                &product_data.first_price_account,
+                &price_account.key.to_bytes(),
+            ),
             ProgramError::InvalidArgument,
         )?;
 
@@ -407,7 +420,10 @@ pub fn del_price(
             ProgramError::InvalidArgument,
         )?;
 
-        pubkey_assign(&mut product_data.px_acc_, bytes_of(&price_data.next_));
+        pubkey_assign(
+            &mut product_data.first_price_account,
+            bytes_of(&price_data.next_),
+        );
     }
 
     // Zero out the balance of the price account to delete it.
@@ -439,11 +455,11 @@ pub fn init_price(
 
     let mut price_data = load_checked::<PriceAccount>(price_account, cmd_args.header.version)?;
     pyth_assert(
-        price_data.ptype_ == cmd_args.price_type,
+        price_data.price_type == cmd_args.price_type,
         ProgramError::InvalidArgument,
     )?;
 
-    price_data.expo_ = cmd_args.exponent;
+    price_data.exponent = cmd_args.exponent;
 
     price_data.last_slot_ = 0;
     price_data.valid_slot_ = 0;
@@ -530,7 +546,7 @@ pub fn add_publisher(
         bytes_of(&cmd_args.publisher),
     );
     price_data.num_ += 1;
-    price_data.size_ =
+    price_data.header.size =
         try_convert::<_, u32>(size_of::<PriceAccount>() - size_of_val(&price_data.comp_))?
             + price_data.num_ * try_convert::<_, u32>(size_of::<PriceComponent>())?;
     Ok(())
@@ -574,7 +590,7 @@ pub fn del_publisher(
                 0,
                 size_of::<PriceComponent>(),
             );
-            price_data.size_ =
+            price_data.header.size =
                 try_convert::<_, u32>(size_of::<PriceAccount>() - size_of_val(&price_data.comp_))?
                     + price_data.num_ * try_convert::<_, u32>(size_of::<PriceComponent>())?;
             return Ok(());
@@ -606,21 +622,22 @@ pub fn add_product(
     let mut mapping_data = load_checked::<MappingAccount>(tail_mapping_account, hdr.version)?;
     // The mapping account must have free space to add the product account
     pyth_assert(
-        mapping_data.num_ < PC_MAP_TABLE_SIZE,
+        mapping_data.number_of_products < PC_MAP_TABLE_SIZE,
         ProgramError::InvalidArgument,
     )?;
 
     initialize_pyth_account_checked::<ProductAccount>(new_product_account, hdr.version)?;
 
-    let current_index: usize = try_convert(mapping_data.num_)?;
+    let current_index: usize = try_convert(mapping_data.number_of_products)?;
     pubkey_assign(
-        &mut mapping_data.prod_[current_index],
+        &mut mapping_data.products_list[current_index],
         bytes_of(&new_product_account.key.to_bytes()),
     );
-    mapping_data.num_ += 1;
-    mapping_data.size_ =
-        try_convert::<_, u32>(size_of::<MappingAccount>() - size_of_val(&mapping_data.prod_))?
-            + mapping_data.num_ * try_convert::<_, u32>(size_of::<CPubkey>())?;
+    mapping_data.number_of_products += 1;
+    mapping_data.header.size = try_convert::<_, u32>(
+        size_of::<MappingAccount>() - size_of_val(&mapping_data.products_list),
+    )? + mapping_data.number_of_products
+        * try_convert::<_, u32>(size_of::<CPubkey>())?;
 
     Ok(())
 }
@@ -680,7 +697,7 @@ pub fn upd_product(
     }
 
     let mut product_data = load_checked::<ProductAccount>(product_account, hdr.version)?;
-    product_data.size_ = try_convert(size_of::<ProductAccount>() + new_data.len())?;
+    product_data.header.size = try_convert(size_of::<ProductAccount>() + new_data.len())?;
 
     Ok(())
 }
@@ -738,36 +755,40 @@ pub fn del_product(
         let product_data = load_checked::<ProductAccount>(product_account, cmd_args.version)?;
 
         // This assertion is just to make the subtractions below simpler
-        pyth_assert(mapping_data.num_ >= 1, ProgramError::InvalidArgument)?;
         pyth_assert(
-            pubkey_is_zero(&product_data.px_acc_),
+            mapping_data.number_of_products >= 1,
+            ProgramError::InvalidArgument,
+        )?;
+        pyth_assert(
+            pubkey_is_zero(&product_data.first_price_account),
             ProgramError::InvalidArgument,
         )?;
 
         let product_key = product_account.key.to_bytes();
         let product_index = mapping_data
-            .prod_
+            .products_list
             .iter()
             .position(|x| pubkey_equal(x, &product_key))
             .ok_or(ProgramError::InvalidArgument)?;
 
         let num_after_removal: usize = try_convert(
             mapping_data
-                .num_
+                .number_of_products
                 .checked_sub(1)
                 .ok_or(ProgramError::InvalidArgument)?,
         )?;
 
-        let last_key_bytes = mapping_data.prod_[num_after_removal];
+        let last_key_bytes = mapping_data.products_list[num_after_removal];
         pubkey_assign(
-            &mut mapping_data.prod_[product_index],
+            &mut mapping_data.products_list[product_index],
             bytes_of(&last_key_bytes),
         );
-        pubkey_clear(&mut mapping_data.prod_[num_after_removal]);
-        mapping_data.num_ = try_convert::<_, u32>(num_after_removal)?;
-        mapping_data.size_ =
-            try_convert::<_, u32>(size_of::<MappingAccount>() - size_of_val(&mapping_data.prod_))?
-                + mapping_data.num_ * try_convert::<_, u32>(size_of::<CPubkey>())?;
+        pubkey_clear(&mut mapping_data.products_list[num_after_removal]);
+        mapping_data.number_of_products = try_convert::<_, u32>(num_after_removal)?;
+        mapping_data.header.size = try_convert::<_, u32>(
+            size_of::<MappingAccount>() - size_of_val(&mapping_data.products_list),
+        )? + mapping_data.number_of_products
+            * try_convert::<_, u32>(size_of::<CPubkey>())?;
     }
 
     // Zero out the balance of the price account to delete it.

--- a/program/rust/src/rust_oracle.rs
+++ b/program/rust/src/rust_oracle.rs
@@ -369,9 +369,12 @@ pub fn add_price(
         initialize_pyth_account_checked::<PriceAccount>(price_account, cmd_args.header.version)?;
     price_data.exponent = cmd_args.exponent;
     price_data.price_type = cmd_args.price_type;
-    pubkey_assign(&mut price_data.prod_, &product_account.key.to_bytes());
     pubkey_assign(
-        &mut price_data.next_,
+        &mut price_data.product_account,
+        &product_account.key.to_bytes(),
+    );
+    pubkey_assign(
+        &mut price_data.next_price_account,
         bytes_of(&product_data.first_price_account),
     );
     pubkey_assign(
@@ -416,13 +419,13 @@ pub fn del_price(
         )?;
 
         pyth_assert(
-            pubkey_equal(&price_data.prod_, &product_account.key.to_bytes()),
+            pubkey_equal(&price_data.product_account, &product_account.key.to_bytes()),
             ProgramError::InvalidArgument,
         )?;
 
         pubkey_assign(
             &mut product_data.first_price_account,
-            bytes_of(&price_data.next_),
+            bytes_of(&price_data.next_price_account),
         );
     }
 

--- a/program/rust/src/tests/test_add_mapping.rs
+++ b/program/rust/src/tests/test_add_mapping.rs
@@ -45,7 +45,7 @@ fn test_add_mapping() {
     {
         let mut cur_mapping_data =
             load_checked::<MappingAccount>(&cur_mapping, PC_VERSION).unwrap();
-        cur_mapping_data.num_ = PC_MAP_TABLE_SIZE;
+        cur_mapping_data.number_of_products = PC_MAP_TABLE_SIZE;
     }
 
     assert!(process_instruction(
@@ -65,12 +65,15 @@ fn test_add_mapping() {
             load_checked::<MappingAccount>(&cur_mapping, PC_VERSION).unwrap();
 
         assert!(pubkey_equal(
-            &cur_mapping_data.next_,
+            &cur_mapping_data.next_mapping_account,
             &next_mapping.key.to_bytes()
         ));
-        assert!(pubkey_is_zero(&next_mapping_data.next_));
-        pubkey_assign(&mut cur_mapping_data.next_, &Pubkey::default().to_bytes());
-        cur_mapping_data.num_ = 0;
+        assert!(pubkey_is_zero(&next_mapping_data.next_mapping_account));
+        pubkey_assign(
+            &mut cur_mapping_data.next_mapping_account,
+            &Pubkey::default().to_bytes(),
+        );
+        cur_mapping_data.number_of_products = 0;
     }
 
     clear_account(&next_mapping).unwrap();
@@ -91,9 +94,9 @@ fn test_add_mapping() {
     {
         let mut cur_mapping_data =
             load_checked::<MappingAccount>(&cur_mapping, PC_VERSION).unwrap();
-        assert!(pubkey_is_zero(&cur_mapping_data.next_));
-        cur_mapping_data.num_ = PC_MAP_TABLE_SIZE;
-        cur_mapping_data.magic_ = 0;
+        assert!(pubkey_is_zero(&cur_mapping_data.next_mapping_account));
+        cur_mapping_data.number_of_products = PC_MAP_TABLE_SIZE;
+        cur_mapping_data.header.magic_number = 0;
     }
 
     assert_eq!(
@@ -111,7 +114,7 @@ fn test_add_mapping() {
 
     {
         let mut cur_mapping_data = load_account_as_mut::<MappingAccount>(&cur_mapping).unwrap();
-        cur_mapping_data.magic_ = PC_MAGIC;
+        cur_mapping_data.header.magic_number = PC_MAGIC;
     }
 
     assert!(process_instruction(

--- a/program/rust/src/tests/test_add_price.rs
+++ b/program/rust/src/tests/test_add_price.rs
@@ -83,10 +83,10 @@ fn test_add_price() {
         assert_eq!(price_data.exponent, 1);
         assert_eq!(price_data.price_type, 1);
         assert!(pubkey_equal(
-            &price_data.prod_,
+            &price_data.product_account,
             &product_account.key.to_bytes()
         ));
-        assert!(pubkey_is_zero(&price_data.next_));
+        assert!(pubkey_is_zero(&price_data.next_price_account));
         assert!(pubkey_equal(
             &product_data.first_price_account,
             &price_account.key.to_bytes()
@@ -110,11 +110,11 @@ fn test_add_price() {
         assert_eq!(price_data_2.exponent, 1);
         assert_eq!(price_data_2.price_type, 1);
         assert!(pubkey_equal(
-            &price_data_2.prod_,
+            &price_data_2.product_account,
             &product_account.key.to_bytes()
         ));
         assert!(pubkey_equal(
-            &price_data_2.next_,
+            &price_data_2.next_price_account,
             &price_account.key.to_bytes()
         ));
         assert!(pubkey_equal(

--- a/program/rust/src/tests/test_add_price.rs
+++ b/program/rust/src/tests/test_add_price.rs
@@ -80,15 +80,15 @@ fn test_add_price() {
     {
         let price_data = load_checked::<PriceAccount>(&price_account, PC_VERSION).unwrap();
         let product_data = load_checked::<ProductAccount>(&product_account, PC_VERSION).unwrap();
-        assert_eq!(price_data.expo_, 1);
-        assert_eq!(price_data.ptype_, 1);
+        assert_eq!(price_data.exponent, 1);
+        assert_eq!(price_data.price_type, 1);
         assert!(pubkey_equal(
             &price_data.prod_,
             &product_account.key.to_bytes()
         ));
         assert!(pubkey_is_zero(&price_data.next_));
         assert!(pubkey_equal(
-            &product_data.px_acc_,
+            &product_data.first_price_account,
             &price_account.key.to_bytes()
         ));
     }
@@ -107,8 +107,8 @@ fn test_add_price() {
     {
         let price_data_2 = load_checked::<PriceAccount>(&price_account_2, PC_VERSION).unwrap();
         let product_data = load_checked::<ProductAccount>(&product_account, PC_VERSION).unwrap();
-        assert_eq!(price_data_2.expo_, 1);
-        assert_eq!(price_data_2.ptype_, 1);
+        assert_eq!(price_data_2.exponent, 1);
+        assert_eq!(price_data_2.price_type, 1);
         assert!(pubkey_equal(
             &price_data_2.prod_,
             &product_account.key.to_bytes()
@@ -118,7 +118,7 @@ fn test_add_price() {
             &price_account.key.to_bytes()
         ));
         assert!(pubkey_equal(
-            &product_data.px_acc_,
+            &product_data.first_price_account,
             &price_account_2.key.to_bytes()
         ));
     }

--- a/program/rust/src/tests/test_add_product.rs
+++ b/program/rust/src/tests/test_add_product.rs
@@ -69,14 +69,17 @@ fn test_add_product() {
         let product_data = load_account_as::<ProductAccount>(&product_account).unwrap();
         let mapping_data = load_checked::<MappingAccount>(&mapping_account, PC_VERSION).unwrap();
 
-        assert_eq!(product_data.magic_, PC_MAGIC);
-        assert_eq!(product_data.ver_, PC_VERSION);
-        assert_eq!(product_data.type_, PC_ACCTYPE_PRODUCT);
-        assert_eq!(product_data.size_, size_of::<ProductAccount>() as u32);
-        assert_eq!(mapping_data.num_, 1);
-        assert_eq!(mapping_data.size_, (MappingAccount::INITIAL_SIZE + 32));
+        assert_eq!(product_data.header.magic_number, PC_MAGIC);
+        assert_eq!(product_data.header.version, PC_VERSION);
+        assert_eq!(product_data.header.account_type, PC_ACCTYPE_PRODUCT);
+        assert_eq!(product_data.header.size, size_of::<ProductAccount>() as u32);
+        assert_eq!(mapping_data.number_of_products, 1);
+        assert_eq!(
+            mapping_data.header.size,
+            (MappingAccount::INITIAL_SIZE + 32)
+        );
         assert!(pubkey_equal(
-            &mapping_data.prod_[0],
+            &mapping_data.products_list[0],
             &product_account.key.to_bytes()
         ));
     }
@@ -93,10 +96,13 @@ fn test_add_product() {
     .is_ok());
     {
         let mapping_data = load_checked::<MappingAccount>(&mapping_account, PC_VERSION).unwrap();
-        assert_eq!(mapping_data.num_, 2);
-        assert_eq!(mapping_data.size_, (MappingAccount::INITIAL_SIZE + 2 * 32));
+        assert_eq!(mapping_data.number_of_products, 2);
+        assert_eq!(
+            mapping_data.header.size,
+            (MappingAccount::INITIAL_SIZE + 2 * 32)
+        );
         assert!(pubkey_equal(
-            &mapping_data.prod_[1],
+            &mapping_data.products_list[1],
             &product_account_2.key.to_bytes()
         ));
     }
@@ -147,10 +153,10 @@ fn test_add_product() {
         .is_ok());
         let mapping_data = load_checked::<MappingAccount>(&mapping_account, PC_VERSION).unwrap();
         assert_eq!(
-            mapping_data.size_,
+            mapping_data.header.size,
             MappingAccount::INITIAL_SIZE + (i + 1) * 32
         );
-        assert_eq!(mapping_data.num_, i + 1);
+        assert_eq!(mapping_data.number_of_products, i + 1);
     }
 
     clear_account(&product_account).unwrap();
@@ -169,5 +175,5 @@ fn test_add_product() {
     );
 
     let mapping_data = load_checked::<MappingAccount>(&mapping_account, PC_VERSION).unwrap();
-    assert_eq!(mapping_data.num_, PC_MAP_TABLE_SIZE);
+    assert_eq!(mapping_data.number_of_products, PC_MAP_TABLE_SIZE);
 }

--- a/program/rust/src/tests/test_add_publisher.rs
+++ b/program/rust/src/tests/test_add_publisher.rs
@@ -74,7 +74,7 @@ fn test_add_publisher() {
         let price_data = load_checked::<PriceAccount>(&price_account, PC_VERSION).unwrap();
         assert_eq!(price_data.num_, 1);
         assert_eq!(
-            price_data.size_,
+            price_data.header.size,
             PriceAccount::INITIAL_SIZE + (size_of::<PriceComponent>() as u32)
         );
         assert!(pubkey_equal(
@@ -127,7 +127,7 @@ fn test_add_publisher() {
                 bytes_of(&cmd.publisher)
             ));
             assert_eq!(
-                price_data.size_,
+                price_data.header.size,
                 PriceAccount::INITIAL_SIZE + (size_of::<PriceComponent>() as u32) * (i + 1)
             );
         }

--- a/program/rust/src/tests/test_del_price.rs
+++ b/program/rust/src/tests/test_del_price.rs
@@ -31,7 +31,7 @@ async fn test_del_price() {
         .get_account_data_as::<ProductAccount>(product1.pubkey())
         .await
         .unwrap();
-    assert!(pubkey_is_zero(&product1_data.px_acc_));
+    assert!(pubkey_is_zero(&product1_data.first_price_account));
 
 
     // price2_1 is the 2nd item in the linked list since price2_2 got added after t.
@@ -48,5 +48,5 @@ async fn test_del_price() {
         .await
         .unwrap();
 
-    assert!(pubkey_is_zero(&product2_data.px_acc_));
+    assert!(pubkey_is_zero(&product2_data.first_price_account));
 }

--- a/program/rust/src/tests/test_del_product.rs
+++ b/program/rust/src/tests/test_del_product.rs
@@ -73,18 +73,18 @@ async fn test_del_product() {
 /// Returns true if the list of products in `mapping_data` contains the keys in `expected` (in the
 /// same order). Also checks `mapping_data.num_` and `size_`.
 fn mapping_product_list_equals(mapping_data: &MappingAccount, expected: Vec<Pubkey>) -> bool {
-    if mapping_data.num_ != expected.len() as u32 {
+    if mapping_data.number_of_products != expected.len() as u32 {
         return false;
     }
 
-    let expected_size = (size_of::<MappingAccount>() - size_of_val(&mapping_data.prod_)
+    let expected_size = (size_of::<MappingAccount>() - size_of_val(&mapping_data.products_list)
         + expected.len() * size_of::<CPubkey>()) as u32;
-    if mapping_data.size_ != expected_size {
+    if mapping_data.header.size != expected_size {
         return false;
     }
 
     for i in 0..expected.len() {
-        if !pubkey_equal(&mapping_data.prod_[i], &expected[i].to_bytes()) {
+        if !pubkey_equal(&mapping_data.products_list[i], &expected[i].to_bytes()) {
             return false;
         }
     }

--- a/program/rust/src/tests/test_del_publisher.rs
+++ b/program/rust/src/tests/test_del_publisher.rs
@@ -82,7 +82,7 @@ fn test_del_publisher() {
         assert_eq!(price_data.comp_[0].latest_.status_, 0);
         assert_eq!(price_data.comp_[0].latest_.pub_slot_, 0);
         assert_eq!(price_data.comp_[0].latest_.corp_act_status_, 0);
-        assert_eq!(price_data.size_, PriceAccount::INITIAL_SIZE);
+        assert_eq!(price_data.header.size, PriceAccount::INITIAL_SIZE);
         assert!(pubkey_is_zero(&price_data.comp_[0].pub_));
 
         price_data.num_ = 2;
@@ -117,7 +117,7 @@ fn test_del_publisher() {
         assert_eq!(price_data.comp_[1].latest_.pub_slot_, 0);
         assert_eq!(price_data.comp_[1].latest_.corp_act_status_, 0);
         assert_eq!(
-            price_data.size_,
+            price_data.header.size,
             PriceAccount::INITIAL_SIZE + (size_of::<PriceComponent>() as u32)
         );
         assert!(pubkey_equal(
@@ -158,7 +158,7 @@ fn test_del_publisher() {
         assert_eq!(price_data.comp_[1].latest_.pub_slot_, 0);
         assert_eq!(price_data.comp_[1].latest_.corp_act_status_, 0);
         assert_eq!(
-            price_data.size_,
+            price_data.header.size,
             PriceAccount::INITIAL_SIZE + (size_of::<PriceComponent>() as u32)
         );
         assert!(pubkey_equal(

--- a/program/rust/src/tests/test_init_mapping.rs
+++ b/program/rust/src/tests/test_init_mapping.rs
@@ -43,10 +43,10 @@ fn test_init_mapping() {
     {
         let mapping_data = load_account_as::<MappingAccount>(&mapping_account).unwrap();
 
-        assert_eq!(mapping_data.ver_, PC_VERSION);
-        assert_eq!(mapping_data.magic_, PC_MAGIC);
-        assert_eq!(mapping_data.type_, PC_ACCTYPE_MAPPING);
-        assert_eq!(mapping_data.size_, 56);
+        assert_eq!(mapping_data.header.version, PC_VERSION);
+        assert_eq!(mapping_data.header.magic_number, PC_MAGIC);
+        assert_eq!(mapping_data.header.account_type, PC_ACCTYPE_MAPPING);
+        assert_eq!(mapping_data.header.size, 56);
     }
 
     assert_eq!(

--- a/program/rust/src/tests/test_init_price.rs
+++ b/program/rust/src/tests/test_init_price.rs
@@ -61,8 +61,8 @@ fn test_init_price() {
     initialize_pyth_account_checked::<PriceAccount>(&price_account, PC_VERSION).unwrap();
     {
         let mut price_data = load_checked::<PriceAccount>(&price_account, PC_VERSION).unwrap();
-        price_data.ptype_ = ptype;
-        price_data.expo_ = 0;
+        price_data.price_type = ptype;
+        price_data.exponent = 0;
         price_data.min_pub_ = 7;
         price_data.num_ = 4;
         pubkey_assign(&mut price_data.comp_[0].pub_, bytes_of(&publisher));
@@ -103,8 +103,8 @@ fn test_init_price() {
     {
         let price_data = load_checked::<PriceAccount>(&price_account, PC_VERSION).unwrap();
 
-        assert_eq!(price_data.expo_, -2);
-        assert_eq!(price_data.ptype_, ptype);
+        assert_eq!(price_data.exponent, -2);
+        assert_eq!(price_data.price_type, ptype);
         assert_eq!(price_data.min_pub_, 7);
         assert_eq!(price_data.num_, 4);
         assert!(pubkey_equal(

--- a/program/rust/src/tests/test_init_price.rs
+++ b/program/rust/src/tests/test_init_price.rs
@@ -67,8 +67,8 @@ fn test_init_price() {
         price_data.num_ = 4;
         pubkey_assign(&mut price_data.comp_[0].pub_, bytes_of(&publisher));
         pubkey_assign(&mut price_data.comp_[3].pub_, bytes_of(&publisher2));
-        pubkey_assign(&mut price_data.prod_, bytes_of(&product));
-        pubkey_assign(&mut price_data.next_, bytes_of(&next_price));
+        pubkey_assign(&mut price_data.product_account, bytes_of(&product));
+        pubkey_assign(&mut price_data.next_price_account, bytes_of(&next_price));
 
         price_data.last_slot_ = 100;
         price_data.valid_slot_ = 100;
@@ -115,8 +115,14 @@ fn test_init_price() {
             &price_data.comp_[3].pub_,
             bytes_of(&publisher2)
         ));
-        assert!(pubkey_equal(&price_data.prod_, bytes_of(&product)));
-        assert!(pubkey_equal(&price_data.next_, bytes_of(&next_price)));
+        assert!(pubkey_equal(
+            &price_data.product_account,
+            bytes_of(&product)
+        ));
+        assert!(pubkey_equal(
+            &price_data.next_price_account,
+            bytes_of(&next_price)
+        ));
 
         assert_eq!(price_data.last_slot_, 0);
         assert_eq!(price_data.valid_slot_, 0);

--- a/program/rust/src/tests/test_sizes.rs
+++ b/program/rust/src/tests/test_sizes.rs
@@ -96,7 +96,7 @@ fn test_offsets() {
     let mapping_data = load_checked::<MappingAccount>(&mapping_account, PC_VERSION).unwrap();
 
     assert_eq!(
-        size_of::<MappingAccount>() - size_of_val(&mapping_data.prod_),
+        size_of::<MappingAccount>() - size_of_val(&mapping_data.products_list),
         try_convert::<_, usize>(MappingAccount::INITIAL_SIZE).unwrap()
     );
 }

--- a/program/rust/src/tests/test_upd_product.rs
+++ b/program/rust/src/tests/test_upd_product.rs
@@ -52,7 +52,7 @@ fn test_upd_product() {
 
     {
         let product_data = load_checked::<ProductAccount>(&product_account, PC_VERSION).unwrap();
-        assert_eq!(product_data.size_, ProductAccount::INITIAL_SIZE + 9);
+        assert_eq!(product_data.header.size, ProductAccount::INITIAL_SIZE + 9);
     }
 
     // bad size on the 1st string in the key-value pair list
@@ -78,7 +78,7 @@ fn test_upd_product() {
     assert!(account_has_key_values(&product_account, &kvs).unwrap_or(false));
     {
         let product_data = load_checked::<ProductAccount>(&product_account, PC_VERSION).unwrap();
-        assert_eq!(product_data.size_, ProductAccount::INITIAL_SIZE);
+        assert_eq!(product_data.header.size, ProductAccount::INITIAL_SIZE);
     }
 
     // uneven number of keys and values
@@ -125,8 +125,11 @@ fn account_has_key_values(
     product_account: &AccountInfo,
     expected: &[&str],
 ) -> Result<bool, ProgramError> {
-    let account_size: usize =
-        try_convert(load_checked::<ProductAccount>(product_account, PC_VERSION)?.size_)?;
+    let account_size: usize = try_convert(
+        load_checked::<ProductAccount>(product_account, PC_VERSION)?
+            .header
+            .size,
+    )?;
     let mut all_account_data = product_account.try_borrow_mut_data()?;
     let kv_data = &mut all_account_data[size_of::<ProductAccount>()..account_size];
     let mut kv_idx = 0;

--- a/program/rust/src/utils.rs
+++ b/program/rust/src/utils.rs
@@ -75,7 +75,7 @@ pub fn check_valid_signable_account(
 pub fn valid_fresh_account(account: &AccountInfo) -> bool {
     let pyth_acc = load_account_as::<AccountHeader>(account);
     match pyth_acc {
-        Ok(pyth_acc) => pyth_acc.magic_ == 0 && pyth_acc.ver_ == 0,
+        Ok(pyth_acc) => pyth_acc.magic_number == 0 && pyth_acc.version == 0,
         Err(_) => false,
     }
 }


### PR DESCRIPTION
Renaming fields in structs now that they're in Rust. Not touching most of the structs from `pc_price_t` (`PriceAccount`) because they're still used by upd_aggregate.