### PR TITLE
Turn minimum function into constant

### DIFF
--- a/program/rust/src/c_oracle_header.rs
+++ b/program/rust/src/c_oracle_header.rs
@@ -29,9 +29,7 @@ pub trait PythAccount: Pod {
     const INITIAL_SIZE: u32;
     /// `minimum_size()` is the minimum size that the solana account holding the struct needs to
     /// have. `INITIAL_SIZE` <= `minimum_size()`
-    fn minimum_size() -> usize {
-        size_of::<Self>()
-    }
+    const MINIMUM_SIZE: usize = size_of::<Self>();
 }
 
 impl PythAccount for MappingAccount {
@@ -43,9 +41,7 @@ impl PythAccount for MappingAccount {
 impl PythAccount for ProductAccount {
     const ACCOUNT_TYPE: u32 = PC_ACCTYPE_PRODUCT;
     const INITIAL_SIZE: u32 = size_of::<ProductAccount>() as u32;
-    fn minimum_size() -> usize {
-        PC_PROD_ACC_SIZE as usize
-    }
+    const MINIMUM_SIZE: usize = PC_PROD_ACC_SIZE as usize;
 }
 
 impl PythAccount for PriceAccount {

--- a/program/rust/src/deserialize.rs
+++ b/program/rust/src/deserialize.rs
@@ -74,7 +74,7 @@ pub fn load_checked<'a, T: PythAccount>(
     version: u32,
 ) -> Result<RefMut<'a, T>, ProgramError> {
     pyth_assert(
-        account.data_len() >= T::minimum_size(),
+        account.data_len() >= T::MINIMUM_SIZE,
         OracleError::AccountTooSmall.into(),
     )?;
 
@@ -96,7 +96,7 @@ pub fn initialize_pyth_account_checked<'a, T: PythAccount>(
     version: u32,
 ) -> Result<RefMut<'a, T>, ProgramError> {
     pyth_assert(
-        account.data_len() >= T::minimum_size(),
+        account.data_len() >= T::MINIMUM_SIZE,
         OracleError::AccountTooSmall.into(),
     )?;
     check_valid_fresh_account(account)?;

--- a/program/rust/src/tests/test_add_publisher.rs
+++ b/program/rust/src/tests/test_add_publisher.rs
@@ -56,7 +56,7 @@ fn test_add_publisher() {
 
     // Now give the price account enough lamports to be rent exempt
     **price_account.try_borrow_mut_lamports().unwrap() =
-        Rent::minimum_balance(&Rent::default(), PriceAccount::minimum_size());
+        Rent::minimum_balance(&Rent::default(), PriceAccount::MINIMUM_SIZE);
 
 
     assert!(process_instruction(

--- a/program/rust/src/tests/test_utils.rs
+++ b/program/rust/src/tests/test_utils.rs
@@ -43,8 +43,8 @@ impl AccountSetup {
     pub fn new<T: PythAccount>(owner: &Pubkey) -> Self {
         let key = Pubkey::new_unique();
         let owner = owner.clone();
-        let balance = Rent::minimum_balance(&Rent::default(), T::minimum_size());
-        let size = T::minimum_size();
+        let balance = Rent::minimum_balance(&Rent::default(), T::MINIMUM_SIZE);
+        let size = T::MINIMUM_SIZE;
         let data = [0; UPPER_BOUND_OF_ALL_ACCOUNT_SIZES];
         return AccountSetup {
             key,


### PR DESCRIPTION
I realized minimum_size can be a constant. This will allow to cleanup some other parts.