### PR TITLE
Port MAX_CI_DIVISOR and MAX_NUM_DECIMALS

### DIFF
--- a/program/c/src/oracle/oracle.h
+++ b/program/c/src/oracle/oracle.h
@@ -28,14 +28,9 @@ const uint64_t EXTRA_PUBLISHER_SPACE = 1000ULL;
 #define PC_PUBKEY_SIZE_64   (PC_PUBKEY_SIZE/sizeof(uint64_t))
 #define PC_MAP_TABLE_SIZE   640
 #define PC_COMP_SIZE         32
-// Bound on the range of the exponent in price accounts. This number is set such that the
-// PD-based EMA computation does not lose too much precision.
-#define PC_MAX_NUM_DECIMALS   8
+
 #define PC_PROD_ACC_SIZE    512
 #define PC_EXP_DECAY         -9
-// If ci > price / PC_MAX_CI_DIVISOR, set publisher status to unknown.
-// (e.g., 20 means ci must be < 5% of price)
-#define PC_MAX_CI_DIVISOR    20
 
 #ifndef PC_HEAP_START
 #define PC_HEAP_START (0x300000000)

--- a/program/rust/src/c_oracle_header.rs
+++ b/program/rust/src/c_oracle_header.rs
@@ -13,6 +13,14 @@ use std::mem::size_of;
 //things defined in bindings.h
 include!("../bindings.rs");
 
+
+/// If ci > price / PC_MAX_CI_DIVISOR, set publisher status to unknown.
+/// (e.g., 20 means ci must be < 5% of price)
+pub const MAX_CI_DIVISOR: i64 = 20;
+/// Bound on the range of the exponent in price accounts. This number is set such that the
+/// PD-based EMA computation does not lose too much precision.
+pub const MAX_NUM_DECIMALS: i32 = 8;
+
 /// The PythAccount trait's purpose is to attach constants to the 3 types of accounts that Pyth has
 /// (mapping, price, product). This allows less duplicated code, because now we can create generic
 /// functions to perform common checks on the accounts and to load and initialize the accounts.

--- a/program/rust/src/rust_oracle.rs
+++ b/program/rust/src/rust_oracle.rs
@@ -10,9 +10,9 @@ use crate::c_oracle_header::{
     PriceEma,
     PriceInfo,
     ProductAccount,
+    MAX_CI_DIVISOR,
     PC_COMP_SIZE,
     PC_MAP_TABLE_SIZE,
-    PC_MAX_CI_DIVISOR,
     PC_PROD_ACC_SIZE,
     PC_PTYPE_UNKNOWN,
     PC_STATUS_UNKNOWN,
@@ -273,7 +273,7 @@ pub fn upd_price(
     // Try to update the publisher's price
     if is_component_update(cmd_args)? {
         let mut status: u32 = cmd_args.status;
-        let mut threshold_conf = cmd_args.price / PC_MAX_CI_DIVISOR as i64;
+        let mut threshold_conf = cmd_args.price / MAX_CI_DIVISOR;
 
         if threshold_conf < 0 {
             threshold_conf = -threshold_conf;

--- a/program/rust/src/tests/test_init_price.rs
+++ b/program/rust/src/tests/test_init_price.rs
@@ -4,7 +4,7 @@ use solana_program::pubkey::Pubkey;
 
 use crate::c_oracle_header::{
     PriceAccount,
-    PC_MAX_NUM_DECIMALS,
+    MAX_NUM_DECIMALS,
     PC_VERSION,
 };
 use crate::deserialize::{
@@ -143,7 +143,7 @@ fn test_init_price() {
     price_account.is_signer = true;
     let cmd: InitPriceArgs = InitPriceArgs {
         header:     OracleCommand::InitPrice.into(),
-        exponent:   -(PC_MAX_NUM_DECIMALS as i32) - 1,
+        exponent:   -MAX_NUM_DECIMALS - 1,
         price_type: ptype,
     };
     let instruction_data = bytes_of::<InitPriceArgs>(&cmd);

--- a/program/rust/src/utils.rs
+++ b/program/rust/src/utils.rs
@@ -1,6 +1,6 @@
 use crate::c_oracle_header::{
     AccountHeader,
-    PC_MAX_NUM_DECIMALS,
+    MAX_NUM_DECIMALS,
 };
 use crate::deserialize::load_account_as;
 use crate::instruction::{
@@ -83,7 +83,7 @@ pub fn check_valid_fresh_account(account: &AccountInfo) -> Result<(), ProgramErr
 // Check that an exponent is within the range of permitted exponents for price accounts.
 pub fn check_exponent_range(expo: i32) -> Result<(), ProgramError> {
     pyth_assert(
-        expo >= -(PC_MAX_NUM_DECIMALS as i32) && expo <= PC_MAX_NUM_DECIMALS as i32,
+        (-MAX_NUM_DECIMALS..=MAX_NUM_DECIMALS).contains(&expo),
         ProgramError::InvalidArgument,
     )
 }


### PR DESCRIPTION
I want to move these constants to Rust.
They can be deleted from `oracle.h`. Additionally, we no longer have to use `as` conversions when they're used.