### PR TITLE
Check to see if price account exists in either network when handling subscribe_price_sched

### DIFF
--- a/pc/user.cpp
+++ b/pc/user.cpp
@@ -273,7 +273,12 @@ void user::parse_sub_price_sched( uint32_t tok, uint32_t itok )
     if ( 0 == (ntok = jp_.find_val( ptok, "account" ) ) ) break;
     pub_key pkey;
     pkey.init_from_text( jp_.get_str( ntok ) );
+
+    // Check to see if the price exists in either the primary or the secondary manager
     price *sptr = sptr_->get_price( pkey );
+    if ( !sptr && sptr_->has_secondary() ) {
+      sptr = sptr_->get_secondary()->get_price( pkey );
+    };
     if ( PC_UNLIKELY( !sptr ) ) { add_unknown_symbol(itok); return; }
 
     // add subscription


### PR DESCRIPTION
To ensure clients are able to subscribe to `price_sched` updates when only one network is connected at startup, `subscribe_price_sched` should check to see if the account is present in either network.