### PR TITLE
Gate sma with test flag

### DIFF
--- a/program/rust/src/time_machine_types.rs
+++ b/program/rust/src/time_machine_types.rs
@@ -39,12 +39,16 @@ pub struct DataPoint {
 
 impl PriceAccountWrapper {
     pub fn initialize_time_machine(&mut self) -> Result<(), OracleError> {
+        // This is only enabled in tests while in development
+        #[cfg(test)]
         self.time_machine
             .initialize(THIRTY_MINUTES, PC_MAX_SEND_LATENCY.into());
         Ok(())
     }
 
     pub fn add_price_to_time_machine(&mut self) -> Result<(), OracleError> {
+        // This is only enabled in tests while in development
+        #[cfg(test)]
         self.time_machine.add_datapoint( &DataPoint{
             previous_timestamp : self.price_data.prev_timestamp_,
             current_timestamp: self.price_data.timestamp_,

--- a/program/rust/src/time_machine_types.rs
+++ b/program/rust/src/time_machine_types.rs
@@ -39,16 +39,12 @@ pub struct DataPoint {
 
 impl PriceAccountWrapper {
     pub fn initialize_time_machine(&mut self) -> Result<(), OracleError> {
-        // This is only enabled in tests while in development
-        #[cfg(test)]
         self.time_machine
             .initialize(THIRTY_MINUTES, PC_MAX_SEND_LATENCY.into());
         Ok(())
     }
 
     pub fn add_price_to_time_machine(&mut self) -> Result<(), OracleError> {
-        // This is only enabled in tests while in development
-        #[cfg(test)]
         self.time_machine.add_datapoint( &DataPoint{
             previous_timestamp : self.price_data.prev_timestamp_,
             current_timestamp: self.price_data.timestamp_,


### PR DESCRIPTION
I'm refactoring the gating of the sma feature. To make sure we never go into this part of the code in production.
`resize_price_account` is still available but:
1. Requires a price account signature
2. If an account is resized our code keeps working, because our code only checks that `account.data.len() >= MINIMUM_SIZE`