### PR TITLE
Extra check from audit

### DIFF
--- a/program/rust/src/utils.rs
+++ b/program/rust/src/utils.rs
@@ -29,6 +29,7 @@ use solana_program::system_instruction::{
     assign,
     transfer,
 };
+use solana_program::system_program;
 use solana_program::sysvar::rent::Rent;
 use std::borrow::BorrowMut;
 
@@ -52,7 +53,7 @@ pub fn clear_account(account: &AccountInfo) -> Result<(), ProgramError> {
 }
 
 pub fn valid_funding_account(account: &AccountInfo) -> bool {
-    account.is_signer && account.is_writable
+    account.is_signer && account.is_writable && *account.owner == system_program::id()
 }
 
 pub fn check_valid_funding_account(account: &AccountInfo) -> Result<(), ProgramError> {


### PR DESCRIPTION
Check on the funding account from the internal audit.
I don't think there's ever a situation where funder is not owned by the system program. Even `executor_key` from the executor will be owned by system program.