### PR TITLE
Guibescos/transition to permissions

### DIFF
--- a/program/rust/src/lib.rs
+++ b/program/rust/src/lib.rs
@@ -1,8 +1,6 @@
 #![deny(warnings)]
 // Allow non upper case globals from C
 #![allow(non_upper_case_globals)]
-// Allow using the solana_program::entrypoint::deserialize function
-#![allow(clippy::not_unsafe_ptr_arg_deref)]
 
 mod c_oracle_header;
 mod deserialize;

--- a/program/rust/src/lib.rs
+++ b/program/rust/src/lib.rs
@@ -1,3 +1,4 @@
+#![deny(warnings)]
 // Allow non upper case globals from C
 #![allow(non_upper_case_globals)]
 

--- a/program/rust/src/lib.rs
+++ b/program/rust/src/lib.rs
@@ -1,4 +1,3 @@
-#![deny(warnings)]
 // Allow non upper case globals from C
 #![allow(non_upper_case_globals)]
 

--- a/program/rust/src/rust_oracle.rs
+++ b/program/rust/src/rust_oracle.rs
@@ -43,7 +43,6 @@ use crate::utils::{
     check_exponent_range,
     check_is_upgrade_authority_for_program,
     check_valid_funding_account,
-    check_valid_signable_account,
     check_valid_signable_account_or_permissioned_funding_account,
     check_valid_writable_account,
     get_rent,

--- a/program/rust/src/rust_oracle.rs
+++ b/program/rust/src/rust_oracle.rs
@@ -90,11 +90,12 @@ pub fn resize_price_account(
     accounts: &[AccountInfo],
     instruction_data: &[u8],
 ) -> ProgramResult {
-    let (funding_account, price_account, system_program, permissions_account_option) = match accounts {
-        [x, y, z] => Ok((x, y, z, None)),
-        [x, y, z, p] => Ok((x, y, z, Some(p))),
-        _ => Err(OracleError::InvalidNumberOfAccounts),
-    }?;
+    let (funding_account, price_account, system_program, permissions_account_option) =
+        match accounts {
+            [x, y, z] => Ok((x, y, z, None)),
+            [x, y, z, p] => Ok((x, y, z, Some(p))),
+            _ => Err(OracleError::InvalidNumberOfAccounts),
+        }?;
 
     let hdr = load::<CommandHeader>(instruction_data)?;
 
@@ -219,7 +220,7 @@ pub fn add_mapping(
         permissions_account_option,
         hdr,
     )?;
-    
+
     let mut cur_mapping = load_checked::<MappingAccount>(cur_mapping, hdr.version)?;
     pyth_assert(
         cur_mapping.number_of_products == PC_MAP_TABLE_SIZE
@@ -367,11 +368,12 @@ pub fn add_price(
     )?;
 
 
-    let (funding_account, product_account, price_account, permissions_account_option) = match accounts {
-        [x, y, z] => Ok((x, y, z, None)),
-        [x, y, z, p] => Ok((x, y, z, Some(p))),
-        _ => Err(OracleError::InvalidNumberOfAccounts),
-    }?;
+    let (funding_account, product_account, price_account, permissions_account_option) =
+        match accounts {
+            [x, y, z] => Ok((x, y, z, None)),
+            [x, y, z, p] => Ok((x, y, z, Some(p))),
+            _ => Err(OracleError::InvalidNumberOfAccounts),
+        }?;
 
     check_valid_funding_account(funding_account)?;
     check_valid_signable_account_or_permissioned_funding_account(
@@ -415,11 +417,12 @@ pub fn del_price(
     accounts: &[AccountInfo],
     instruction_data: &[u8],
 ) -> ProgramResult {
-    let (funding_account, product_account, price_account, permissions_account_option) = match accounts {
-        [w, x, y] => Ok((w, x, y, None)),
-        [w, x, y, p] => Ok((w, x, y, Some(p))),
-        _ => Err(OracleError::InvalidNumberOfAccounts),
-    }?;
+    let (funding_account, product_account, price_account, permissions_account_option) =
+        match accounts {
+            [w, x, y] => Ok((w, x, y, None)),
+            [w, x, y, p] => Ok((w, x, y, Some(p))),
+            _ => Err(OracleError::InvalidNumberOfAccounts),
+        }?;
 
     let cmd_args = load::<CommandHeader>(instruction_data)?;
 
@@ -429,18 +432,17 @@ pub fn del_price(
         product_account,
         funding_account,
         permissions_account_option,
-        &cmd_args,
+        cmd_args,
     )?;
     check_valid_signable_account_or_permissioned_funding_account(
         program_id,
         price_account,
         funding_account,
         permissions_account_option,
-        &cmd_args,
+        cmd_args,
     )?;
 
     {
-        
         let mut product_data = load_checked::<ProductAccount>(product_account, cmd_args.version)?;
         let price_data = load_checked::<PriceAccount>(price_account, cmd_args.version)?;
         pyth_assert(
@@ -654,11 +656,12 @@ pub fn add_product(
     accounts: &[AccountInfo],
     instruction_data: &[u8],
 ) -> ProgramResult {
-    let (funding_account, tail_mapping_account, new_product_account, permissions_account_option) = match accounts {
-        [x, y, z] => Ok((x, y, z, None)),
-        [x, y, z, p] => Ok((x, y, z, Some(p))),
-        _ => Err(OracleError::InvalidNumberOfAccounts),
-    }?;
+    let (funding_account, tail_mapping_account, new_product_account, permissions_account_option) =
+        match accounts {
+            [x, y, z] => Ok((x, y, z, None)),
+            [x, y, z, p] => Ok((x, y, z, Some(p))),
+            _ => Err(OracleError::InvalidNumberOfAccounts),
+        }?;
 
     let hdr = load::<CommandHeader>(instruction_data)?;
 
@@ -668,17 +671,17 @@ pub fn add_product(
         tail_mapping_account,
         funding_account,
         permissions_account_option,
-        &hdr,
+        hdr,
     )?;
     check_valid_signable_account_or_permissioned_funding_account(
         program_id,
         new_product_account,
         funding_account,
         permissions_account_option,
-        &hdr,
+        hdr,
     )?;
 
-   
+
     let mut mapping_data = load_checked::<MappingAccount>(tail_mapping_account, hdr.version)?;
     // The mapping account must have free space to add the product account
     pyth_assert(
@@ -720,10 +723,10 @@ pub fn upd_product(
         product_account,
         funding_account,
         permissions_account_option,
-        &hdr,
+        hdr,
     )?;
 
-    
+
     {
         // Validate that product_account contains the appropriate account header
         let mut _product_data = load_checked::<ProductAccount>(product_account, hdr.version)?;
@@ -814,11 +817,12 @@ pub fn del_product(
     accounts: &[AccountInfo],
     instruction_data: &[u8],
 ) -> ProgramResult {
-    let (funding_account, mapping_account, product_account, permissions_account_option) = match accounts {
-        [w, x, y] => Ok((w, x, y, None)),
-        [w, x, y, p] => Ok((w, x, y, Some(p))),
-        _ => Err(OracleError::InvalidNumberOfAccounts),
-    }?;
+    let (funding_account, mapping_account, product_account, permissions_account_option) =
+        match accounts {
+            [w, x, y] => Ok((w, x, y, None)),
+            [w, x, y, p] => Ok((w, x, y, Some(p))),
+            _ => Err(OracleError::InvalidNumberOfAccounts),
+        }?;
 
     let cmd_args = load::<CommandHeader>(instruction_data)?;
 
@@ -828,7 +832,7 @@ pub fn del_product(
         mapping_account,
         funding_account,
         permissions_account_option,
-        &cmd_args,
+        cmd_args,
     )?;
 
     check_valid_signable_account_or_permissioned_funding_account(
@@ -836,12 +840,11 @@ pub fn del_product(
         product_account,
         funding_account,
         permissions_account_option,
-        &cmd_args,
+        cmd_args,
     )?;
 
 
     {
-        
         let mut mapping_data = load_checked::<MappingAccount>(mapping_account, cmd_args.version)?;
         let product_data = load_checked::<ProductAccount>(product_account, cmd_args.version)?;
 

--- a/program/rust/src/tests/mod.rs
+++ b/program/rust/src/tests/mod.rs
@@ -8,6 +8,7 @@ mod test_del_product;
 mod test_del_publisher;
 mod test_init_mapping;
 mod test_init_price;
+mod test_permission_migration;
 mod test_resize_account;
 mod test_set_min_pub;
 mod test_sizes;

--- a/program/rust/src/tests/test_permission_migration.rs
+++ b/program/rust/src/tests/test_permission_migration.rs
@@ -3,14 +3,9 @@ use crate::c_oracle_header::{
     PermissionAccount,
     PriceAccount,
     ProductAccount,
-    PC_ACCTYPE_MAPPING,
-    PC_MAGIC,
     PC_VERSION,
 };
-use crate::deserialize::{
-    initialize_pyth_account_checked,
-    load_account_as,
-};
+use crate::deserialize::initialize_pyth_account_checked;
 use crate::error::OracleError;
 use crate::instruction::OracleCommand::{
     AddMapping,
@@ -36,11 +31,8 @@ use crate::instruction::{
 };
 use crate::processor::process_instruction;
 use crate::tests::test_utils::AccountSetup;
-use crate::utils::clear_account;
 use bytemuck::bytes_of;
 use solana_program::pubkey::Pubkey;
-use std::cell::RefCell;
-use std::rc::Rc;
 
 #[test]
 fn test_permission_migration() {
@@ -238,6 +230,7 @@ fn test_permission_migration() {
             &[
                 funding_account.clone(),
                 price_account.clone(),
+                price_account.clone(), // Mock system program
                 permissions_account.clone()
             ],
             bytes_of::<CommandHeader>(&ResizePriceAccount.into())

--- a/program/rust/src/tests/test_permission_migration.rs
+++ b/program/rust/src/tests/test_permission_migration.rs
@@ -1,0 +1,275 @@
+use crate::c_oracle_header::{
+    MappingAccount,
+    PermissionAccount,
+    PriceAccount,
+    ProductAccount,
+    PC_ACCTYPE_MAPPING,
+    PC_MAGIC,
+    PC_VERSION,
+};
+use crate::deserialize::{
+    initialize_pyth_account_checked,
+    load_account_as,
+};
+use crate::error::OracleError;
+use crate::instruction::OracleCommand::{
+    AddMapping,
+    AddPrice,
+    AddProduct,
+    AddPublisher,
+    DelPrice,
+    DelProduct,
+    DelPublisher,
+    InitMapping,
+    InitPrice,
+    ResizePriceAccount,
+    SetMinPub,
+    UpdProduct,
+};
+use crate::instruction::{
+    AddPriceArgs,
+    AddPublisherArgs,
+    CommandHeader,
+    DelPublisherArgs,
+    InitPriceArgs,
+    SetMinPubArgs,
+};
+use crate::processor::process_instruction;
+use crate::tests::test_utils::AccountSetup;
+use crate::utils::clear_account;
+use bytemuck::bytes_of;
+use solana_program::pubkey::Pubkey;
+use std::cell::RefCell;
+use std::rc::Rc;
+
+#[test]
+fn test_permission_migration() {
+    let program_id = Pubkey::new_unique();
+
+    let mut permissions_setup = AccountSetup::new_permission(&program_id);
+    let permissions_account = permissions_setup.to_account_info();
+
+    let mut funding_setup = AccountSetup::new_funding();
+    let funding_account = funding_setup.to_account_info();
+
+    let mut attacker_setup = AccountSetup::new_funding();
+    let attacker_account = attacker_setup.to_account_info();
+
+    let mut mapping_setup = AccountSetup::new::<MappingAccount>(&program_id);
+    let mut mapping_account = mapping_setup.to_account_info();
+
+    let mut next_mapping_setup = AccountSetup::new::<MappingAccount>(&program_id);
+    let mut next_mapping_account = next_mapping_setup.to_account_info();
+
+    let mut product_setup = AccountSetup::new::<ProductAccount>(&program_id);
+    let mut product_account = product_setup.to_account_info();
+
+    let mut price_setup = AccountSetup::new::<PriceAccount>(&program_id);
+    let mut price_account = price_setup.to_account_info();
+
+
+    product_account.is_signer = false;
+    mapping_account.is_signer = false;
+    price_account.is_signer = false;
+    next_mapping_account.is_signer = false;
+
+
+    {
+        let mut permissions_account_data =
+            initialize_pyth_account_checked::<PermissionAccount>(&permissions_account, PC_VERSION)
+                .unwrap();
+        permissions_account_data.master_authority = *funding_account.key;
+    }
+
+    assert_eq!(
+        process_instruction(
+            &program_id,
+            &[
+                attacker_account.clone(),
+                mapping_account.clone(),
+                next_mapping_account.clone(),
+                permissions_account.clone()
+            ],
+            bytes_of::<CommandHeader>(&AddMapping.into())
+        ),
+        Err(OracleError::PermissionViolation.into())
+    );
+
+
+    process_instruction(
+        &program_id,
+        &[
+            funding_account.clone(),
+            mapping_account.clone(),
+            permissions_account.clone(),
+        ],
+        bytes_of::<CommandHeader>(&InitMapping.into()),
+    )
+    .unwrap();
+
+    assert_eq!(
+        process_instruction(
+            &program_id,
+            &[
+                funding_account.clone(),
+                mapping_account.clone(),
+                next_mapping_account.clone(),
+                permissions_account.clone()
+            ],
+            bytes_of::<CommandHeader>(&AddMapping.into())
+        ),
+        Err(OracleError::PermissionViolation.into())
+    );
+
+    assert_eq!(
+        process_instruction(
+            &program_id,
+            &[
+                funding_account.clone(),
+                mapping_account.clone(),
+                product_account.clone(),
+                permissions_account.clone()
+            ],
+            bytes_of::<CommandHeader>(&AddProduct.into())
+        ),
+        Err(OracleError::PermissionViolation.into())
+    );
+
+    assert_eq!(
+        process_instruction(
+            &program_id,
+            &[
+                funding_account.clone(),
+                product_account.clone(),
+                permissions_account.clone()
+            ],
+            bytes_of::<CommandHeader>(&UpdProduct.into())
+        ),
+        Err(OracleError::PermissionViolation.into())
+    );
+
+    assert_eq!(
+        process_instruction(
+            &program_id,
+            &[
+                funding_account.clone(),
+                product_account.clone(),
+                price_account.clone(),
+                permissions_account.clone()
+            ],
+            bytes_of::<AddPriceArgs>(&AddPriceArgs {
+                header:     AddPrice.into(),
+                exponent:   -8,
+                price_type: 1,
+            })
+        ),
+        Err(OracleError::PermissionViolation.into())
+    );
+
+    assert_eq!(
+        process_instruction(
+            &program_id,
+            &[
+                funding_account.clone(),
+                price_account.clone(),
+                permissions_account.clone()
+            ],
+            bytes_of::<InitPriceArgs>(&InitPriceArgs {
+                header:     InitPrice.into(),
+                exponent:   -8,
+                price_type: 1,
+            })
+        ),
+        Err(OracleError::PermissionViolation.into())
+    );
+
+    assert_eq!(
+        process_instruction(
+            &program_id,
+            &[
+                funding_account.clone(),
+                price_account.clone(),
+                permissions_account.clone()
+            ],
+            bytes_of::<AddPublisherArgs>(&AddPublisherArgs {
+                header:    AddPublisher.into(),
+                publisher: Pubkey::new_unique(),
+            })
+        ),
+        Err(OracleError::PermissionViolation.into())
+    );
+
+    assert_eq!(
+        process_instruction(
+            &program_id,
+            &[
+                funding_account.clone(),
+                price_account.clone(),
+                permissions_account.clone()
+            ],
+            bytes_of::<DelPublisherArgs>(&DelPublisherArgs {
+                header:    DelPublisher.into(),
+                publisher: Pubkey::new_unique(),
+            })
+        ),
+        Err(OracleError::PermissionViolation.into())
+    );
+
+    assert_eq!(
+        process_instruction(
+            &program_id,
+            &[
+                funding_account.clone(),
+                price_account.clone(),
+                permissions_account.clone()
+            ],
+            bytes_of::<SetMinPubArgs>(&SetMinPubArgs {
+                header:             SetMinPub.into(),
+                minimum_publishers: 3,
+                unused_:            [0; 3],
+            })
+        ),
+        Err(OracleError::PermissionViolation.into())
+    );
+
+    assert_eq!(
+        process_instruction(
+            &program_id,
+            &[
+                funding_account.clone(),
+                price_account.clone(),
+                permissions_account.clone()
+            ],
+            bytes_of::<CommandHeader>(&ResizePriceAccount.into())
+        ),
+        Err(OracleError::PermissionViolation.into())
+    );
+
+    assert_eq!(
+        process_instruction(
+            &program_id,
+            &[
+                funding_account.clone(),
+                product_account.clone(),
+                price_account.clone(),
+                permissions_account.clone()
+            ],
+            bytes_of::<CommandHeader>(&DelPrice.into())
+        ),
+        Err(OracleError::PermissionViolation.into())
+    );
+
+    assert_eq!(
+        process_instruction(
+            &program_id,
+            &[
+                funding_account.clone(),
+                mapping_account.clone(),
+                product_account.clone(),
+                permissions_account.clone()
+            ],
+            bytes_of::<CommandHeader>(&DelProduct.into())
+        ),
+        Err(OracleError::PermissionViolation.into())
+    );
+}


### PR DESCRIPTION
Update all instructions that require account signatures to having the `PermissionAccount` checks.
It is backwards compatible and this PR doesn't try to define the permissions.