### PR TITLE
Add fPIC flag 

### DIFF
--- a/program/c/makefile
+++ b/program/c/makefile
@@ -7,6 +7,6 @@ cpyth-bpf:
 	bash -c "ar rcs target/libcpyth-bpf.a target/**/*.o"
 cpyth-native:
 #   Compile C code to system architecture for use by rust's cargo test
-	gcc -c ./src/oracle/native/upd_aggregate.c -o ./target/cpyth-native.o
+	gcc -c ./src/oracle/native/upd_aggregate.c -o ./target/cpyth-native.o -fPIC
 #   Bundle C code compiled to system architecture for use by rust's cargo test
 	ar rcs target/libcpyth-native.a ./target/cpyth-native.o


### PR DESCRIPTION
My code wasn't compiling on the RHEL vm. The compiler asked me to add this flag.
It only affects the tests, because cpyth-native.o is only used to test locally.
After reading online what the flag does, and seeing it's present in the `bpf.mk` makefile, I don't see the harm in adding it.