### PR TITLE
Reduce size of Oracle binary

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,8 @@
 [profile.release]
 opt-level = 2
-lto = true
+lto = "fat"
+codegen-units = 1
+strip = true
 
 [workspace]
 members = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,6 @@
 opt-level = 2
 lto = "fat"
 codegen-units = 1
-strip = true
 
 [workspace]
 members = [

--- a/program/rust/src/processor.rs
+++ b/program/rust/src/processor.rs
@@ -10,7 +10,6 @@ use crate::c_oracle_header::{
     command_t_e_cmd_del_publisher,
     command_t_e_cmd_init_mapping,
     command_t_e_cmd_init_price,
-    command_t_e_cmd_resize_price_account,
     command_t_e_cmd_set_min_pub,
     command_t_e_cmd_upd_price,
     command_t_e_cmd_upd_price_no_fail_on_error,
@@ -34,7 +33,6 @@ use crate::rust_oracle::{
     del_publisher,
     init_mapping,
     init_price,
-    resize_price_account,
     set_min_pub,
     upd_price,
     upd_price_no_fail_on_error,
@@ -63,9 +61,6 @@ pub fn process_instruction(
         }
         command_t_e_cmd_upd_price_no_fail_on_error => {
             upd_price_no_fail_on_error(program_id, accounts, instruction_data)
-        }
-        command_t_e_cmd_resize_price_account => {
-            resize_price_account(program_id, accounts, instruction_data)
         }
         command_t_e_cmd_add_price => add_price(program_id, accounts, instruction_data),
         command_t_e_cmd_init_mapping => init_mapping(program_id, accounts, instruction_data),

--- a/program/rust/src/rust_oracle.rs
+++ b/program/rust/src/rust_oracle.rs
@@ -10,16 +10,12 @@ use bytemuck::{
 use solana_program::account_info::AccountInfo;
 use solana_program::clock::Clock;
 use solana_program::entrypoint::ProgramResult;
-use solana_program::program::invoke;
 use solana_program::program_error::ProgramError;
 use solana_program::program_memory::{
     sol_memcpy,
     sol_memset,
 };
 use solana_program::pubkey::Pubkey;
-use solana_program::rent::Rent;
-use solana_program::system_instruction::transfer;
-use solana_program::system_program::check_id;
 use solana_program::sysvar::Sysvar;
 
 use crate::c_oracle_header::{
@@ -44,7 +40,6 @@ use crate::c_oracle_header::{
     PC_PROD_ACC_SIZE,
     PC_PTYPE_UNKNOWN,
     PC_STATUS_UNKNOWN,
-    PC_VERSION,
 };
 use crate::deserialize::{
     initialize_pyth_account_checked, /* TODO: This has a confusingly similar name to a Solana
@@ -52,7 +47,6 @@ use crate::deserialize::{
     load,
     load_checked,
 };
-use crate::time_machine_types::PriceAccountWrapper;
 use crate::utils::{
     check_exponent_range,
     check_valid_fresh_account,
@@ -68,11 +62,6 @@ use crate::utils::{
     read_pc_str_t,
     try_convert,
 };
-use crate::OracleError;
-
-const PRICE_T_SIZE: usize = size_of::<pc_price_t>();
-const PRICE_ACCOUNT_SIZE: usize = size_of::<PriceAccountWrapper>();
-
 
 #[cfg(target_arch = "bpf")]
 #[link(name = "cpyth-bpf")]
@@ -85,77 +74,6 @@ extern "C" {
 extern "C" {
     pub fn c_upd_aggregate(_input: *mut u8, clock_slot: u64, clock_timestamp: i64) -> bool;
 }
-
-fn send_lamports<'a>(
-    from: &AccountInfo<'a>,
-    to: &AccountInfo<'a>,
-    system_program: &AccountInfo<'a>,
-    amount: u64,
-) -> Result<(), ProgramError> {
-    let transfer_instruction = transfer(from.key, to.key, amount);
-    invoke(
-        &transfer_instruction,
-        &[from.clone(), to.clone(), system_program.clone()],
-    )?;
-    Ok(())
-}
-
-/// resizes a price account so that it fits the Time Machine
-/// key[0] funding account       [signer writable]
-/// key[1] price account         [Signer writable]
-/// key[2] system program        [readable]
-pub fn resize_price_account(
-    program_id: &Pubkey,
-    accounts: &[AccountInfo],
-    _instruction_data: &[u8],
-) -> ProgramResult {
-    let [funding_account_info, price_account_info, system_program] = match accounts {
-        [x, y, z] => Ok([x, y, z]),
-        _ => Err(ProgramError::InvalidArgument),
-    }?;
-
-    check_valid_funding_account(funding_account_info)?;
-    check_valid_signable_account(program_id, price_account_info, size_of::<pc_price_t>())?;
-    pyth_assert(
-        check_id(system_program.key),
-        OracleError::InvalidSystemAccount.into(),
-    )?;
-    //throw an error if not a price account
-    //need to makre sure it goes out of scope immediatly to avoid mutable borrow errors
-    {
-        load_checked::<pc_price_t>(price_account_info, PC_VERSION)?;
-    }
-    let account_len = price_account_info.try_data_len()?;
-    match account_len {
-        PRICE_T_SIZE => {
-            //ensure account is still rent exempt after resizing
-            let rent: Rent = Default::default();
-            let lamports_needed: u64 = rent
-                .minimum_balance(size_of::<PriceAccountWrapper>())
-                .saturating_sub(price_account_info.lamports());
-            if lamports_needed > 0 {
-                send_lamports(
-                    funding_account_info,
-                    price_account_info,
-                    system_program,
-                    lamports_needed,
-                )?;
-            }
-            //resize
-            //we do not need to zero initialize since this is the first time this memory
-            //is allocated
-            price_account_info.realloc(size_of::<PriceAccountWrapper>(), false)?;
-            //The load below would fail if the account was not a price account, reverting the whole
-            // transaction
-            let mut _price_account =
-                load_checked::<PriceAccountWrapper>(price_account_info, PC_VERSION)?;
-            Ok(())
-        }
-        PRICE_ACCOUNT_SIZE => Ok(()),
-        _ => Err(ProgramError::InvalidArgument),
-    }
-}
-
 
 /// initialize the first mapping account in a new linked-list of mapping accounts
 /// accounts[0] funding account           [signer writable]

--- a/program/rust/src/rust_oracle.rs
+++ b/program/rust/src/rust_oracle.rs
@@ -371,7 +371,7 @@ pub fn init_price(
         0,
         size_of::<pc_price_info_t>(),
     );
-    for i in 0..(price_data.comp_.len() as usize) {
+    for i in 0..price_data.comp_.len() {
         sol_memset(
             bytes_of_mut(&mut price_data.comp_[i].agg_),
             0,

--- a/program/rust/src/time_machine_types.rs
+++ b/program/rust/src/time_machine_types.rs
@@ -5,12 +5,10 @@ use crate::c_oracle_header::{
     PC_ACCTYPE_PRICE,
     PC_PRICE_T_COMP_OFFSET,
 };
-use crate::error::OracleError;
 use bytemuck::{
     Pod,
     Zeroable,
 };
-use solana_program::msg;
 
 
 #[derive(Debug, Clone, Copy)]
@@ -32,17 +30,6 @@ pub struct PriceAccountWrapper {
     pub extra_publisher_space: [u8; EXTRA_PUBLISHER_SPACE as usize],
     //TimeMachine
     pub time_machine:          TimeMachineWrapper,
-}
-impl PriceAccountWrapper {
-    pub fn initialize_time_machine(&mut self) -> Result<(), OracleError> {
-        msg!("implement me");
-        Ok(())
-    }
-
-    pub fn add_price_to_time_machine(&mut self) -> Result<(), OracleError> {
-        msg!("implement me");
-        Ok(())
-    }
 }
 
 #[cfg(target_endian = "little")]


### PR DESCRIPTION
This PR tweaks some compilation settings and removes some unused code, to reduce the size of the Oracle binary to 68576B.