### PR TITLE
Remove bincode

### DIFF
--- a/program/rust/Cargo.toml
+++ b/program/rust/Cargo.toml
@@ -14,7 +14,6 @@ bytemuck = "1.11.0"
 thiserror = "1.0"
 num-derive = "0.3"
 num-traits = "0.2"
-bincode = "1.3.3"
 
 [dev-dependencies]
 solana-program-test = "=1.13.3"
@@ -23,6 +22,7 @@ tokio = "1.14.1"
 hex = "0.3.1"
 quickcheck = "1"
 quickcheck_macros = "1"
+bincode = "1.3.3"
 
 [features]
 debug = []

--- a/program/rust/src/processor/upd_permissions.rs
+++ b/program/rust/src/processor/upd_permissions.rs
@@ -39,11 +39,19 @@ pub fn upd_permissions(
     accounts: &[AccountInfo],
     instruction_data: &[u8],
 ) -> ProgramResult {
+    let [funding_account, programdata_account, permissions_account, system_program] = match accounts
+    {
+        [w, x, y, z] => Ok([w, x, y, z]),
+        _ => Err(OracleError::InvalidNumberOfAccounts),
+    }?;
+
+    let cmd_args = load::<UpdPermissionsArgs>(instruction_data)?;
 
     check_valid_funding_account(funding_account)?;
     check_is_upgrade_authority_for_program(funding_account, programdata_account, program_id)?;
 
     let (permission_pda_address, bump_seed) =
+        Pubkey::find_program_address(&[PERMISSIONS_SEED.as_bytes()], program_id);
     pyth_assert(
         permission_pda_address == *permissions_account.key,
         OracleError::InvalidPda.into(),

--- a/program/rust/src/processor/upd_permissions.rs
+++ b/program/rust/src/processor/upd_permissions.rs
@@ -39,19 +39,11 @@ pub fn upd_permissions(
     accounts: &[AccountInfo],
     instruction_data: &[u8],
 ) -> ProgramResult {
-    let [funding_account, programdata_account, permissions_account, system_program] = match accounts
-    {
-        [w, x, y, z] => Ok([w, x, y, z]),
-        _ => Err(OracleError::InvalidNumberOfAccounts),
-    }?;
-
-    let cmd_args = load::<UpdPermissionsArgs>(instruction_data)?;
 
     check_valid_funding_account(funding_account)?;
     check_is_upgrade_authority_for_program(funding_account, programdata_account, program_id)?;
 
     let (permission_pda_address, bump_seed) =
-        Pubkey::find_program_address(&[PERMISSIONS_SEED.as_bytes()], program_id);
     pyth_assert(
         permission_pda_address == *permissions_account.key,
         OracleError::InvalidPda.into(),

--- a/program/rust/src/utils.rs
+++ b/program/rust/src/utils.rs
@@ -1,3 +1,5 @@
+use solana_program::bpf_loader_upgradeable;
+
 use {
     crate::{
         accounts::{
@@ -225,12 +227,6 @@ pub fn check_is_upgrade_authority_for_program(
     // 1. programdata_account is actually this program's buffer
     let (programdata_address, _) =
         Pubkey::find_program_address(&[&program_id.to_bytes()], &bpf_loader_upgradeable::id());
-
-    pyth_assert(
-        programdata_address.eq(programdata_account.key),
-        OracleError::InvalidUpgradeAuthority.into(),
-    )?;
-
 
     // 2. upgrade_authority_account is actually the authority inside programdata_account
     if let UpgradeableLoaderState::ProgramData {

--- a/program/rust/src/utils.rs
+++ b/program/rust/src/utils.rs
@@ -1,5 +1,3 @@
-use solana_program::bpf_loader_upgradeable;
-
 use {
     crate::{
         accounts::{
@@ -227,6 +225,12 @@ pub fn check_is_upgrade_authority_for_program(
     // 1. programdata_account is actually this program's buffer
     let (programdata_address, _) =
         Pubkey::find_program_address(&[&program_id.to_bytes()], &bpf_loader_upgradeable::id());
+
+    pyth_assert(
+        programdata_address.eq(programdata_account.key),
+        OracleError::InvalidUpgradeAuthority.into(),
+    )?;
+
 
     // 2. upgrade_authority_account is actually the authority inside programdata_account
     if let UpgradeableLoaderState::ProgramData {

--- a/program/rust/src/utils.rs
+++ b/program/rust/src/utils.rs
@@ -218,12 +218,16 @@ pub fn is_component_update(cmd_args: &UpdPriceArgs) -> Result<bool, OracleError>
 #[repr(C)]
 #[derive(Pod, Zeroable, Copy, Clone)]
 struct ProgramdataAccount {
+    /// 3 is the variant for programdata
     pub account_type:          u32,
-    pub unused1:               u32,
-    pub unused2:               u32,
+    /// Space for slot of last upgrade (we don't use this field)
+    pub slot:                  [u32; 2],
+    /// 0 if immutable, 1 if has upgrade authority
     pub has_upgrade_authority: u8,
+    /// Upgrade authority of the program
     pub upgrade_authority:     Pubkey,
-    pub unused3:               [u8; 3],
+    /// Unused field needed for this struct to be Pod
+    pub unused:                [u8; 3],
 }
 
 /// Check that `programdata_account` is actually the buffer for `program_id`.


### PR DESCRIPTION
Remove bincode.  We are forced to use bytemuck to deserialize the programdata account.
This a big size gain : 170k -> 99k