### PR TITLE
Fix solana dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,8 +106,6 @@ root@pyth-dev# usermod -u 1002 -g 1004 -s /bin/bash pyth
 
 Finally, in docker extension inside VS Code click right and choose "Attach VS Code". If you're using a remote host in VS Code make sure to let this connection be open.
 
-To get best experience from C++ IntelliSense, open entire `/home/pyth` in VS Code to include `solana` directory in home for lookup directories.
-
 ### pre-commit hooks
 pre-commit is a tool that checks and fixes simple issues (formatting, ...) before each commit. You can install it by following [their website](https://pre-commit.com/). In order to enable checks for this repo run `pre-commit install` from command-line in the root of this repo.
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -40,7 +40,7 @@ RUN useradd -m pyth
 # Fixes a bug in the solana docker image
 # https://github.com/solana-labs/solana/issues/20577
 RUN mkdir /usr/bin/sdk/bpf/dependencies \
-    && chmod 777 /usr/bin/sdk/bpf/dependencies
+    && chmod -R 777 /usr/bin/
 
 
 USER pyth

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -61,9 +61,7 @@ COPY --chown=pyth:pyth . pyth-client/
 RUN cd pyth-client && ./scripts/build.sh
 
 RUN ./pyth-client/scripts/get-bpf-tools.sh
-# Copy solana sdk and apply patch.
-RUN mkdir solana
-RUN cp -a /usr/bin/sdk solana
+# Apply patch to solana
 RUN ./pyth-client/scripts/patch-solana.sh
 
 # Build and test the oracle program.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -40,7 +40,7 @@ RUN useradd -m pyth
 # Fixes a bug in the solana docker image
 # https://github.com/solana-labs/solana/issues/20577
 RUN mkdir /usr/bin/sdk/bpf/dependencies \
-    && chmod -R 777 /usr/bin/
+    && chmod -R 777 /usr/bin/sdk/bpf
 
 
 USER pyth

--- a/pctest/setup_local.sh
+++ b/pctest/setup_local.sh
@@ -2,7 +2,8 @@
 
 PYTH=./pyth
 PYTH_ADMIN=./pyth_admin
-SOLANA=../../solana/target/release/solana
+SOLANA_DIR="$(dirname $(which cargo-build-bpf))"
+SOLANA="$SOLANA_DIR/solana"
 SOL_OPT="-u localhost --commitment finalized"
 RPC="-r localhost"
 FINAL="-c finalized"

--- a/pctest/setup_pub.sh
+++ b/pctest/setup_pub.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
 
 PYTH=./pyth
-SOLANA=../../solana/target/release/solana
-SOLANA_KEYGEN=../../solana/target/release/solana-keygen
+SOLANA_DIR="$(dirname $(which cargo-build-bpf))"
+SOLANA="$SOLANA_DIR/solana"
+SOLANA_KEYGEN="$SOLANA_DIR/solana-keygen"
+
 SOL_OPT="-u localhost --commitment finalized"
 RPC="-r localhost"
 FINAL="-c finalized"

--- a/program/c/makefile
+++ b/program/c/makefile
@@ -1,5 +1,5 @@
 OUT_DIR := ./target
-SOLANA := "$(dirname $(which cargo-build-bpf))"
+SOLANA := $(shell dirname $(shell which cargo-build-bpf))
 include $(SOLANA)/sdk/bpf/c/bpf.mk
 
 cpyth-bpf:

--- a/program/c/makefile
+++ b/program/c/makefile
@@ -1,5 +1,5 @@
 OUT_DIR := ./target
-SOLANA := ../../../solana
+SOLANA := "$(dirname $(which cargo-build-bpf))"
 include $(SOLANA)/sdk/bpf/c/bpf.mk
 
 cpyth-bpf:

--- a/program/rust/build.rs
+++ b/program/rust/build.rs
@@ -21,7 +21,7 @@ fn main() {
         .expect("Couldn't write bindings!");
 }
 
-/// Find the Solana header file for bindgen
+/// Find the Solana C header bindgen
 fn get_solana_inc_path() -> PathBuf {
     let which_stdout = Command::new("which")
         .args(["cargo-build-bpf"])

--- a/program/rust/build.rs
+++ b/program/rust/build.rs
@@ -1,11 +1,17 @@
-use bindgen::Builder;
+use {
+    bindgen::Builder,
+    std::{
+        path::PathBuf,
+        process::Command,
+    },
+};
 
 fn main() {
     println!("cargo:rustc-link-search=./program/c/target");
 
     // Generate and write bindings
     let bindings = Builder::default()
-        .clang_arg("-I../../../solana/sdk/bpf/c/inc/")
+        .clang_arg(format!("-I{:}", get_solana_inc_path().display()))
         .header("./src/bindings.h")
         .rustfmt_bindings(true)
         .generate()
@@ -13,4 +19,18 @@ fn main() {
     bindings
         .write_to_file("./bindings.rs")
         .expect("Couldn't write bindings!");
+}
+
+/// Find the Solana header file for bindgen
+fn get_solana_inc_path() -> PathBuf {
+    let which_stdout = Command::new("which")
+        .args(["cargo-build-bpf"])
+        .output()
+        .unwrap()
+        .stdout;
+    let mut path = PathBuf::new();
+    path.push(std::str::from_utf8(&which_stdout).unwrap());
+    path.pop(); //
+    path.push("sdk/bpf/c/inc/");
+    path
 }

--- a/scripts/build-bpf.sh
+++ b/scripts/build-bpf.sh
@@ -31,10 +31,10 @@ make cpyth-native
 rm ./target/*-keypair.json
 
 
-# #build Rust and link it with C
+#build Rust and link it with C
 cd "${PYTH_DIR}"
-# cargo clean
-# cargo test-bpf
+cargo clean
+cargo test-bpf
 cargo clean
 cargo build-bpf
 

--- a/scripts/build-bpf.sh
+++ b/scripts/build-bpf.sh
@@ -31,10 +31,10 @@ make cpyth-native
 rm ./target/*-keypair.json
 
 
-#build Rust and link it with C
+# #build Rust and link it with C
 cd "${PYTH_DIR}"
-cargo clean
-cargo test-bpf
+# cargo clean
+# cargo test-bpf
 cargo clean
 cargo build-bpf
 

--- a/scripts/patch-solana.sh
+++ b/scripts/patch-solana.sh
@@ -10,8 +10,7 @@ set -eu
 
 THIS_DIR="$( dirname "${BASH_SOURCE[0]}" )"
 THIS_DIR="$( cd "${THIS_DIR}" && pwd )"
-SOLANA="${SOLANA:-$THIS_DIR/../../solana}"
-SOLANA="$( cd "${SOLANA}" && pwd )"
+SOLANA="$(dirname $(which cargo-build-bpf))"
 
 set -x
 cd "${SOLANA}"


### PR DESCRIPTION
The goal of this PR is fixing an annoying quirk of the repo that meant you had to the `pyth_client` repo and the `solana` repo side to side in the same folder. The trick is we can find the solana local installation by doing `which cargo-build-bpf`. This is inspired by https://github.com/guibescos/example-helloworld .

Resolving the solana installation ended up a little bit dirty in `build.rs` because bindgen needs to find the solana C headers. This will get better when we get rid of the C headers.