### PR TITLE
Use custom bpf-tools

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -62,7 +62,7 @@ RUN pip3 install solana
 # Build off-chain binaries.
 RUN cd pyth-client && ./scripts/build.sh
 
-
+RUN ./pyth-client/scripts/get-bpf-tools.sh
 # Copy solana sdk and apply patch.
 RUN mkdir solana
 RUN cp -a /usr/bin/sdk solana

--- a/scripts/get-bpf-tools.sh
+++ b/scripts/get-bpf-tools.sh
@@ -1,8 +1,12 @@
+#!/usr/bin/env bash
+#
 # The goal of this script is downloading our own version of bpf/sbf tools. When cargo-build-bpf/sbf gets called
 # https://github.com/solana-labs/sbf-tools/releases/download/v1.29/solana-bpf-tools-linux.tar.bz2 gets downloaded, extracted and linked as a toolchain.
 # This script is meant to override that behavior and use another version of bpf/sbf-tools.
 # Using a custom version of bpf/sbf-tools allows our use of -Z build-std=std,panic_abort flags that make the binary smaller. These flags compile the std library from scratch.
 # If solana fixes bpf/sbf-tools, we can revert back to the default behavior (once this PR https://github.com/solana-labs/cargo/pull/1 gets merged and released)
+set -eux
+
 curl https://github.com/guibescos/sbf-tools/releases/download/v1.29.1/solana-bpf-tools-linux.tar.bz2 --output solana-bpf-tools-linux.tar.bz2 -L
 mkdir -p ~/.cache/solana/v1.29/bpf-tools/
 tar -xf solana-bpf-tools-linux.tar.bz2 -C ~/.cache/solana/v1.29/bpf-tools/

--- a/scripts/get-bpf-tools.sh
+++ b/scripts/get-bpf-tools.sh
@@ -1,8 +1,8 @@
-# The goal of this script is downloading our own version of bpf/sbf tools. When cargo-build-bpf gets called
-# https://github.com/solana-labs/sbf-tools/releases/download/v1.29/solana-bpf-tools-linux.tar.bz2 get downloaded extracted and linked.
-# This script is meant to override that behavior and use another version of bpf-tools.
-# Using a custom version of bpf-tools allows our use of -Z build-std=std,panic_abort flags that make the binary smaller
-# If solana fixes bpf-tools, we can revert back to the default behavior (PR : https://github.com/solana-labs/cargo/pull/1)
+# The goal of this script is downloading our own version of bpf/sbf tools. When cargo-build-bpf/sbf gets called
+# https://github.com/solana-labs/sbf-tools/releases/download/v1.29/solana-bpf-tools-linux.tar.bz2 gets downloaded, extracted and linked as a toolchain.
+# This script is meant to override that behavior and use another version of bpf/sbf-tools.
+# Using a custom version of bpf/sbf-tools allows our use of -Z build-std=std,panic_abort flags that make the binary smaller. These flags compile the std library from scratch.
+# If solana fixes bpf/sbf-tools, we can revert back to the default behavior (once this PR https://github.com/solana-labs/cargo/pull/1 gets merged and released)
 curl https://github.com/guibescos/sbf-tools/releases/download/v1.29.1/solana-bpf-tools-linux.tar.bz2 --output solana-bpf-tools-linux.tar.bz2 -L
 mkdir -p ~/.cache/solana/v1.29/bpf-tools/
 tar -xf solana-bpf-tools-linux.tar.bz2 -C ~/.cache/solana/v1.29/bpf-tools/

--- a/scripts/get-bpf-tools.sh
+++ b/scripts/get-bpf-tools.sh
@@ -1,0 +1,10 @@
+# The goal of this script is downloading our own version of bpf/sbf tools. When cargo-build-bpf gets called
+# https://github.com/solana-labs/sbf-tools/releases/download/v1.29/solana-bpf-tools-linux.tar.bz2 get downloaded extracted and linked.
+# This script is meant to override that behavior and use another version of bpf-tools.
+# Using a custom version of bpf-tools allows our use of -Z build-std=std,panic_abort flags that make the binary smaller
+# If solana fixes bpf-tools, we can revert back to the default behavior (PR : https://github.com/solana-labs/cargo/pull/1)
+curl https://github.com/guibescos/sbf-tools/releases/download/v1.29.1/solana-bpf-tools-linux.tar.bz2 --output solana-bpf-tools-linux.tar.bz2 -L
+mkdir -p ~/.cache/solana/v1.29/bpf-tools/
+tar -xf solana-bpf-tools-linux.tar.bz2 -C ~/.cache/solana/v1.29/bpf-tools/
+rm solana-bpf-tools-linux.tar.bz2
+rustup toolchain link bpf ~/.cache/solana/v1.29/bpf-tools/rust

--- a/scripts/get-bpf-tools.sh
+++ b/scripts/get-bpf-tools.sh
@@ -7,4 +7,13 @@ curl https://github.com/guibescos/sbf-tools/releases/download/v1.29.1/solana-bpf
 mkdir -p ~/.cache/solana/v1.29/bpf-tools/
 tar -xf solana-bpf-tools-linux.tar.bz2 -C ~/.cache/solana/v1.29/bpf-tools/
 rm solana-bpf-tools-linux.tar.bz2
+
+# Source cargo
+if ! which cargo 2> /dev/null
+then
+  # shellcheck disable=SC1090
+  source "${CARGO_HOME:-$HOME/.cargo}/env"
+fi
+
+# Link the toolchain for future use
 rustup toolchain link bpf ~/.cache/solana/v1.29/bpf-tools/rust


### PR DESCRIPTION
With the current solana-labs bpf-tools (the toolchain that builds bpf programs), the flags `-Z build-std=std,panic_abort` don't work. These flags compile the standard rust library from scratch and make the program smaller. 

There is evidence that the solana team plans to release a version that support this : https://github.com/solana-labs/solana/blob/9f370475d40dbe68f1a51d34fc3df07e5327d6c3/sdk/cargo-build-sbf/src/main.rs#L625

This PR is meant to make the repo use a fork of bpf-tools instead of the solana-labs release. The only difference between the my fork and solana-labs is that my fork uses https://github.com/solana-labs/compiler-builtins/tree/sbf-tools-v1.30 instead of  https://github.com/solana-labs/compiler-builtins/tree/bpf-tools-v1.27 (a package bump basically) . 

TLDR : I think the solana team is gonna make a release eventually enabling what I want to do (the changes have made it to the master branch of solana but not the releases yet) but I don't really want to wait.

