### PR TITLE
Add compilation flags and check size in CI

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -66,6 +66,7 @@ RUN ./pyth-client/scripts/patch-solana.sh
 
 # Build and test the oracle program.
 RUN cd pyth-client && ./scripts/build-bpf.sh .
+RUN cd pyth-client && ./scripts/check-size.sh
 # Run aggregation logic tests
 RUN cd pyth-client && ./scripts/run-aggregation-tests.sh
 RUN /bin/bash -l -c "pytest-3 --pyargs pyth"

--- a/scripts/build-bpf.sh
+++ b/scripts/build-bpf.sh
@@ -31,10 +31,10 @@ make cpyth-native
 rm ./target/*-keypair.json
 
 
-# #build Rust and link it with C
+#build Rust and link it with C
 cd "${PYTH_DIR}"
-# cargo clean
-# cargo test-bpf
+cargo clean
+cargo test-bpf
 cargo clean
 cargo build-bpf
 

--- a/scripts/build-bpf.sh
+++ b/scripts/build-bpf.sh
@@ -34,9 +34,9 @@ rm ./target/*-keypair.json
 #build Rust and link it with C
 cd "${PYTH_DIR}"
 cargo clean
-cargo test-bpf
+cargo-test-bpf
 cargo clean
-cargo build-bpf
+cargo-build-bpf -- -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort
 
 sha256sum ./target/**/*.so
 

--- a/scripts/build-bpf.sh
+++ b/scripts/build-bpf.sh
@@ -31,10 +31,10 @@ make cpyth-native
 rm ./target/*-keypair.json
 
 
-#build Rust and link it with C
+# #build Rust and link it with C
 cd "${PYTH_DIR}"
-cargo clean
-cargo test-bpf
+# cargo clean
+# cargo test-bpf
 cargo clean
 cargo build-bpf
 

--- a/scripts/check-size.sh
+++ b/scripts/check-size.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+#
+# While Solana doesn't support resizing programs, the oracle binary needs to be smaller than 81760 bytes
+ORACLE_SIZE=$(wc -c ./target/deploy/pyth_oracle.so | awk '{print $1}')
+if [ $ORACLE_SIZE -lt 81760 ]
+then
+    echo "Size of pyth_oracle.so is small enough to be deployed to mainnet."
+    echo $ORACLE_SIZE
+else
+    echo "Size of pyth_oracle.so is too big to be deployed to mainnet."
+    echo $ORACLE_SIZE
+    exit 1
+fi


### PR DESCRIPTION
The goal of this PR : 
- Add the flags `-Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort` to the compilation of the oracle. This flags compile the rust std library instead of using a rebuilt binary and disable panic tracebacks.
- Add a script that checks the size of the program for CI against the hardcoded size of the onchain account.

Once this PR gets merged, it'll fit onchain!