### PR TITLE
Guibescos/add set min pub to security auth

### DIFF
--- a/program/rust/src/accounts/permission.rs
+++ b/program/rust/src/accounts/permission.rs
@@ -46,6 +46,7 @@ impl PermissionAccount {
         #[allow(clippy::match_like_matches_macro)]
         match (*key, command) {
             (pubkey, _) if pubkey == self.master_authority => true,
+            (pubkey, OracleCommand::SetMinPub) if pubkey == self.security_authority => true,
             _ => false,
         }
     }

--- a/program/rust/src/tests/test_permission_migration.rs
+++ b/program/rust/src/tests/test_permission_migration.rs
@@ -274,6 +274,7 @@ fn test_permission_migration() {
     );
 
 
+    // Security authority can change minimum number of publishers
     process_instruction(
         &program_id,
         &[
@@ -292,6 +293,7 @@ fn test_permission_migration() {
     )
     .unwrap();
 
+    // Security authority can't add publishers
     assert_eq!(
         process_instruction(
             &program_id,

--- a/program/rust/src/tests/test_permission_migration.rs
+++ b/program/rust/src/tests/test_permission_migration.rs
@@ -16,7 +16,6 @@ use {
             DelPublisherArgs,
             InitPriceArgs,
             OracleCommand::{
-                self,
                 AddMapping,
                 AddPrice,
                 AddProduct,
@@ -35,7 +34,6 @@ use {
         tests::test_utils::AccountSetup,
     },
     bytemuck::bytes_of,
-    num_traits::ToPrimitive,
     solana_program::pubkey::Pubkey,
 };
 
@@ -283,10 +281,7 @@ fn test_permission_migration() {
             permissions_account.clone(),
         ],
         bytes_of::<SetMinPubArgs>(&SetMinPubArgs {
-            header:             CommandHeader {
-                version: PC_VERSION,
-                command: OracleCommand::SetMinPub.to_i32().unwrap(),
-            },
+            header:             SetMinPub.into(),
             minimum_publishers: 5,
             unused_:            [0; 3],
         }),


### PR DESCRIPTION
I want to add `SetMinPub` capabilities to the `security_authority` for our automation MVP.