### PR TITLE
Default value of 20 for min pub

### DIFF
--- a/program/rust/src/c_oracle_header.rs
+++ b/program/rust/src/c_oracle_header.rs
@@ -12,3 +12,4 @@ pub const MAX_CI_DIVISOR: i64 = 3;
 /// Bound on the range of the exponent in price accounts. This number is set such that the
 /// PD-based EMA computation does not lose too much precision.
 pub const MAX_NUM_DECIMALS: i32 = 8;
+pub const PRICE_ACCOUNT_DEFAULT_MIN_PUB: u8 = 20;

--- a/program/rust/src/processor/add_price.rs
+++ b/program/rust/src/processor/add_price.rs
@@ -76,6 +76,7 @@ pub fn add_price(
     price_data.price_type = cmd_args.price_type;
     price_data.product_account = *product_account.key;
     price_data.next_price_account = product_data.first_price_account;
+    price_data.min_pub_ = 20;
     product_data.first_price_account = *price_account.key;
 
     Ok(())

--- a/program/rust/src/processor/add_price.rs
+++ b/program/rust/src/processor/add_price.rs
@@ -5,7 +5,10 @@ use {
             ProductAccount,
             PythAccount,
         },
-        c_oracle_header::PC_PTYPE_UNKNOWN,
+        c_oracle_header::{
+            PC_PTYPE_UNKNOWN,
+            PRICE_ACCOUNT_DEFAULT_MIN_PUB,
+        },
         deserialize::{
             load,
             load_checked,
@@ -76,7 +79,7 @@ pub fn add_price(
     price_data.price_type = cmd_args.price_type;
     price_data.product_account = *product_account.key;
     price_data.next_price_account = product_data.first_price_account;
-    price_data.min_pub_ = 20;
+    price_data.min_pub_ = PRICE_ACCOUNT_DEFAULT_MIN_PUB;
     product_data.first_price_account = *price_account.key;
 
     Ok(())

--- a/program/rust/src/tests/test_add_price.rs
+++ b/program/rust/src/tests/test_add_price.rs
@@ -7,7 +7,10 @@ use {
             ProductAccount,
             PythAccount,
         },
-        c_oracle_header::PC_VERSION,
+        c_oracle_header::{
+            PC_VERSION,
+            PRICE_ACCOUNT_DEFAULT_MIN_PUB,
+        },
         deserialize::load_checked,
         error::OracleError,
         instruction::{
@@ -82,7 +85,7 @@ fn test_add_price() {
         let product_data = load_checked::<ProductAccount>(&product_account, PC_VERSION).unwrap();
         assert_eq!(price_data.exponent, 1);
         assert_eq!(price_data.price_type, 1);
-        assert_eq!(price_data.min_pub_, 20);
+        assert_eq!(price_data.min_pub_, PRICE_ACCOUNT_DEFAULT_MIN_PUB);
         assert!(price_data.product_account == *product_account.key);
         assert!(price_data.next_price_account == Pubkey::default());
         assert!(product_data.first_price_account == *price_account.key);
@@ -104,7 +107,7 @@ fn test_add_price() {
         let product_data = load_checked::<ProductAccount>(&product_account, PC_VERSION).unwrap();
         assert_eq!(price_data_2.exponent, 1);
         assert_eq!(price_data_2.price_type, 1);
-        assert_eq!(price_data_2.min_pub_, 20);
+        assert_eq!(price_data_2.min_pub_, PRICE_ACCOUNT_DEFAULT_MIN_PUB);
         assert!(price_data_2.product_account == *product_account.key);
         assert!(price_data_2.next_price_account == *price_account.key);
         assert!(product_data.first_price_account == *price_account_2.key);

--- a/program/rust/src/tests/test_add_price.rs
+++ b/program/rust/src/tests/test_add_price.rs
@@ -82,6 +82,7 @@ fn test_add_price() {
         let product_data = load_checked::<ProductAccount>(&product_account, PC_VERSION).unwrap();
         assert_eq!(price_data.exponent, 1);
         assert_eq!(price_data.price_type, 1);
+        assert_eq!(price_data.min_pub_, 20);
         assert!(price_data.product_account == *product_account.key);
         assert!(price_data.next_price_account == Pubkey::default());
         assert!(product_data.first_price_account == *price_account.key);
@@ -103,6 +104,7 @@ fn test_add_price() {
         let product_data = load_checked::<ProductAccount>(&product_account, PC_VERSION).unwrap();
         assert_eq!(price_data_2.exponent, 1);
         assert_eq!(price_data_2.price_type, 1);
+        assert_eq!(price_data_2.min_pub_, 20);
         assert!(price_data_2.product_account == *product_account.key);
         assert!(price_data_2.next_price_account == *price_account.key);
         assert!(product_data.first_price_account == *price_account_2.key);


### PR DESCRIPTION
A lot of price feeds have been created in the past with min_pub equal to 0, leading to protocols thinking the price is live when it's not.

The goal is changing the default behavior so it's less error prone. By default price accounts will have min_pub equal to 20.