### PR TITLE
Add new status flag for data providers kicked out of aggregate

### DIFF
--- a/program/c/src/oracle/oracle.h
+++ b/program/c/src/oracle/oracle.h
@@ -45,6 +45,7 @@ const uint64_t EXTRA_PUBLISHER_SPACE = 3072ULL;
 #define PC_STATUS_TRADING     1
 #define PC_STATUS_HALTED      2
 #define PC_STATUS_AUCTION     3
+#define PC_STATUS_IGNORED     4
 
 // account types
 #define PC_ACCTYPE_MAPPING    1

--- a/program/rust/src/processor/upd_price.rs
+++ b/program/rust/src/processor/upd_price.rs
@@ -6,7 +6,7 @@ use {
         },
         c_oracle_header::{
             MAX_CI_DIVISOR,
-            PC_STATUS_UNKNOWN,
+            PC_STATUS_IGNORED,
         },
         deserialize::{
             load,
@@ -151,7 +151,7 @@ pub fn upd_price(
         }
 
         if cmd_args.confidence > try_convert::<_, u64>(threshold_conf)? {
-            status = PC_STATUS_UNKNOWN
+            status = PC_STATUS_IGNORED
         }
 
         {

--- a/program/rust/src/tests/test_upd_price.rs
+++ b/program/rust/src/tests/test_upd_price.rs
@@ -5,6 +5,7 @@ use {
             PythAccount,
         },
         c_oracle_header::{
+            PC_STATUS_IGNORED,
             PC_STATUS_TRADING,
             PC_STATUS_UNKNOWN,
             PC_VERSION,
@@ -243,7 +244,7 @@ fn test_upd_price() {
         assert_eq!(price_data.comp_[0].latest_.price_, 50);
         assert_eq!(price_data.comp_[0].latest_.conf_, 20);
         assert_eq!(price_data.comp_[0].latest_.pub_slot_, 5);
-        assert_eq!(price_data.comp_[0].latest_.status_, PC_STATUS_UNKNOWN);
+        assert_eq!(price_data.comp_[0].latest_.status_, PC_STATUS_IGNORED);
         assert_eq!(price_data.valid_slot_, 5);
         assert_eq!(price_data.agg_.pub_slot_, 6);
         assert_eq!(price_data.agg_.price_, 81);
@@ -270,7 +271,7 @@ fn test_upd_price() {
         assert_eq!(price_data.comp_[0].latest_.price_, 50);
         assert_eq!(price_data.comp_[0].latest_.conf_, 20);
         assert_eq!(price_data.comp_[0].latest_.pub_slot_, 6);
-        assert_eq!(price_data.comp_[0].latest_.status_, PC_STATUS_UNKNOWN);
+        assert_eq!(price_data.comp_[0].latest_.status_, PC_STATUS_IGNORED);
         assert_eq!(price_data.valid_slot_, 6);
         assert_eq!(price_data.agg_.pub_slot_, 7);
         assert_eq!(price_data.agg_.price_, 81);

--- a/program/rust/src/tests/test_upd_sma.rs
+++ b/program/rust/src/tests/test_upd_sma.rs
@@ -1,4 +1,7 @@
-use crate::accounts::PythAccount;
+use crate::{
+    accounts::PythAccount,
+    c_oracle_header::PC_STATUS_IGNORED,
+};
 // use crate::processor::process_instruction;
 use {
     crate::{
@@ -309,7 +312,7 @@ fn test_upd_sma() {
         assert_eq!(price_data.price_data.comp_[0].latest_.pub_slot_, 5);
         assert_eq!(
             price_data.price_data.comp_[0].latest_.status_,
-            PC_STATUS_UNKNOWN
+            PC_STATUS_IGNORED
         );
         assert_eq!(price_data.price_data.valid_slot_, 5);
         assert_eq!(price_data.price_data.agg_.pub_slot_, 6);
@@ -349,7 +352,7 @@ fn test_upd_sma() {
         assert_eq!(price_data.price_data.comp_[0].latest_.pub_slot_, 6);
         assert_eq!(
             price_data.price_data.comp_[0].latest_.status_,
-            PC_STATUS_UNKNOWN
+            PC_STATUS_IGNORED
         );
         assert_eq!(price_data.price_data.valid_slot_, 6);
         assert_eq!(price_data.price_data.agg_.pub_slot_, 7);


### PR DESCRIPTION
We currently can't tell the difference between data providers who intentionally publish status=UNKNOWN and data providers that are being automatically filtered out of the aggregate. This is causing problems in the conformance script, where incorrect prices are showing up as the data provider being offline.

This change adds an IGNORED status to represent the case where the data provider is intentionally kicked out.