### PR TITLE
Add toolchain

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,0 +1,5 @@
+
+# This is only used for tests
+[toolchain]
+channel = "1.66.1"
+profile = "minimal"


### PR DESCRIPTION
CI started failing (the bpf tests), I realized a new version of rust got released and was making the tests crash, so I'm pinning the version of rust to one where things worked.