### PR TITLE
Allow negative prices in aggregation

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,30 @@ This command runs a recent pyth-client docker image that already has the necessa
 Therefore, once the container is running, all you have to do is run `cd pyth-client && ./scripts/build.sh`.
 Note that updates to the `pyth-client` directory made inside the docker container will be persisted to the host filesystem (which is probably desirable).
 
+### Local development
+
+First, make sure you're building on the x86_64 architecture.
+On a mac, this command will switch your shell to x86_64:
+
+`env /usr/bin/arch -x86_64 /bin/bash --login`
+
+then in the `program/c` directory, run:
+
+```
+make
+make cpyth-bpf
+make cpyth-native
+```
+
+then in the `program/rust` directory, run:
+
+```
+cargo build-bpf
+cargo test
+```
+
+Note that the tests depend on the bpf build!
+
 ### Fuzzing
 
 Build a docker image for running fuzz tests:
@@ -145,4 +169,3 @@ root@pyth-dev# usermod -u 1002 -g 1004 -s /bin/bash pyth
 ```
 
 Finally, in docker extension inside VS Code click right and choose "Attach VS Code". If you're using a remote host in VS Code make sure to let this connection be open.
-

--- a/README.md
+++ b/README.md
@@ -84,30 +84,6 @@ This command runs a recent pyth-client docker image that already has the necessa
 Therefore, once the container is running, all you have to do is run `cd pyth-client && ./scripts/build.sh`.
 Note that updates to the `pyth-client` directory made inside the docker container will be persisted to the host filesystem (which is probably desirable).
 
-### Local development
-
-First, make sure you're building on the x86_64 architecture.
-On a mac, this command will switch your shell to x86_64:
-
-`env /usr/bin/arch -x86_64 /bin/bash --login`
-
-then in the `program/c` directory, run:
-
-```
-make
-make cpyth-bpf
-make cpyth-native
-```
-
-then in the `program/rust` directory, run:
-
-```
-cargo build-bpf
-cargo test
-```
-
-Note that the tests depend on the bpf build!
-
 ### Fuzzing
 
 Build a docker image for running fuzz tests:

--- a/program/c/src/oracle/upd_aggregate.h
+++ b/program/c/src/oracle/upd_aggregate.h
@@ -180,12 +180,14 @@ static inline bool upd_aggregate( pc_price_t *ptr, uint64_t slot, int64_t timest
       int64_t price     = iptr->agg_.price_;
       int64_t conf      = ( int64_t )( iptr->agg_.conf_ );
       if ( iptr->agg_.status_ == PC_STATUS_TRADING &&
-           (int64_t)0 < conf && (conf + INT64_MIN) < price && price <= (INT64_MAX-conf) && // No overflow for INT64_MAX-conf as conf>0
+           // No overflow for INT64_MIN+conf or INT64_MAX-conf as 0 < conf < INT64_MAX
+           // These checks ensure that price - conf and price + conf do not overflow.
+           (int64_t)0 < conf && (INT64_MIN + conf) <= price && price <= (INT64_MAX-conf) &&
            slot_diff >= 0 && slot_diff <= PC_MAX_SEND_LATENCY ) {
         numv += 1;
-        prcs[ nprcs++ ] = price - conf; // No overflow as 0 < conf < price
+        prcs[ nprcs++ ] = price - conf;
         prcs[ nprcs++ ] = price;
-        prcs[ nprcs++ ] = price + conf; // No overflow as 0 < conf <= INT64_MAX-price
+        prcs[ nprcs++ ] = price + conf;
       }
     }
 

--- a/program/c/src/oracle/upd_aggregate.h
+++ b/program/c/src/oracle/upd_aggregate.h
@@ -102,20 +102,12 @@ static void upd_ema(
     // compute numer/denom and new value from decay factor
     pd_load( numer, ptr->numer_ );
     pd_load( denom, ptr->denom_ );
-    // FIXME: this if statement probably needs to get deleted!
-    if ( numer->v_ < 0 || denom->v_ < 0 ) {
-      // temporary reset twap on negative value
-      pd_set( numer, val );
-      pd_set( denom, one );
-    }
-    else {
-      pd_mul( numer, numer, decay );
-      pd_mul( wval, val, cwgt );
-      pd_add( numer, numer, wval, qs->fact_ );
-      pd_mul( denom, denom, decay );
-      pd_add( denom, denom, cwgt, qs->fact_ );
-      pd_div( val, numer, denom );
-    }
+    pd_mul( numer, numer, decay );
+    pd_mul( wval, val, cwgt );
+    pd_add( numer, numer, wval, qs->fact_ );
+    pd_mul( denom, denom, decay );
+    pd_add( denom, denom, cwgt, qs->fact_ );
+    pd_div( val, numer, denom );
   }
 
   // adjust and store results

--- a/program/c/src/oracle/upd_aggregate.h
+++ b/program/c/src/oracle/upd_aggregate.h
@@ -180,7 +180,7 @@ static inline bool upd_aggregate( pc_price_t *ptr, uint64_t slot, int64_t timest
       int64_t price     = iptr->agg_.price_;
       int64_t conf      = ( int64_t )( iptr->agg_.conf_ );
       if ( iptr->agg_.status_ == PC_STATUS_TRADING &&
-           (int64_t)0 < conf && conf < price && conf <= (INT64_MAX-price) && // No overflow for INT64_MAX-price as price>0
+           (int64_t)0 < conf && (conf + INT64_MIN) < price && price <= (INT64_MAX-conf) && // No overflow for INT64_MAX-conf as conf>0
            slot_diff >= 0 && slot_diff <= PC_MAX_SEND_LATENCY ) {
         numv += 1;
         prcs[ nprcs++ ] = price - conf; // No overflow as 0 < conf < price

--- a/program/c/src/oracle/upd_aggregate.h
+++ b/program/c/src/oracle/upd_aggregate.h
@@ -102,6 +102,7 @@ static void upd_ema(
     // compute numer/denom and new value from decay factor
     pd_load( numer, ptr->numer_ );
     pd_load( denom, ptr->denom_ );
+    // FIXME: this if statement probably needs to get deleted!
     if ( numer->v_ < 0 || denom->v_ < 0 ) {
       // temporary reset twap on negative value
       pd_set( numer, val );

--- a/program/rust/src/lib.rs
+++ b/program/rust/src/lib.rs
@@ -2,6 +2,8 @@
 // Allow non upper case globals from C
 #![allow(non_upper_case_globals)]
 
+extern crate core;
+
 mod accounts;
 mod c_oracle_header;
 mod deserialize;

--- a/program/rust/src/lib.rs
+++ b/program/rust/src/lib.rs
@@ -2,8 +2,6 @@
 // Allow non upper case globals from C
 #![allow(non_upper_case_globals)]
 
-extern crate core;
-
 mod accounts;
 mod c_oracle_header;
 mod deserialize;

--- a/program/rust/src/tests/test_upd_price.rs
+++ b/program/rust/src/tests/test_upd_price.rs
@@ -277,6 +277,60 @@ fn test_upd_price() {
         assert_eq!(price_data.agg_.price_, 81);
         assert_eq!(price_data.agg_.status_, PC_STATUS_UNKNOWN);
     }
+
+    // Negative prices are accepted
+    populate_instruction(&mut instruction_data, -100, 1, 7);
+    update_clock_slot(&mut clock_account, 8);
+
+    assert!(process_instruction(
+        &program_id,
+        &[
+            funding_account.clone(),
+            price_account.clone(),
+            clock_account.clone()
+        ],
+        &instruction_data
+    )
+        .is_ok());
+
+    {
+        let price_data = load_checked::<PriceAccount>(&price_account, PC_VERSION).unwrap();
+        assert_eq!(price_data.comp_[0].latest_.price_, -100);
+        assert_eq!(price_data.comp_[0].latest_.conf_, 1);
+        assert_eq!(price_data.comp_[0].latest_.pub_slot_, 7);
+        assert_eq!(price_data.comp_[0].latest_.status_, PC_STATUS_TRADING);
+        assert_eq!(price_data.valid_slot_, 7);
+        assert_eq!(price_data.agg_.pub_slot_, 8);
+        assert_eq!(price_data.agg_.price_, 81);
+        assert_eq!(price_data.agg_.status_, PC_STATUS_UNKNOWN);
+    }
+
+    // Crank again for aggregate
+    populate_instruction(&mut instruction_data, -100, 1, 7);
+    update_clock_slot(&mut clock_account, 9);
+
+    assert!(process_instruction(
+        &program_id,
+        &[
+            funding_account.clone(),
+            price_account.clone(),
+            clock_account.clone()
+        ],
+        &instruction_data
+    )
+        .is_ok());
+
+    {
+        let price_data = load_checked::<PriceAccount>(&price_account, PC_VERSION).unwrap();
+        assert_eq!(price_data.comp_[0].latest_.price_, -100);
+        assert_eq!(price_data.comp_[0].latest_.conf_, 1);
+        assert_eq!(price_data.comp_[0].latest_.pub_slot_, 7);
+        assert_eq!(price_data.comp_[0].latest_.status_, PC_STATUS_TRADING);
+        assert_eq!(price_data.valid_slot_, 7);
+        assert_eq!(price_data.agg_.pub_slot_, 8);
+        assert_eq!(price_data.agg_.price_, -100);
+        assert_eq!(price_data.agg_.status_, PC_STATUS_TRADING);
+    }
 }
 
 // Create an upd_price instruction with the provided parameters

--- a/program/rust/src/tests/test_upd_price.rs
+++ b/program/rust/src/tests/test_upd_price.rs
@@ -291,7 +291,7 @@ fn test_upd_price() {
         ],
         &instruction_data
     )
-        .is_ok());
+    .is_ok());
 
     {
         let price_data = load_checked::<PriceAccount>(&price_account, PC_VERSION).unwrap();
@@ -318,8 +318,8 @@ fn test_upd_price() {
         ],
         &instruction_data
     )
-        .is_ok());
-    
+    .is_ok());
+
     {
         let price_data = load_checked::<PriceAccount>(&price_account, PC_VERSION).unwrap();
         assert_eq!(price_data.comp_[0].latest_.price_, -100);

--- a/program/rust/src/tests/test_upd_price.rs
+++ b/program/rust/src/tests/test_upd_price.rs
@@ -306,7 +306,7 @@ fn test_upd_price() {
     }
 
     // Crank again for aggregate
-    populate_instruction(&mut instruction_data, -100, 1, 7);
+    populate_instruction(&mut instruction_data, -100, 1, 8);
     update_clock_slot(&mut clock_account, 9);
 
     assert!(process_instruction(
@@ -319,15 +319,15 @@ fn test_upd_price() {
         &instruction_data
     )
         .is_ok());
-
+    
     {
         let price_data = load_checked::<PriceAccount>(&price_account, PC_VERSION).unwrap();
         assert_eq!(price_data.comp_[0].latest_.price_, -100);
         assert_eq!(price_data.comp_[0].latest_.conf_, 1);
-        assert_eq!(price_data.comp_[0].latest_.pub_slot_, 7);
+        assert_eq!(price_data.comp_[0].latest_.pub_slot_, 8);
         assert_eq!(price_data.comp_[0].latest_.status_, PC_STATUS_TRADING);
-        assert_eq!(price_data.valid_slot_, 7);
-        assert_eq!(price_data.agg_.pub_slot_, 8);
+        assert_eq!(price_data.valid_slot_, 8);
+        assert_eq!(price_data.agg_.pub_slot_, 9);
         assert_eq!(price_data.agg_.price_, -100);
         assert_eq!(price_data.agg_.status_, PC_STATUS_TRADING);
     }

--- a/program/rust/test_data/aggregation/2.result
+++ b/program/rust/test_data/aggregation/2.result
@@ -1,1 +1,1 @@
-{"exponent":-3,"price":0,"conf":0,"status":"unknown"}
+{"exponent":-3,"price":-10000,"conf":1000,"status":"trading"}

--- a/program/rust/test_data/aggregation/3.result
+++ b/program/rust/test_data/aggregation/3.result
@@ -1,1 +1,1 @@
-{"exponent":-3,"price":0,"conf":0,"status":"unknown"}
+{"exponent":-3,"price":0,"conf":1000,"status":"trading"}

--- a/program/rust/test_data/aggregation/31.result
+++ b/program/rust/test_data/aggregation/31.result
@@ -1,1 +1,1 @@
-{"exponent":-8,"price":4329187000000,"conf":3187000000,"status":"trading"}
+{"exponent":-8,"price":4328634500000,"conf":2914500000,"status":"trading"}

--- a/program/rust/test_data/aggregation/32.result
+++ b/program/rust/test_data/aggregation/32.result
@@ -1,1 +1,1 @@
-{"exponent":-8,"price":4329402176469,"conf":2206823531,"status":"trading"}
+{"exponent":-8,"price":4329187000000,"conf":3187000000,"status":"trading"}


### PR DESCRIPTION
We want negative prices for yields. The only blocker for negative numbers is an overly-aggressive `if` statement in the aggregation logic designed to prevent overflows. I updated this if statement to the minimum necessary conditions to prevent overflow.

Note that the aggregation algorithm (`price_model`) is already tested with negative numbers (see test_price_model.c) so this should be fine. I also added a test to make sure negative numbers get aggregated properly, and changed some of the existing test cases that include negative numbers.

There was also a temporary check in the ema calculation that prevented negative numbers. I removed that check and added reasonably extensive tests for negative emas to validate the fix.