### PR TITLE
[size-hack] Remove clear account

### DIFF
--- a/program/rust/src/accounts.rs
+++ b/program/rust/src/accounts.rs
@@ -20,16 +20,20 @@ use {
         account_info::AccountInfo,
         program::invoke_signed,
         program_error::ProgramError,
-        program_memory::sol_memset,
         pubkey::Pubkey,
         system_instruction::create_account,
     },
     std::{
-        borrow::BorrowMut,
         cell::RefMut,
         mem::size_of,
     },
 };
+#[cfg(test)]
+use {
+    solana_program::program_memory::sol_memset,
+    std::borrow::BorrowMut,
+};
+
 
 mod mapping;
 mod permission;

--- a/program/rust/src/accounts.rs
+++ b/program/rust/src/accounts.rs
@@ -109,7 +109,6 @@ pub trait PythAccount: Pod {
         )?;
 
         check_valid_fresh_account(account)?;
-        clear_account(account)?;
 
         {
             let mut account_header = load_account_as_mut::<AccountHeader>(account)?;
@@ -170,6 +169,7 @@ fn create<'a>(
 }
 
 /// Sets the data of account to all-zero
+#[cfg(test)]
 pub fn clear_account(account: &AccountInfo) -> Result<(), ProgramError> {
     let mut data = account
         .try_borrow_mut_data()


### PR DESCRIPTION
I need to make to program smaller again. This is one idea.

Everytime we create a new account, we manually zero it. 
I think this is and has always been unnecessary. Being able to create non-zero accounts belonging to a given program would break solana.