### PR TITLE
Add TWAP Message format

### DIFF
--- a/program/rust/src/accounts.rs
+++ b/program/rust/src/accounts.rs
@@ -50,12 +50,14 @@ pub use {
     permission::PermissionAccount,
     price::{
         PriceAccount,
+        PriceAccountV1orV2,
         PriceAccountV2,
         PriceComponent,
         PriceCumulative,
         PriceEma,
         PriceFeedMessage,
         PriceInfo,
+        TWAPMessage,
     },
     product::{
         read_pc_str_t,

--- a/program/rust/src/accounts.rs
+++ b/program/rust/src/accounts.rs
@@ -50,7 +50,6 @@ pub use {
     permission::PermissionAccount,
     price::{
         PriceAccount,
-        PriceAccountV1orV2,
         PriceAccountV2,
         PriceComponent,
         PriceCumulative,

--- a/program/rust/src/accounts.rs
+++ b/program/rust/src/accounts.rs
@@ -56,7 +56,7 @@ pub use {
         PriceEma,
         PriceFeedMessage,
         PriceInfo,
-        TWAPMessage,
+        TwapMessage,
     },
     product::{
         read_pc_str_t,

--- a/program/rust/src/accounts/price.rs
+++ b/program/rust/src/accounts/price.rs
@@ -140,7 +140,7 @@ impl PriceAccountV2 {
 // This struct can't overflow since :
 // |sum(price * slotgap)| <= sum(|price * slotgap|) <= max(|price|) * sum(slotgap) <= i64::MAX * * current_slot <= i64::MAX * u64::MAX <= i128::MAX
 // |sum(conf * slotgap)| <= sum(|conf * slotgap|) <= max(|conf|) * sum(slotgap) <= u64::MAX * current_slot <= u64::MAX * u64::MAX <= u128::MAX
-// num_gaps <= current_slot <= u64::MAX
+// num_down_slots <= current_slot <= u64::MAX
 /// Contains cumulative sums of aggregative price and confidence used to compute arithmetic moving averages.
 /// Informally the TWAP between time t and time T can be computed as :
 /// `(T.price_cumulative.price - t.price_cumulative.price) / (T.agg_.pub_slot_ - t.agg_.pub_slot_)`
@@ -317,7 +317,7 @@ pub struct TWAPMessage {
     pub id:                [u8; 32],
     pub cumulative_price:  i128,
     pub cumulative_conf:   u128,
-    pub num_gaps:          u64,
+    pub num_down_slots:    u64,
     pub exponent:          i32,
     pub publish_time:      i64,
     pub prev_publish_time: i64,
@@ -341,7 +341,7 @@ impl TWAPMessage {
             id: key.to_bytes(),
             cumulative_price: account.price_cumulative.price,
             cumulative_conf: account.price_cumulative.conf,
-            num_gaps: account.price_cumulative.num_gaps,
+            num_down_slots: account.price_cumulative.num_down_slots,
             exponent: account.exponent,
             publish_time,
             prev_publish_time: account.prev_timestamp_,
@@ -370,7 +370,7 @@ impl TWAPMessage {
         bytes[i..i + 16].clone_from_slice(&self.cumulative_conf.to_be_bytes());
         i += 16;
 
-        bytes[i..i + 8].clone_from_slice(&self.num_gaps.to_be_bytes());
+        bytes[i..i + 8].clone_from_slice(&self.num_down_slots.to_be_bytes());
         i += 8;
 
         bytes[i..i + 4].clone_from_slice(&self.exponent.to_be_bytes());

--- a/program/rust/src/accounts/price.rs
+++ b/program/rust/src/accounts/price.rs
@@ -11,22 +11,14 @@ use {
             PC_MAX_SEND_LATENCY,
             PC_STATUS_TRADING,
         },
-        deserialize::load_checked,
         error::OracleError,
     },
     bytemuck::{
         Pod,
         Zeroable,
     },
-    solana_program::{
-        account_info::AccountInfo,
-        program_error::ProgramError,
-        pubkey::Pubkey,
-    },
-    std::{
-        cell::RefMut,
-        mem::size_of,
-    },
+    solana_program::pubkey::Pubkey,
+    std::mem::size_of,
 };
 
 #[repr(C)]
@@ -249,30 +241,7 @@ impl PriceFeedMessage {
     pub const MESSAGE_SIZE: usize = 1 + 32 + 8 + 8 + 4 + 8 + 8 + 8 + 8;
     pub const DISCRIMINATOR: u8 = 0;
 
-    pub fn from_price_account(key: &Pubkey, account: &PriceAccount) -> Self {
-        let (price, conf, publish_time) = if account.agg_.status_ == PC_STATUS_TRADING {
-            (account.agg_.price_, account.agg_.conf_, account.timestamp_)
-        } else {
-            (
-                account.prev_price_,
-                account.prev_conf_,
-                account.prev_timestamp_,
-            )
-        };
-
-        Self {
-            id: key.to_bytes(),
-            price,
-            conf,
-            exponent: account.exponent,
-            publish_time,
-            prev_publish_time: account.prev_timestamp_,
-            ema_price: account.twap_.val_,
-            ema_conf: account.twac_.val_ as u64,
-        }
-    }
-
-    pub fn from_price_account_v2(key: &Pubkey, account: &PriceAccountV2) -> Self {
+    pub fn from_price_account(key: &Pubkey, account: &PriceAccountV2) -> Self {
         let (price, conf, publish_time) = if account.agg_.status_ == PC_STATUS_TRADING {
             (account.agg_.price_, account.agg_.conf_, account.timestamp_)
         } else {
@@ -417,68 +386,5 @@ impl TWAPMessage {
         i += 8;
 
         bytes
-    }
-}
-
-
-pub enum PriceAccountV1orV2<'a> {
-    PriceAccount(RefMut<'a, PriceAccount>),
-    PriceAccountV2(RefMut<'a, PriceAccountV2>),
-}
-
-impl<'a> PriceAccountV1orV2<'a> {
-    pub fn load_checked(account_info: &'a AccountInfo, version: u32) -> Result<Self, ProgramError> {
-        let account_len = account_info.try_data_len()?;
-        if account_len >= PriceAccountV2::MINIMUM_SIZE {
-            return Ok(PriceAccountV1orV2::PriceAccountV2(load_checked::<
-                PriceAccountV2,
-            >(
-                account_info, version
-            )?));
-        } else {
-            return Ok(PriceAccountV1orV2::PriceAccount(load_checked::<
-                PriceAccount,
-            >(
-                account_info, version
-            )?));
-        }
-    }
-    pub fn get_message_sent(&self) -> bool {
-        match self {
-            PriceAccountV1orV2::PriceAccount(price_data) => price_data.message_sent_ == 1,
-            PriceAccountV1orV2::PriceAccountV2(price_data) => price_data.message_sent_ == 1,
-        }
-    }
-
-    pub fn set_message_sent(&mut self, value: u8) {
-        match self {
-            PriceAccountV1orV2::PriceAccount(price_data) => price_data.message_sent_ = value,
-            PriceAccountV1orV2::PriceAccountV2(price_data) => price_data.message_sent_ = value,
-        }
-    }
-
-    pub fn get_messages(&mut self, price_account: &AccountInfo) -> Vec<Vec<u8>> {
-        match self {
-            PriceAccountV1orV2::PriceAccount(price_data) => vec![
-                PriceFeedMessage::from_price_account(price_account.key, price_data)
-                    .as_bytes()
-                    .to_vec(),
-            ],
-            PriceAccountV1orV2::PriceAccountV2(price_data) => vec![
-                PriceFeedMessage::from_price_account_v2(price_account.key, price_data)
-                    .as_bytes()
-                    .to_vec(),
-                TWAPMessage::from_price_account(price_account.key, price_data)
-                    .as_bytes()
-                    .to_vec(),
-            ],
-        }
-    }
-
-    pub fn update_price_cumulative_if_needed(&mut self) -> Result<(), ProgramError> {
-        if let PriceAccountV1orV2::PriceAccountV2(price_data) = self {
-            price_data.update_price_cumulative()?;
-        }
-        Ok(())
     }
 }

--- a/program/rust/src/accounts/price.rs
+++ b/program/rust/src/accounts/price.rs
@@ -304,16 +304,10 @@ impl PriceFeedMessage {
     }
 }
 
-/// Message format for sending data to other chains via the accumulator program
-/// When serialized, each message starts with a unique 1-byte discriminator, followed by the
-/// serialized struct data in the definition(s) below.
-///
-/// Messages are forward-compatible. You may add new fields to messages after all previously
-/// defined fields. All code for parsing messages must ignore any extraneous bytes at the end of
-/// the message (which could be fields that the code does not yet understand).
+/// Message format for sending Twap data via the accumulator program
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq)]
-pub struct TWAPMessage {
+pub struct TwapMessage {
     pub id:                [u8; 32],
     pub cumulative_price:  i128,
     pub cumulative_conf:   u128,
@@ -324,7 +318,7 @@ pub struct TWAPMessage {
     pub publish_slot:      u64,
 }
 
-impl TWAPMessage {
+impl TwapMessage {
     // The size of the serialized message. Note that this is not the same as the size of the struct
     // (because of the discriminator & struct padding/alignment).
     pub const MESSAGE_SIZE: usize = 1 + 32 + 16 + 16 + 8 + 4 + 8 + 8 + 8;

--- a/program/rust/src/processor/upd_price.rs
+++ b/program/rust/src/processor/upd_price.rs
@@ -6,7 +6,7 @@ use {
             PriceFeedMessage,
             PriceInfo,
             PythAccount,
-            TWAPMessage,
+            TwapMessage,
             UPD_PRICE_WRITE_SEED,
         },
         deserialize::{
@@ -173,9 +173,12 @@ pub fn upd_price(
                 load_checked::<PriceAccountV2>(price_account, cmd_args.header.version)?;
             price_data.update_price_cumulative()?;
 
-            if aggregate_updated {
-                price_data.message_sent_ = 0;
-            }
+            // We want to send a message every time the aggregate price updates. However, during the migration,
+            // not every publisher will necessarily provide the accumulator accounts. The message_sent_ flag
+            // ensures that after every aggregate update, the next publisher who provides the accumulator accounts
+            // will send the message.
+            price_data.message_sent_ = 0;
+
 
             if let Some(accumulator_accounts) = maybe_accumulator_accounts {
                 if price_data.message_sent_ == 0 {
@@ -213,7 +216,7 @@ pub fn upd_price(
                         PriceFeedMessage::from_price_account(price_account.key, &price_data)
                             .as_bytes()
                             .to_vec(),
-                        TWAPMessage::from_price_account(price_account.key, &price_data)
+                        TwapMessage::from_price_account(price_account.key, &price_data)
                             .as_bytes()
                             .to_vec(),
                     ];

--- a/program/rust/src/processor/upd_price.rs
+++ b/program/rust/src/processor/upd_price.rs
@@ -168,16 +168,18 @@ pub fn upd_price(
 
     {
         let account_len = price_account.try_data_len()?;
-        if aggregate_updated && account_len >= PriceAccountV2::MINIMUM_SIZE {
+        if account_len >= PriceAccountV2::MINIMUM_SIZE {
             let mut price_data =
                 load_checked::<PriceAccountV2>(price_account, cmd_args.header.version)?;
-            price_data.update_price_cumulative()?;
 
-            // We want to send a message every time the aggregate price updates. However, during the migration,
-            // not every publisher will necessarily provide the accumulator accounts. The message_sent_ flag
-            // ensures that after every aggregate update, the next publisher who provides the accumulator accounts
-            // will send the message.
-            price_data.message_sent_ = 0;
+            if aggregate_updated {
+                price_data.update_price_cumulative()?;
+                // We want to send a message every time the aggregate price updates. However, during the migration,
+                // not every publisher will necessarily provide the accumulator accounts. The message_sent_ flag
+                // ensures that after every aggregate update, the next publisher who provides the accumulator accounts
+                // will send the message.
+                price_data.message_sent_ = 0;
+            }
 
 
             if let Some(accumulator_accounts) = maybe_accumulator_accounts {

--- a/program/rust/src/processor/upd_price.rs
+++ b/program/rust/src/processor/upd_price.rs
@@ -2,10 +2,8 @@ use {
     crate::{
         accounts::{
             PriceAccount,
-            PriceAccountV2,
-            PriceFeedMessage,
+            PriceAccountV1orV2,
             PriceInfo,
-            PythAccount,
             UPD_PRICE_WRITE_SEED,
         },
         deserialize::{
@@ -165,93 +163,90 @@ pub fn upd_price(
         }
     }
 
+
     {
-        let account_len = price_account.try_data_len()?;
-        if aggregate_updated && account_len >= PriceAccountV2::MINIMUM_SIZE {
-            let mut price_data =
-                load_checked::<PriceAccountV2>(price_account, cmd_args.header.version)?;
-            price_data.update_price_cumulative()?;
+        // We want to send a message every time the aggregate price updates. However, during the migration,
+        // not every publisher will necessarily provide the accumulator accounts. The message_sent_ flag
+        // ensures that after every aggregate update, the next publisher who provides the accumulator accounts
+        // will send the message.
+
+        let mut price_account_v1_or_v2 =
+            PriceAccountV1orV2::load_checked(price_account, cmd_args.header.version)?;
+
+        if aggregate_updated {
+            price_account_v1_or_v2.update_price_cumulative_if_needed()?;
+
+            price_account_v1_or_v2.set_message_sent(0);
         }
-    }
 
-    let mut price_data = load_checked::<PriceAccount>(price_account, cmd_args.header.version)?;
-    // We want to send a message every time the aggregate price updates. However, during the migration,
-    // not every publisher will necessarily provide the accumulator accounts. The message_sent_ flag
-    // ensures that after every aggregate update, the next publisher who provides the accumulator accounts
-    // will send the message.
-    if aggregate_updated {
-        price_data.message_sent_ = 0;
-    }
+        if let Some(accumulator_accounts) = maybe_accumulator_accounts {
+            if !price_account_v1_or_v2.get_message_sent() {
+                // Check that the oracle PDA is correctly configured for the program we are calling.
+                let oracle_auth_seeds: &[&[u8]] = &[
+                    UPD_PRICE_WRITE_SEED.as_bytes(),
+                    &accumulator_accounts.program_id.key.to_bytes(),
+                ];
+                let (expected_oracle_auth_pda, bump) =
+                    Pubkey::find_program_address(oracle_auth_seeds, program_id);
+                pyth_assert(
+                    expected_oracle_auth_pda == *accumulator_accounts.oracle_auth_pda.key,
+                    OracleError::InvalidPda.into(),
+                )?;
 
-    if let Some(accumulator_accounts) = maybe_accumulator_accounts {
-        if price_data.message_sent_ == 0 {
-            // Check that the oracle PDA is correctly configured for the program we are calling.
-            let oracle_auth_seeds: &[&[u8]] = &[
-                UPD_PRICE_WRITE_SEED.as_bytes(),
-                &accumulator_accounts.program_id.key.to_bytes(),
-            ];
-            let (expected_oracle_auth_pda, bump) =
-                Pubkey::find_program_address(oracle_auth_seeds, program_id);
-            pyth_assert(
-                expected_oracle_auth_pda == *accumulator_accounts.oracle_auth_pda.key,
-                OracleError::InvalidPda.into(),
-            )?;
-
-            let account_metas = vec![
-                AccountMeta {
-                    pubkey:      *accumulator_accounts.whitelist.key,
-                    is_signer:   false,
-                    is_writable: false,
-                },
-                AccountMeta {
-                    pubkey:      *accumulator_accounts.oracle_auth_pda.key,
-                    is_signer:   true,
-                    is_writable: false,
-                },
-                AccountMeta {
-                    pubkey:      *accumulator_accounts.message_buffer_data.key,
-                    is_signer:   false,
-                    is_writable: true,
-                },
-            ];
-
-            let message =
-                vec![
-                    PriceFeedMessage::from_price_account(price_account.key, &price_data)
-                        .as_bytes()
-                        .to_vec(),
+                let account_metas = vec![
+                    AccountMeta {
+                        pubkey:      *accumulator_accounts.whitelist.key,
+                        is_signer:   false,
+                        is_writable: false,
+                    },
+                    AccountMeta {
+                        pubkey:      *accumulator_accounts.oracle_auth_pda.key,
+                        is_signer:   true,
+                        is_writable: false,
+                    },
+                    AccountMeta {
+                        pubkey:      *accumulator_accounts.message_buffer_data.key,
+                        is_signer:   false,
+                        is_writable: true,
+                    },
                 ];
 
-            // anchor discriminator for "global:put_all"
-            let discriminator = [212, 225, 193, 91, 151, 238, 20, 93];
-            let create_inputs_ix = Instruction::new_with_borsh(
-                *accumulator_accounts.program_id.key,
-                &(discriminator, price_account.key.to_bytes(), message),
-                account_metas,
-            );
+                let message = price_account_v1_or_v2.get_messages(price_account);
 
-            let auth_seeds_with_bump: &[&[u8]] = &[
-                UPD_PRICE_WRITE_SEED.as_bytes(),
-                &accumulator_accounts.program_id.key.to_bytes(),
-                &[bump],
-            ];
+                // anchor discriminator for "global:put_all"
+                let discriminator = [212, 225, 193, 91, 151, 238, 20, 93];
+                let create_inputs_ix = Instruction::new_with_borsh(
+                    *accumulator_accounts.program_id.key,
+                    &(discriminator, price_account.key.to_bytes(), message),
+                    account_metas,
+                );
 
-            invoke_signed(&create_inputs_ix, accounts, &[auth_seeds_with_bump])?;
-            price_data.message_sent_ = 1;
+                let auth_seeds_with_bump: &[&[u8]] = &[
+                    UPD_PRICE_WRITE_SEED.as_bytes(),
+                    &accumulator_accounts.program_id.key.to_bytes(),
+                    &[bump],
+                ];
+
+                invoke_signed(&create_inputs_ix, accounts, &[auth_seeds_with_bump])?;
+                price_account_v1_or_v2.set_message_sent(1);
+            }
         }
     }
 
-    // Try to update the publisher's price
-    if is_component_update(cmd_args)? {
-        let status: u32 =
-            get_status_for_update(cmd_args.price, cmd_args.confidence, cmd_args.status)?;
+    {
+        let mut price_data = load_checked::<PriceAccount>(price_account, cmd_args.header.version)?;
+        // Try to update the publisher's price
+        if is_component_update(cmd_args)? {
+            let status: u32 =
+                get_status_for_update(cmd_args.price, cmd_args.confidence, cmd_args.status)?;
 
-        {
-            let publisher_price = &mut price_data.comp_[publisher_index].latest_;
-            publisher_price.price_ = cmd_args.price;
-            publisher_price.conf_ = cmd_args.confidence;
-            publisher_price.status_ = status;
-            publisher_price.pub_slot_ = cmd_args.publishing_slot;
+            {
+                let publisher_price = &mut price_data.comp_[publisher_index].latest_;
+                publisher_price.price_ = cmd_args.price;
+                publisher_price.conf_ = cmd_args.confidence;
+                publisher_price.status_ = status;
+                publisher_price.pub_slot_ = cmd_args.publishing_slot;
+            }
         }
     }
 

--- a/program/rust/src/tests/test_message.rs
+++ b/program/rust/src/tests/test_message.rs
@@ -52,7 +52,7 @@ impl Arbitrary for TWAPMessage {
             id,
             cumulative_price: i128::arbitrary(g),
             cumulative_conf: u128::arbitrary(g),
-            num_gaps: u64::arbitrary(g),
+            num_down_slots: u64::arbitrary(g),
             exponent: i32::arbitrary(g),
             publish_time,
             prev_publish_time: publish_time.saturating_sub(i64::arbitrary(g)),
@@ -98,7 +98,7 @@ impl TWAPMessage {
 
         let cumulative_price = cursor.read_i128::<BigEndian>().ok()?;
         let cumulative_conf = cursor.read_u128::<BigEndian>().ok()?;
-        let num_gaps = cursor.read_u64::<BigEndian>().ok()?;
+        let num_down_slots = cursor.read_u64::<BigEndian>().ok()?;
         let exponent = cursor.read_i32::<BigEndian>().ok()?;
         let publish_time = cursor.read_i64::<BigEndian>().ok()?;
         let prev_publish_time = cursor.read_i64::<BigEndian>().ok()?;
@@ -112,7 +112,7 @@ impl TWAPMessage {
                 id,
                 cumulative_price,
                 cumulative_conf,
-                num_gaps,
+                num_down_slots,
                 exponent,
                 publish_time,
                 prev_publish_time,

--- a/program/rust/src/tests/test_message.rs
+++ b/program/rust/src/tests/test_message.rs
@@ -1,7 +1,7 @@
 use {
     crate::accounts::{
         PriceFeedMessage,
-        TWAPMessage,
+        TwapMessage,
     },
     byteorder::{
         BigEndian,
@@ -14,8 +14,6 @@ use {
         Read,
     },
 };
-
-// TODO: test serialization and deserialization of PriceFeedMessage
 
 impl Arbitrary for PriceFeedMessage {
     fn arbitrary(g: &mut quickcheck::Gen) -> Self {
@@ -35,89 +33,6 @@ impl Arbitrary for PriceFeedMessage {
             prev_publish_time: publish_time.saturating_sub(i64::arbitrary(g)),
             ema_price: i64::arbitrary(g),
             ema_conf: u64::arbitrary(g),
-        }
-    }
-}
-
-impl Arbitrary for TWAPMessage {
-    fn arbitrary(g: &mut quickcheck::Gen) -> Self {
-        let mut id = [0u8; 32];
-        for item in &mut id {
-            *item = u8::arbitrary(g);
-        }
-
-        let publish_time = i64::arbitrary(g);
-
-        TWAPMessage {
-            id,
-            cumulative_price: i128::arbitrary(g),
-            cumulative_conf: u128::arbitrary(g),
-            num_down_slots: u64::arbitrary(g),
-            exponent: i32::arbitrary(g),
-            publish_time,
-            prev_publish_time: publish_time.saturating_sub(i64::arbitrary(g)),
-            publish_slot: u64::arbitrary(g),
-        }
-    }
-}
-
-#[quickcheck]
-fn test_price_feed_message_roundtrip(input: PriceFeedMessage) -> bool {
-    let reconstructed = PriceFeedMessage::from_bytes(&input.as_bytes());
-
-    println!("Failed test case:");
-    println!("{:?}", input);
-    println!("{:?}", reconstructed);
-
-    reconstructed.is_some() && reconstructed.unwrap() == input
-}
-
-#[quickcheck]
-fn test_twap_message_roundtrip(input: TWAPMessage) -> bool {
-    let reconstructed = TWAPMessage::from_bytes(&input.as_bytes());
-
-    println!("Failed test case:");
-    println!("{:?}", input);
-    println!("{:?}", reconstructed);
-
-    reconstructed.is_some() && reconstructed.unwrap() == input
-}
-
-
-impl TWAPMessage {
-    fn from_bytes(bytes: &[u8]) -> Option<Self> {
-        let mut cursor = Cursor::new(bytes);
-
-        let discriminator = cursor.read_u8().ok()?;
-        if discriminator != 1 {
-            return None;
-        }
-
-        let mut id = [0u8; 32];
-        cursor.read_exact(&mut id).ok()?;
-
-        let cumulative_price = cursor.read_i128::<BigEndian>().ok()?;
-        let cumulative_conf = cursor.read_u128::<BigEndian>().ok()?;
-        let num_down_slots = cursor.read_u64::<BigEndian>().ok()?;
-        let exponent = cursor.read_i32::<BigEndian>().ok()?;
-        let publish_time = cursor.read_i64::<BigEndian>().ok()?;
-        let prev_publish_time = cursor.read_i64::<BigEndian>().ok()?;
-        let publish_slot = cursor.read_u64::<BigEndian>().ok()?;
-
-        if cursor.position() as usize != bytes.len() {
-            // The message bytes are longer than expected
-            None
-        } else {
-            Some(Self {
-                id,
-                cumulative_price,
-                cumulative_conf,
-                num_down_slots,
-                exponent,
-                publish_time,
-                prev_publish_time,
-                publish_slot,
-            })
         }
     }
 }
@@ -160,4 +75,87 @@ impl PriceFeedMessage {
             })
         }
     }
+}
+
+#[quickcheck]
+fn test_price_feed_message_roundtrip(input: PriceFeedMessage) -> bool {
+    let reconstructed = PriceFeedMessage::from_bytes(&input.as_bytes());
+
+    println!("Failed test case:");
+    println!("{:?}", input);
+    println!("{:?}", reconstructed);
+
+    reconstructed.is_some() && reconstructed.unwrap() == input
+}
+
+
+impl Arbitrary for TwapMessage {
+    fn arbitrary(g: &mut quickcheck::Gen) -> Self {
+        let mut id = [0u8; 32];
+        for item in &mut id {
+            *item = u8::arbitrary(g);
+        }
+
+        let publish_time = i64::arbitrary(g);
+
+        TwapMessage {
+            id,
+            cumulative_price: i128::arbitrary(g),
+            cumulative_conf: u128::arbitrary(g),
+            num_down_slots: u64::arbitrary(g),
+            exponent: i32::arbitrary(g),
+            publish_time,
+            prev_publish_time: publish_time.saturating_sub(i64::arbitrary(g)),
+            publish_slot: u64::arbitrary(g),
+        }
+    }
+}
+
+impl TwapMessage {
+    fn from_bytes(bytes: &[u8]) -> Option<Self> {
+        let mut cursor = Cursor::new(bytes);
+
+        let discriminator = cursor.read_u8().ok()?;
+        if discriminator != 1 {
+            return None;
+        }
+
+        let mut id = [0u8; 32];
+        cursor.read_exact(&mut id).ok()?;
+
+        let cumulative_price = cursor.read_i128::<BigEndian>().ok()?;
+        let cumulative_conf = cursor.read_u128::<BigEndian>().ok()?;
+        let num_down_slots = cursor.read_u64::<BigEndian>().ok()?;
+        let exponent = cursor.read_i32::<BigEndian>().ok()?;
+        let publish_time = cursor.read_i64::<BigEndian>().ok()?;
+        let prev_publish_time = cursor.read_i64::<BigEndian>().ok()?;
+        let publish_slot = cursor.read_u64::<BigEndian>().ok()?;
+
+        if cursor.position() as usize != bytes.len() {
+            // The message bytes are longer than expected
+            None
+        } else {
+            Some(Self {
+                id,
+                cumulative_price,
+                cumulative_conf,
+                num_down_slots,
+                exponent,
+                publish_time,
+                prev_publish_time,
+                publish_slot,
+            })
+        }
+    }
+}
+
+#[quickcheck]
+fn test_twap_message_roundtrip(input: TwapMessage) -> bool {
+    let reconstructed = TwapMessage::from_bytes(&input.as_bytes());
+
+    println!("Failed test case:");
+    println!("{:?}", input);
+    println!("{:?}", reconstructed);
+
+    reconstructed.is_some() && reconstructed.unwrap() == input
 }

--- a/program/rust/src/tests/test_message.rs
+++ b/program/rust/src/tests/test_message.rs
@@ -1,5 +1,8 @@
 use {
-    crate::accounts::PriceFeedMessage,
+    crate::accounts::{
+        PriceFeedMessage,
+        TWAPMessage,
+    },
     byteorder::{
         BigEndian,
         ReadBytesExt,
@@ -36,9 +39,31 @@ impl Arbitrary for PriceFeedMessage {
     }
 }
 
+impl Arbitrary for TWAPMessage {
+    fn arbitrary(g: &mut quickcheck::Gen) -> Self {
+        let mut id = [0u8; 32];
+        for item in &mut id {
+            *item = u8::arbitrary(g);
+        }
+
+        let publish_time = i64::arbitrary(g);
+
+        TWAPMessage {
+            id,
+            cumulative_price: i128::arbitrary(g),
+            cumulative_conf: u128::arbitrary(g),
+            num_gaps: u64::arbitrary(g),
+            exponent: i32::arbitrary(g),
+            publish_time,
+            prev_publish_time: publish_time.saturating_sub(i64::arbitrary(g)),
+            publish_slot: u64::arbitrary(g),
+        }
+    }
+}
+
 #[quickcheck]
 fn test_price_feed_message_roundtrip(input: PriceFeedMessage) -> bool {
-    let reconstructed = from_bytes(&input.as_bytes());
+    let reconstructed = PriceFeedMessage::from_bytes(&input.as_bytes());
 
     println!("Failed test case:");
     println!("{:?}", input);
@@ -47,40 +72,92 @@ fn test_price_feed_message_roundtrip(input: PriceFeedMessage) -> bool {
     reconstructed.is_some() && reconstructed.unwrap() == input
 }
 
-/// TODO: move this parsing implementation to a separate data format library.
-fn from_bytes(bytes: &[u8]) -> Option<PriceFeedMessage> {
-    let mut cursor = Cursor::new(bytes);
+#[quickcheck]
+fn test_twap_message_roundtrip(input: TWAPMessage) -> bool {
+    let reconstructed = TWAPMessage::from_bytes(&input.as_bytes());
 
-    let discriminator = cursor.read_u8().ok()?;
-    if discriminator != 0 {
-        return None;
+    println!("Failed test case:");
+    println!("{:?}", input);
+    println!("{:?}", reconstructed);
+
+    reconstructed.is_some() && reconstructed.unwrap() == input
+}
+
+
+impl TWAPMessage {
+    fn from_bytes(bytes: &[u8]) -> Option<Self> {
+        let mut cursor = Cursor::new(bytes);
+
+        let discriminator = cursor.read_u8().ok()?;
+        if discriminator != 1 {
+            return None;
+        }
+
+        let mut id = [0u8; 32];
+        cursor.read_exact(&mut id).ok()?;
+
+        let cumulative_price = cursor.read_i128::<BigEndian>().ok()?;
+        let cumulative_conf = cursor.read_u128::<BigEndian>().ok()?;
+        let num_gaps = cursor.read_u64::<BigEndian>().ok()?;
+        let exponent = cursor.read_i32::<BigEndian>().ok()?;
+        let publish_time = cursor.read_i64::<BigEndian>().ok()?;
+        let prev_publish_time = cursor.read_i64::<BigEndian>().ok()?;
+        let publish_slot = cursor.read_u64::<BigEndian>().ok()?;
+
+        if cursor.position() as usize != bytes.len() {
+            // The message bytes are longer than expected
+            None
+        } else {
+            Some(Self {
+                id,
+                cumulative_price,
+                cumulative_conf,
+                num_gaps,
+                exponent,
+                publish_time,
+                prev_publish_time,
+                publish_slot,
+            })
+        }
     }
+}
 
-    let mut id = [0u8; 32];
-    cursor.read_exact(&mut id).ok()?;
+/// TODO: move this parsing implementation to a separate data format library.
+impl PriceFeedMessage {
+    fn from_bytes(bytes: &[u8]) -> Option<Self> {
+        let mut cursor = Cursor::new(bytes);
 
-    let price = cursor.read_i64::<BigEndian>().ok()?;
-    let conf = cursor.read_u64::<BigEndian>().ok()?;
-    let exponent = cursor.read_i32::<BigEndian>().ok()?;
-    let publish_time = cursor.read_i64::<BigEndian>().ok()?;
-    let prev_publish_time = cursor.read_i64::<BigEndian>().ok()?;
-    let ema_price = cursor.read_i64::<BigEndian>().ok()?;
-    let ema_conf = cursor.read_u64::<BigEndian>().ok()?;
+        let discriminator = cursor.read_u8().ok()?;
+        if discriminator != 0 {
+            return None;
+        }
+
+        let mut id = [0u8; 32];
+        cursor.read_exact(&mut id).ok()?;
+
+        let price = cursor.read_i64::<BigEndian>().ok()?;
+        let conf = cursor.read_u64::<BigEndian>().ok()?;
+        let exponent = cursor.read_i32::<BigEndian>().ok()?;
+        let publish_time = cursor.read_i64::<BigEndian>().ok()?;
+        let prev_publish_time = cursor.read_i64::<BigEndian>().ok()?;
+        let ema_price = cursor.read_i64::<BigEndian>().ok()?;
+        let ema_conf = cursor.read_u64::<BigEndian>().ok()?;
 
 
-    if cursor.position() as usize != bytes.len() {
-        // The message bytes are longer than expected
-        None
-    } else {
-        Some(PriceFeedMessage {
-            id,
-            price,
-            conf,
-            exponent,
-            publish_time,
-            prev_publish_time,
-            ema_price,
-            ema_conf,
-        })
+        if cursor.position() as usize != bytes.len() {
+            // The message bytes are longer than expected
+            None
+        } else {
+            Some(Self {
+                id,
+                price,
+                conf,
+                exponent,
+                publish_time,
+                prev_publish_time,
+                ema_price,
+                ema_conf,
+            })
+        }
     }
 }


### PR DESCRIPTION
There's some awkwardness around whether the messages get created from PriceAccount or PriceAccoutV2 (the twap fields only exist in PriceAccountV2) but we can work on that later. Right now accounts have to be upgraded before messages start getting sent.

Key point is the `TwapMessage` struct.