### PR TITLE
Explicitly set type of discriminator

### DIFF
--- a/program/rust/src/processor/upd_price.rs
+++ b/program/rust/src/processor/upd_price.rs
@@ -229,7 +229,7 @@ pub fn upd_price(
                 ];
 
                 // anchor discriminator for "global:put_all"
-                let discriminator = [212, 225, 193, 91, 151, 238, 20, 93];
+                let discriminator: [u8; 8] = [212, 225, 193, 91, 151, 238, 20, 93];
                 let create_inputs_ix = Instruction::new_with_borsh(
                     *accumulator_accounts.program_id.key,
                     &(discriminator, price_account.key.to_bytes(), message),


### PR DESCRIPTION
explicitly set type of discriminator to be [u8; 8] otherwise `Instruction::new_with_borsh` assumes it's a `[i32;8]` which will cause the ix to be unrecognized when the oracle program attempts to invoke the message buffer CPI call since it will be padded with extra 0's