### PR TITLE
Improvements to Message in the Oracle Program

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1437,15 +1437,6 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
-
-[[package]]
-name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
@@ -2509,7 +2500,7 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
- "strum 0.21.0",
+ "strum",
  "test-generator",
  "thiserror",
  "tokio",
@@ -3785,8 +3776,8 @@ dependencies = [
  "solana-vote-program",
  "solana-zk-token-proof-program",
  "solana-zk-token-sdk",
- "strum 0.24.1",
- "strum_macros 0.24.3",
+ "strum",
+ "strum_macros",
  "symlink",
  "tar",
  "tempfile",
@@ -4154,32 +4145,11 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "strum"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aaf86bbcfd1fa9670b7a129f64fc0c9fcbbfe4f1bc4210e9e98fe71ffc12cde2"
-dependencies = [
- "strum_macros 0.21.1",
-]
-
-[[package]]
-name = "strum"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
 dependencies = [
- "strum_macros 0.24.3",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d06aaeeee809dbc59eb4556183dd927df67db1540de5be8d3ec0b6636358a5ec"
-dependencies = [
- "heck 0.3.3",
- "proc-macro2 1.0.56",
- "quote 1.0.26",
- "syn 1.0.109",
+ "strum_macros",
 ]
 
 [[package]]
@@ -4188,7 +4158,7 @@ version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
 dependencies = [
- "heck 0.4.1",
+ "heck",
  "proc-macro2 1.0.56",
  "quote 1.0.26",
  "rustversion",
@@ -4706,12 +4676,6 @@ checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
 dependencies = [
  "tinyvec",
 ]
-
-[[package]]
-name = "unicode-segmentation"
-version = "1.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1437,6 +1437,15 @@ dependencies = [
 
 [[package]]
 name = "heck"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
@@ -2500,6 +2509,7 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
+ "strum 0.21.0",
  "test-generator",
  "thiserror",
  "tokio",
@@ -3775,8 +3785,8 @@ dependencies = [
  "solana-vote-program",
  "solana-zk-token-proof-program",
  "solana-zk-token-sdk",
- "strum",
- "strum_macros",
+ "strum 0.24.1",
+ "strum_macros 0.24.3",
  "symlink",
  "tar",
  "tempfile",
@@ -4144,11 +4154,32 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "strum"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aaf86bbcfd1fa9670b7a129f64fc0c9fcbbfe4f1bc4210e9e98fe71ffc12cde2"
+dependencies = [
+ "strum_macros 0.21.1",
+]
+
+[[package]]
+name = "strum"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.24.3",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d06aaeeee809dbc59eb4556183dd927df67db1540de5be8d3ec0b6636358a5ec"
+dependencies = [
+ "heck 0.3.3",
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -4157,7 +4188,7 @@ version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2 1.0.56",
  "quote 1.0.26",
  "rustversion",
@@ -4675,6 +4706,12 @@ checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
 
 [[package]]
 name = "unicode-width"

--- a/program/rust/Cargo.toml
+++ b/program/rust/Cargo.toml
@@ -15,6 +15,8 @@ thiserror = "1.0"
 num-derive = "0.3"
 num-traits = "0.2"
 byteorder = "1.4.3"
+serde = { version = "1.0", features = ["derive"], optional = true }
+strum = { version = "0.21.0", features = ["derive"], optional = true }
 
 [dev-dependencies]
 solana-program-test = "=1.13.3"
@@ -30,10 +32,9 @@ serde_json = "1.0"
 test-generator = "0.3.1"
 csv = "1.1"
 
-
 [features]
 debug = []
-library = []
+library = ["serde", "strum"]
 pythnet = []
 
 [lib]

--- a/program/rust/Cargo.toml
+++ b/program/rust/Cargo.toml
@@ -16,7 +16,7 @@ num-derive = "0.3"
 num-traits = "0.2"
 byteorder = "1.4.3"
 serde = { version = "1.0", features = ["derive"], optional = true }
-strum = { version = "0.21.0", features = ["derive"], optional = true }
+strum = { version = "0.24.1", features = ["derive"], optional = true }
 
 [dev-dependencies]
 solana-program-test = "=1.13.3"
@@ -34,7 +34,7 @@ csv = "1.1"
 
 [features]
 debug = []
-library = ["serde", "strum"]
+library = []
 pythnet = []
 
 [lib]

--- a/program/rust/src/accounts.rs
+++ b/program/rust/src/accounts.rs
@@ -40,6 +40,9 @@ mod permission;
 mod price;
 mod product;
 
+// Some types only exist during use as a library.
+#[cfg(feature = "strum")]
+pub use price::MessageType;
 #[cfg(test)]
 pub use product::{
     account_has_key_values,

--- a/program/rust/src/accounts/price.rs
+++ b/program/rust/src/accounts/price.rs
@@ -230,6 +230,15 @@ impl PythAccount for PriceAccountV2 {
 /// Once we start using the unused structs and methods, the contract size will increase.
 
 #[derive(Debug, Copy, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "strum", derive(strum::EnumDiscriminants))]
+#[cfg_attr(feature = "strum", strum_discriminants(derive(strum::EnumIter, Hash)))]
+#[cfg_attr(feature = "strum", strum_discriminants(name(MessageType)))]
+#[cfg_attr(feature = "strum", strum_discriminants(vis(pub)))]
+#[cfg_attr(
+    all(feature = "strum", feature = "serde"),
+    strum_discriminants(derive(serde::Serialize, serde::Deserialize))
+)]
 pub enum Message {
     PriceFeedMessage(PriceFeedMessage),
     TwapMessage(TwapMessage),
@@ -248,16 +257,32 @@ impl Message {
             _ => Err(OracleError::DeserializationError),
         }
     }
+
     pub fn to_bytes(self) -> Vec<u8> {
         match self {
             Self::PriceFeedMessage(msg) => msg.to_bytes().to_vec(),
             Self::TwapMessage(msg) => msg.to_bytes().to_vec(),
         }
     }
+
+    pub fn publish_time(&self) -> i64 {
+        match self {
+            Self::PriceFeedMessage(msg) => msg.publish_time,
+            Self::TwapMessage(msg) => msg.publish_time,
+        }
+    }
+
+    pub fn id(&self) -> [u8; 32] {
+        match self {
+            Self::PriceFeedMessage(msg) => msg.id,
+            Self::TwapMessage(msg) => msg.id,
+        }
+    }
 }
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PriceFeedMessage {
     pub id:                [u8; 32],
     pub price:             i64,
@@ -409,6 +434,7 @@ impl PriceFeedMessage {
 /// Message format for sending Twap data via the accumulator program
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TwapMessage {
     pub id:                [u8; 32],
     pub cumulative_price:  i128,

--- a/program/rust/src/accounts/price.rs
+++ b/program/rust/src/accounts/price.rs
@@ -231,13 +231,22 @@ impl PythAccount for PriceAccountV2 {
 
 #[derive(Debug, Copy, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "strum", derive(strum::EnumDiscriminants))]
-#[cfg_attr(feature = "strum", strum_discriminants(derive(strum::EnumIter, Hash)))]
-#[cfg_attr(feature = "strum", strum_discriminants(name(MessageType)))]
-#[cfg_attr(feature = "strum", strum_discriminants(vis(pub)))]
 #[cfg_attr(
-    all(feature = "strum", feature = "serde"),
-    strum_discriminants(derive(serde::Serialize, serde::Deserialize))
+    feature = "strum",
+    derive(strum::EnumDiscriminants),
+    strum_discriminants(name(MessageType)),
+    strum_discriminants(vis(pub)),
+    strum_discriminants(derive(
+        Hash,
+        strum::EnumIter,
+        strum::EnumString,
+        strum::IntoStaticStr,
+        strum::ToString,
+    )),
+    cfg_attr(
+        feature = "serde",
+        strum_discriminants(derive(serde::Serialize, serde::Deserialize))
+    )
 )]
 pub enum Message {
     PriceFeedMessage(PriceFeedMessage),

--- a/program/rust/src/lib.rs
+++ b/program/rust/src/lib.rs
@@ -23,6 +23,8 @@ mod log;
 // While we have `pyth-sdk-rs` which exposes a more friendly interface, this is still useful when a
 // downstream user wants to confirm for example that they can compile against the binary interface
 // of this program for their specific solana version.
+#[cfg(feature = "strum")]
+pub use accounts::MessageType;
 #[cfg(feature = "library")]
 pub use accounts::{
     AccountHeader,


### PR DESCRIPTION
This PR extends the `Message` type with features that are helpful to users consuming the program as a library.

- Adds strum/serde to `Message*` during `--features = library` use.
- Adds methods to extract id/publish_time from any message.
- Exports the new `MessageType` enum generated by strum.