### PR TITLE
Use message structures defined in pythnet sdk

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1178,6 +1178,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
+name = "fast-math"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2465292146cdfc2011350fe3b1c616ac83cf0faeedb33463ba1c332ed8948d66"
+dependencies = [
+ "ieee754",
+]
+
+[[package]]
 name = "fastrand"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1472,6 +1481,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "histogram"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1617,6 +1635,12 @@ dependencies = [
  "unicode-bidi",
  "unicode-normalization",
 ]
+
+[[package]]
+name = "ieee754"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9007da9cacbd3e6343da136e98b0d2df013f553d35bdec8b518f07bea768e19c"
 
 [[package]]
 name = "im"
@@ -2489,9 +2513,10 @@ dependencies = [
  "bytemuck",
  "byteorder",
  "csv",
- "hex",
+ "hex 0.3.2",
  "num-derive",
  "num-traits",
+ "pythnet-sdk",
  "quickcheck",
  "quickcheck_macros",
  "rand 0.8.5",
@@ -2504,6 +2529,25 @@ dependencies = [
  "test-generator",
  "thiserror",
  "tokio",
+]
+
+[[package]]
+name = "pythnet-sdk"
+version = "1.13.6"
+source = "git+https://github.com/pyth-network/pyth-crosschain?rev=9f950c694be5e9e6996dca217c2c3e29aac1df48#9f950c694be5e9e6996dca217c2c3e29aac1df48"
+dependencies = [
+ "bincode",
+ "borsh",
+ "bytemuck",
+ "byteorder",
+ "fast-math",
+ "hex 0.4.3",
+ "quickcheck",
+ "rustc_version",
+ "serde",
+ "sha3 0.10.7",
+ "slow_primes",
+ "thiserror",
 ]
 
 [[package]]
@@ -3207,6 +3251,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6528351c9bc8ab22353f9d776db39a20288e8d6c37ef8cfe3317cf875eecfc2d"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "slow_primes"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58267dd2fbaa6dceecba9e3e106d2d90a2b02497c0e8b01b8759beccf5113938"
+dependencies = [
+ "num",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2534,7 +2534,7 @@ dependencies = [
 [[package]]
 name = "pythnet-sdk"
 version = "1.13.6"
-source = "git+https://github.com/pyth-network/pyth-crosschain?rev=e7a3a98ac957782075615936fd689aa9283dfb09#e7a3a98ac957782075615936fd689aa9283dfb09"
+source = "git+https://github.com/pyth-network/pyth-crosschain?rev=60144002053a93f424be70decd8a8ccb8d618d81#60144002053a93f424be70decd8a8ccb8d618d81"
 dependencies = [
  "bincode",
  "borsh",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2534,7 +2534,7 @@ dependencies = [
 [[package]]
 name = "pythnet-sdk"
 version = "1.13.6"
-source = "git+https://github.com/pyth-network/pyth-crosschain?rev=9f950c694be5e9e6996dca217c2c3e29aac1df48#9f950c694be5e9e6996dca217c2c3e29aac1df48"
+source = "git+https://github.com/pyth-network/pyth-crosschain?rev=e7a3a98ac957782075615936fd689aa9283dfb09#e7a3a98ac957782075615936fd689aa9283dfb09"
 dependencies = [
  "bincode",
  "borsh",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 members = [
   "program/rust"
 ]

--- a/program/rust/Cargo.toml
+++ b/program/rust/Cargo.toml
@@ -17,7 +17,7 @@ num-traits = "0.2"
 byteorder = "1.4.3"
 serde = { version = "1.0", features = ["derive"], optional = true }
 strum = { version = "0.24.1", features = ["derive"], optional = true }
-pythnet-sdk = { git = "https://github.com/pyth-network/pyth-crosschain", rev="9f950c694be5e9e6996dca217c2c3e29aac1df48"}
+pythnet-sdk = { git = "https://github.com/pyth-network/pyth-crosschain", rev="e7a3a98ac957782075615936fd689aa9283dfb09"}
 
 [dev-dependencies]
 solana-program-test = "=1.13.3"
@@ -29,7 +29,7 @@ rand = "0.8.5"
 quickcheck_macros = "1"
 bincode = "1.3.3"
 serde = { version = "1.0", features = ["derive"] }
-pythnet-sdk = { git = "https://github.com/pyth-network/pyth-crosschain", rev="9f950c694be5e9e6996dca217c2c3e29aac1df48", features = ["quickcheck"]}
+pythnet-sdk = { git = "https://github.com/pyth-network/pyth-crosschain", rev="e7a3a98ac957782075615936fd689aa9283dfb09", features = ["quickcheck"]}
 serde_json = "1.0"
 test-generator = "0.3.1"
 csv = "1.1"

--- a/program/rust/Cargo.toml
+++ b/program/rust/Cargo.toml
@@ -17,7 +17,7 @@ num-traits = "0.2"
 byteorder = "1.4.3"
 serde = { version = "1.0", features = ["derive"], optional = true }
 strum = { version = "0.24.1", features = ["derive"], optional = true }
-pythnet-sdk = { git = "https://github.com/pyth-network/pyth-crosschain", rev="e7a3a98ac957782075615936fd689aa9283dfb09"}
+pythnet-sdk = { git = "https://github.com/pyth-network/pyth-crosschain", rev="60144002053a93f424be70decd8a8ccb8d618d81"}
 
 [dev-dependencies]
 solana-program-test = "=1.13.3"
@@ -29,7 +29,7 @@ rand = "0.8.5"
 quickcheck_macros = "1"
 bincode = "1.3.3"
 serde = { version = "1.0", features = ["derive"] }
-pythnet-sdk = { git = "https://github.com/pyth-network/pyth-crosschain", rev="e7a3a98ac957782075615936fd689aa9283dfb09", features = ["quickcheck"]}
+pythnet-sdk = { git = "https://github.com/pyth-network/pyth-crosschain", rev="60144002053a93f424be70decd8a8ccb8d618d81", features = ["quickcheck"]}
 serde_json = "1.0"
 test-generator = "0.3.1"
 csv = "1.1"

--- a/program/rust/Cargo.toml
+++ b/program/rust/Cargo.toml
@@ -17,6 +17,7 @@ num-traits = "0.2"
 byteorder = "1.4.3"
 serde = { version = "1.0", features = ["derive"], optional = true }
 strum = { version = "0.24.1", features = ["derive"], optional = true }
+pythnet-sdk = { git = "https://github.com/pyth-network/pyth-crosschain", rev="9f950c694be5e9e6996dca217c2c3e29aac1df48"}
 
 [dev-dependencies]
 solana-program-test = "=1.13.3"
@@ -28,6 +29,7 @@ rand = "0.8.5"
 quickcheck_macros = "1"
 bincode = "1.3.3"
 serde = { version = "1.0", features = ["derive"] }
+pythnet-sdk = { git = "https://github.com/pyth-network/pyth-crosschain", rev="9f950c694be5e9e6996dca217c2c3e29aac1df48", features = ["quickcheck"]}
 serde_json = "1.0"
 test-generator = "0.3.1"
 csv = "1.1"

--- a/program/rust/src/accounts.rs
+++ b/program/rust/src/accounts.rs
@@ -52,15 +52,13 @@ pub use {
     mapping::MappingAccount,
     permission::PermissionAccount,
     price::{
-        Message,
         PriceAccount,
         PriceAccountV2,
         PriceComponent,
         PriceCumulative,
         PriceEma,
-        PriceFeedMessage,
         PriceInfo,
-        TwapMessage,
+        PythOracleSerialize,
     },
     product::{
         read_pc_str_t,

--- a/program/rust/src/lib.rs
+++ b/program/rust/src/lib.rs
@@ -29,16 +29,13 @@ pub use accounts::MessageType;
 pub use accounts::{
     AccountHeader,
     MappingAccount,
-    Message,
     PermissionAccount,
     PriceAccount,
     PriceComponent,
     PriceEma,
-    PriceFeedMessage,
     PriceInfo,
     ProductAccount,
     PythAccount,
-    TwapMessage,
 };
 use {
     crate::error::OracleError,

--- a/program/rust/src/processor/upd_price.rs
+++ b/program/rust/src/processor/upd_price.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "pythnet")]
 use {
     crate::accounts::{
-        PriceFeedMessage,
+        PythOracleSerialize,
         UPD_PRICE_WRITE_SEED,
     },
     solana_program::instruction::{
@@ -225,13 +225,9 @@ pub fn upd_price(
                         is_writable: true,
                     },
                 ];
-
-                let message =
-                    vec![
-                        PriceFeedMessage::from_price_account(price_account.key, &price_data)
-                            .to_bytes()
-                            .to_vec(),
-                    ];
+                let message = vec![price_data
+                    .as_price_feed_message(price_account.key)
+                    .to_bytes()];
 
                 // anchor discriminator for "global:put_all"
                 let discriminator: [u8; 8] = [212, 225, 193, 91, 151, 238, 20, 93];

--- a/program/rust/src/tests/test_message.rs
+++ b/program/rust/src/tests/test_message.rs
@@ -27,11 +27,14 @@ fn test_price_feed_message_roundtrip(input: PriceFeedMessage) -> bool {
 
 #[quickcheck]
 fn test_twap_message_roundtrip(input: TwapMessage) -> bool {
-    let reconstructed = from_slice::<BigEndian, TwapMessage>(&input.to_bytes()).unwrap();
+    let reconstructed = from_slice::<BigEndian, Message>(&input.to_bytes()).unwrap();
 
     println!("Failed test case:");
     println!("{:?}", input);
     println!("{:?}", reconstructed);
 
-    reconstructed == input
+    match reconstructed {
+        Message::TwapMessage(reconstructed) => reconstructed == input,
+        _ => false,
+    }
 }

--- a/program/rust/src/tests/test_message.rs
+++ b/program/rust/src/tests/test_message.rs
@@ -1,97 +1,37 @@
 use {
-    crate::accounts::{
-        Message,
-        PriceFeedMessage,
-        TwapMessage,
+    crate::accounts::PythOracleSerialize,
+    byteorder::BigEndian,
+    pythnet_sdk::{
+        messages::{
+            Message,
+            PriceFeedMessage,
+            TwapMessage,
+        },
+        wire::from_slice,
     },
-    quickcheck::Arbitrary,
     quickcheck_macros::quickcheck,
 };
 
-impl Arbitrary for PriceFeedMessage {
-    fn arbitrary(g: &mut quickcheck::Gen) -> Self {
-        let mut id = [0u8; 32];
-        for item in &mut id {
-            *item = u8::arbitrary(g);
-        }
-
-        let publish_time = i64::arbitrary(g);
-
-        PriceFeedMessage {
-            id,
-            price: i64::arbitrary(g),
-            conf: u64::arbitrary(g),
-            exponent: i32::arbitrary(g),
-            publish_time,
-            prev_publish_time: publish_time.saturating_sub(i64::arbitrary(g)),
-            ema_price: i64::arbitrary(g),
-            ema_conf: u64::arbitrary(g),
-        }
-    }
-}
-
 #[quickcheck]
 fn test_price_feed_message_roundtrip(input: PriceFeedMessage) -> bool {
-    let reconstructed = PriceFeedMessage::try_from_bytes(&input.to_bytes());
+    let reconstructed = from_slice::<BigEndian, Message>(&input.to_bytes()).unwrap();
 
     println!("Failed test case:");
     println!("{:?}", input);
     println!("{:?}", reconstructed);
-
-    reconstructed == Ok(input)
-}
-
-
-impl Arbitrary for TwapMessage {
-    fn arbitrary(g: &mut quickcheck::Gen) -> Self {
-        let mut id = [0u8; 32];
-        for item in &mut id {
-            *item = u8::arbitrary(g);
-        }
-
-        let publish_time = i64::arbitrary(g);
-
-        TwapMessage {
-            id,
-            cumulative_price: i128::arbitrary(g),
-            cumulative_conf: u128::arbitrary(g),
-            num_down_slots: u64::arbitrary(g),
-            exponent: i32::arbitrary(g),
-            publish_time,
-            prev_publish_time: publish_time.saturating_sub(i64::arbitrary(g)),
-            publish_slot: u64::arbitrary(g),
-        }
+    match reconstructed {
+        Message::PriceFeedMessage(reconstructed) => reconstructed == input,
+        _ => false,
     }
 }
 
 #[quickcheck]
 fn test_twap_message_roundtrip(input: TwapMessage) -> bool {
-    let reconstructed = TwapMessage::try_from_bytes(&input.to_bytes());
+    let reconstructed = from_slice::<BigEndian, TwapMessage>(&input.to_bytes()).unwrap();
 
     println!("Failed test case:");
     println!("{:?}", input);
     println!("{:?}", reconstructed);
 
-    reconstructed == Ok(input)
-}
-
-
-impl Arbitrary for Message {
-    fn arbitrary(g: &mut quickcheck::Gen) -> Self {
-        match u8::arbitrary(g) % 2 {
-            0 => Message::PriceFeedMessage(Arbitrary::arbitrary(g)),
-            _ => Message::TwapMessage(Arbitrary::arbitrary(g)),
-        }
-    }
-}
-
-#[quickcheck]
-fn test_message_roundtrip(input: Message) -> bool {
-    let reconstructed = Message::try_from_bytes(&input.to_bytes());
-
-    println!("Failed test case:");
-    println!("{:?}", input);
-    println!("{:?}", reconstructed);
-
-    reconstructed == Ok(input)
+    reconstructed == input
 }


### PR DESCRIPTION
Since the custom serialization implementations are solana specific and mainly for reducing the binary size, they are kept in this package via a custom trait.
Deserialization functions were removed since they were not used and the default serde provided by pythnet sdk should work identically. Serialization tests are now repurposed to test our custom serialization and the general deserialization lead to the same original structure.