### PR TITLE
scripts/build-bpf.sh: Move contract binaries to target/pyth/{solana|pythnet}

### DIFF
--- a/scripts/build-bpf.sh
+++ b/scripts/build-bpf.sh
@@ -26,14 +26,14 @@ cargo test --locked --features pythnet
 
 cargo-build-bpf -- --locked -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort
 sha256sum ./target/**/*.so
+echo "Checking size of pyth_oracle.so for mainnet"
+./scripts/check-size.sh 81760
 mkdir -p target/pyth/solana/
 mv target/deploy/pyth_oracle.so target/pyth/solana/pyth_oracle_solana.so
-echo "Checking size of pyth_oracle.so for mainnet"
-./scripts/check-size.sh 81760 target/pyth/solana/pyth_oracle_solana.so
 
 cargo-build-bpf -- --locked -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort --features pythnet
 sha256sum ./target/**/*.so
+echo "Checking size of pyth_oracle.so for pythnet"
+./scripts/check-size.sh 88429
 mkdir -p target/pyth/pythnet/
 mv target/deploy/pyth_oracle.so target/pyth/pythnet/pyth_oracle_pythnet.so
-echo "Checking size of pyth_oracle.so for pythnet"
-./scripts/check-size.sh 88429 target/pyth/pythnet/pyth_oracle_pythnet.so

--- a/scripts/build-bpf.sh
+++ b/scripts/build-bpf.sh
@@ -26,10 +26,14 @@ cargo test --locked --features pythnet
 
 cargo-build-bpf -- --locked -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort
 sha256sum ./target/**/*.so
+mkdir -p target/pyth/solana/
+mv target/deploy/pyth_oracle.so target/pyth/solana/pyth_oracle_solana.so
 echo "Checking size of pyth_oracle.so for mainnet"
-./scripts/check-size.sh 81760
+./scripts/check-size.sh 81760 target/pyth/solana/pyth_oracle_solana.so
 
 cargo-build-bpf -- --locked -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort --features pythnet
 sha256sum ./target/**/*.so
+mkdir -p target/pyth/pythnet/
+mv target/deploy/pyth_oracle.so target/pyth/pythnet/pyth_oracle_pythnet.so
 echo "Checking size of pyth_oracle.so for pythnet"
-./scripts/check-size.sh 88429
+./scripts/check-size.sh 88429 target/pyth/pythnet/pyth_oracle_pythnet.so

--- a/scripts/check-size.sh
+++ b/scripts/check-size.sh
@@ -1,13 +1,17 @@
 #!/usr/bin/env bash
 #
+set -e
+
+max_size=$1
+filename=${2:-./target/deploy/pyth_oracle.so}
 
 # While Solana doesn't support resizing programs, the oracle binary needs to be smaller than 81760 bytes
 # (The available space for the oracle program on pythnet is 88429 and mainnet is 81760)
-ORACLE_SIZE=$(wc -c ./target/deploy/pyth_oracle.so | awk '{print $1}')
-if [ $ORACLE_SIZE -lt ${1} ]
+ORACLE_SIZE=$(wc -c $filename | awk '{print $1}')
+if [ $ORACLE_SIZE -lt ${max_size} ]
 then
-    echo "Size of pyth_oracle.so is small enough to be deployed, since ${ORACLE_SIZE} is less than ${1}"
+    echo "Size of ${filename} is small enough to be deployed, since ${ORACLE_SIZE} is less than ${max_size}"
 else
-    echo "Size of pyth_oracle.so is too big to be deployed, since ${ORACLE_SIZE} is greater than ${1}"
+    echo "Size of ${filename} is too big to be deployed, since ${ORACLE_SIZE} is greater than ${max_size}"
     exit 1
 fi

--- a/scripts/check-size.sh
+++ b/scripts/check-size.sh
@@ -1,17 +1,13 @@
 #!/usr/bin/env bash
 #
-set -e
-
-max_size=$1
-filename=${2:-./target/deploy/pyth_oracle.so}
 
 # While Solana doesn't support resizing programs, the oracle binary needs to be smaller than 81760 bytes
 # (The available space for the oracle program on pythnet is 88429 and mainnet is 81760)
-ORACLE_SIZE=$(wc -c $filename | awk '{print $1}')
-if [ $ORACLE_SIZE -lt ${max_size} ]
+ORACLE_SIZE=$(wc -c ./target/deploy/pyth_oracle.so | awk '{print $1}')
+if [ $ORACLE_SIZE -lt ${1} ]
 then
-    echo "Size of ${filename} is small enough to be deployed, since ${ORACLE_SIZE} is less than ${max_size}"
+    echo "Size of pyth_oracle.so is small enough to be deployed, since ${ORACLE_SIZE} is less than ${1}"
 else
-    echo "Size of ${filename} is too big to be deployed, since ${ORACLE_SIZE} is greater than ${max_size}"
+    echo "Size of pyth_oracle.so is too big to be deployed, since ${ORACLE_SIZE} is greater than ${1}"
     exit 1
 fi


### PR DESCRIPTION
This change makes `scripts/build-bpf.sh` provide both solana/pythnet contract flavors in a custom `target/pyth` directory. It should help disambiguate the binaries and make building for both environments a single step. Previously, the build would overwrite the Solana contract flavor with the `--features pythnet` version.