### PR TITLE
One release instead of two releases (one for mainnet and one for pythnet)

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,12 +15,9 @@ env:
   DOCKER_USER: ${{ secrets.DOCKER_IO_USER }}
   IS_RELEASE: ${{
     startsWith( github.ref, 'refs/tags/pythd-' ) ||
-    startsWith( github.ref, 'refs/tags/mainnet-' ) }} ||
-    startsWith( github.ref, 'refs/tags/pythnet-' ) }}
-  IS_MAINNET_RELEASE: ${{
-    startsWith( github.ref, 'refs/tags/mainnet-' ) }}
-  IS_PYTHNET_RELEASE: ${{
-    startsWith( github.ref, 'refs/tags/pythnet-' ) }}
+    startsWith( github.ref, 'refs/tags/oracle-' ) }}
+  IS_ORACLE_RELEASE: ${{
+    startsWith( github.ref, 'refs/tags/oracle-' ) }}
 
 
 jobs:
@@ -59,31 +56,25 @@ jobs:
           }
           echo "${{ secrets.DOCKER_IO_PASS }}" | publish
 
-      - name : Get Mainnet binary from docker
-        if : env.IS_MAINNET_RELEASE == 'true'
+      - name : Get binary from docker
+        if : env.IS_ORACLE_RELEASE == 'true'
         run : |
             docker create -ti --name container "${DOCKER_IMAGE}" bash
+            docker cp container:/home/pyth/pyth-client/target/pyth/pythnet/pyth_oracle_pythnet.so .
             docker cp container:/home/pyth/pyth-client/target/pyth/solana/pyth_oracle_solana.so .
             docker rm -f container
 
-      - name : Publish Mainnet binary
-        if : env.IS_MAINNET_RELEASE == 'true'
+      - name : Publish Solana binary
+        if : env.IS_ORACLE_RELEASE == 'true'
         uses: svenstaro/upload-release-action@133984371c30d34e38222a64855679a414cb7575
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: ./pyth_oracle_solana.so
           asset_name: pyth_oracle_solana.so
           tag: ${{ github.ref }}
-
-      - name : Get Pythnet binary from docker
-        if : env.IS_PYTHNET_RELEASE == 'true'
-        run : |
-            docker create -ti --name container "${DOCKER_IMAGE}" bash
-            docker cp container:/home/pyth/pyth-client/target/pyth/pythnet/pyth_oracle_pythnet.so .
-            docker rm -f container
-
+  
       - name : Publish Pythnet binary
-        if : env.IS_PYTHNET_RELEASE == 'true'
+        if : env.IS_ORACLE_RELEASE == 'true'
         uses: svenstaro/upload-release-action@133984371c30d34e38222a64855679a414cb7575
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Revert back to `oracle-v` releases