### PR TITLE
Extend `upd_aggregate` and `add/del_publisher` to support 64 price components on pythnet

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,5 +17,5 @@ repos:
     - id: cargo-clippy
       name: Cargo clippy
       language: "rust"
-      entry : cargo +nightly-2023-03-01 clippy --tests -- -D warnings
+      entry : cargo +nightly-2023-03-01 clippy --tests --features check -- -D warnings
       pass_filenames : false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,8 +14,13 @@ repos:
       language: "rust"
       entry: cargo +nightly-2023-03-01 fmt
       pass_filenames: false
-    - id: cargo-clippy
-      name: Cargo clippy
+    - id: cargo-clippy-solana
+      name: Cargo Clippy Solana
       language: "rust"
       entry : cargo +nightly-2023-03-01 clippy --tests --features check -- -D warnings
+      pass_filenames : false
+    - id: cargo-clippy-pythnet
+      name: Cargo Clippy Pythnet
+      language: "rust"
+      entry : cargo +nightly-2023-03-01 clippy --tests --features pythnet,check -- -D warnings
       pass_filenames : false

--- a/pcapps/pyth_csv.cpp
+++ b/pcapps/pyth_csv.cpp
@@ -83,7 +83,7 @@ void csv_print::print_header()
             << ",prev_slot"
             << ",prev_price"
             << ",prev_conf";
-  for(unsigned i=0; i != PC_COMP_SIZE; ++i ) {
+  for(unsigned i=0; i != PC_NUM_COMP; ++i ) {
     std::cout << ",comp_status_" << i
               << ",comp_price_" << i
               << ",comp_conf_" << i
@@ -156,7 +156,7 @@ void csv_print::parse_price( replay& rep )
               << ',' << cptr->agg_.conf_
               << ',' << cptr->agg_.pub_slot_;
   }
-  for( unsigned i=ptr->num_; i != PC_COMP_SIZE; ++i ) {
+  for( unsigned i=ptr->num_; i != PC_NUM_COMP; ++i ) {
     std::cout << ",,,,";
   }
   std::cout << std::endl;

--- a/program/c/makefile
+++ b/program/c/makefile
@@ -11,11 +11,22 @@ else
   include $(SOLANA)/sdk/sbf/c/sbf.mk
 endif
 
+ifdef PC_PYTHNET
+  FEATURES_H_BODY:="\#pragma once\n\#define PC_PYTHNET 1"
+else
+  FEATURES_H_BODY:="\#pragma once"
+endif
+
+
+.PHONY: features.h
+features.h:
+	echo $(FEATURES_H_BODY) > src/oracle/features.h
+
 
 # Bundle C code compiled to bpf for use by rust
 # The all target is defined by the solana makefile included above and generates the needed .o file.
 .PHONY: cpyth-bpf
-cpyth-bpf: all
+cpyth-bpf: features.h all
 	bash -c "ar rc $(OUT_DIR)/libcpyth-bpf.a $(OUT_DIR)/oracle/*.o"
 
 
@@ -24,21 +35,21 @@ cpyth-bpf: all
 # 1) Compile C code to system architecture for use by rust's cargo test
 # 2) Bundle C code compiled to system architecture for use by rust's cargo test
 .PHONY: cpyth-native
-cpyth-native:
-	gcc $(CFLAGS) -c ./src/oracle/native/upd_aggregate.c -o $(OUT_DIR)/cpyth-native.o -fPIC
+cpyth-native: features.h
+	gcc -c ./src/oracle/native/upd_aggregate.c -o $(OUT_DIR)/cpyth-native.o -fPIC
 	ar rcs $(OUT_DIR)/libcpyth-native.a $(OUT_DIR)/cpyth-native.o
 
 
 # Note: there's probably a smart way to do this with wildcards but I (jayant) can't figure it out
 .PHONY: test
-test:
+test: features.h
 	mkdir -p $(OUT_DIR)/test/
-	gcc $(CFLAGS) -c ./src/oracle/model/test_price_model.c -o $(OUT_DIR)/test/test_price_model.o -fPIC
-	gcc $(CFLAGS) -c ./src/oracle/sort/test_sort_stable.c -o $(OUT_DIR)/test/test_sort_stable.o -fPIC
-	gcc $(CFLAGS) -c ./src/oracle/util/test_align.c -o $(OUT_DIR)/test/test_align.o -fPIC
-	gcc $(CFLAGS) -c ./src/oracle/util/test_avg.c -o $(OUT_DIR)/test/test_avg.o -fPIC
-	gcc $(CFLAGS) -c ./src/oracle/util/test_hash.c -o $(OUT_DIR)/test/test_hash.o -fPIC
-	gcc $(CFLAGS) -c ./src/oracle/util/test_prng.c -o $(OUT_DIR)/test/test_prng.o -fPIC
-	gcc $(CFLAGS) -c ./src/oracle/util/test_round.c -o $(OUT_DIR)/test/test_round.o -fPIC
-	gcc $(CFLAGS) -c ./src/oracle/util/test_sar.c -o $(OUT_DIR)/test/test_sar.o -fPIC
+	gcc -c ./src/oracle/model/test_price_model.c -o $(OUT_DIR)/test/test_price_model.o -fPIC
+	gcc -c ./src/oracle/sort/test_sort_stable.c -o $(OUT_DIR)/test/test_sort_stable.o -fPIC
+	gcc -c ./src/oracle/util/test_align.c -o $(OUT_DIR)/test/test_align.o -fPIC
+	gcc -c ./src/oracle/util/test_avg.c -o $(OUT_DIR)/test/test_avg.o -fPIC
+	gcc -c ./src/oracle/util/test_hash.c -o $(OUT_DIR)/test/test_hash.o -fPIC
+	gcc -c ./src/oracle/util/test_prng.c -o $(OUT_DIR)/test/test_prng.o -fPIC
+	gcc -c ./src/oracle/util/test_round.c -o $(OUT_DIR)/test/test_round.o -fPIC
+	gcc -c ./src/oracle/util/test_sar.c -o $(OUT_DIR)/test/test_sar.o -fPIC
 	ar rcs $(OUT_DIR)/libcpyth-test.a $(OUT_DIR)/test/*.o

--- a/program/c/makefile
+++ b/program/c/makefile
@@ -25,7 +25,7 @@ cpyth-bpf: all
 # 2) Bundle C code compiled to system architecture for use by rust's cargo test
 .PHONY: cpyth-native
 cpyth-native:
-	gcc -c ./src/oracle/native/upd_aggregate.c -o $(OUT_DIR)/cpyth-native.o -fPIC
+	gcc $(CFLAGS) -c ./src/oracle/native/upd_aggregate.c -o $(OUT_DIR)/cpyth-native.o -fPIC
 	ar rcs $(OUT_DIR)/libcpyth-native.a $(OUT_DIR)/cpyth-native.o
 
 
@@ -33,12 +33,12 @@ cpyth-native:
 .PHONY: test
 test:
 	mkdir -p $(OUT_DIR)/test/
-	gcc -c ./src/oracle/model/test_price_model.c -o $(OUT_DIR)/test/test_price_model.o -fPIC
-	gcc -c ./src/oracle/sort/test_sort_stable.c -o $(OUT_DIR)/test/test_sort_stable.o -fPIC
-	gcc -c ./src/oracle/util/test_align.c -o $(OUT_DIR)/test/test_align.o -fPIC
-	gcc -c ./src/oracle/util/test_avg.c -o $(OUT_DIR)/test/test_avg.o -fPIC
-	gcc -c ./src/oracle/util/test_hash.c -o $(OUT_DIR)/test/test_hash.o -fPIC
-	gcc -c ./src/oracle/util/test_prng.c -o $(OUT_DIR)/test/test_prng.o -fPIC
-	gcc -c ./src/oracle/util/test_round.c -o $(OUT_DIR)/test/test_round.o -fPIC
-	gcc -c ./src/oracle/util/test_sar.c -o $(OUT_DIR)/test/test_sar.o -fPIC
+	gcc $(CFLAGS) -c ./src/oracle/model/test_price_model.c -o $(OUT_DIR)/test/test_price_model.o -fPIC
+	gcc $(CFLAGS) -c ./src/oracle/sort/test_sort_stable.c -o $(OUT_DIR)/test/test_sort_stable.o -fPIC
+	gcc $(CFLAGS) -c ./src/oracle/util/test_align.c -o $(OUT_DIR)/test/test_align.o -fPIC
+	gcc $(CFLAGS) -c ./src/oracle/util/test_avg.c -o $(OUT_DIR)/test/test_avg.o -fPIC
+	gcc $(CFLAGS) -c ./src/oracle/util/test_hash.c -o $(OUT_DIR)/test/test_hash.o -fPIC
+	gcc $(CFLAGS) -c ./src/oracle/util/test_prng.c -o $(OUT_DIR)/test/test_prng.o -fPIC
+	gcc $(CFLAGS) -c ./src/oracle/util/test_round.c -o $(OUT_DIR)/test/test_round.o -fPIC
+	gcc $(CFLAGS) -c ./src/oracle/util/test_sar.c -o $(OUT_DIR)/test/test_sar.o -fPIC
 	ar rcs $(OUT_DIR)/libcpyth-test.a $(OUT_DIR)/test/*.o

--- a/program/c/makefile
+++ b/program/c/makefile
@@ -11,6 +11,9 @@ else
   include $(SOLANA)/sdk/sbf/c/sbf.mk
 endif
 
+# Propagate the PC_PYTHNET feature by conditionally defining it in a
+# features.h header. The makefile included from Solana SDK does not
+# have an easy way to pass extra C flags which motivates this approach.
 ifdef PC_PYTHNET
   FEATURES_H_BODY:="\#pragma once\n\#define PC_PYTHNET 1"
 else
@@ -18,7 +21,7 @@ else
 endif
 
 
-.PHONY: features.h
+.PHONY: features.h # Putting this in .PHONY makes sure the header is always regenerated
 features.h:
 	echo $(FEATURES_H_BODY) > src/oracle/features.h
 

--- a/program/c/src/oracle/native/upd_aggregate.c
+++ b/program/c/src/oracle/native/upd_aggregate.c
@@ -7,8 +7,13 @@ char heap_start[8192];
 #define static_assert _Static_assert
 
 #include "../upd_aggregate.h"
+#include "features.h"
 
-extern bool c_upd_aggregate( pc_price_t *ptr, uint64_t slot, int64_t timestamp ){
+#ifdef PC_PYTHNET
+extern bool c_upd_aggregate_pythnet( pc_price_t *ptr, uint64_t slot, int64_t timestamp ){
+#else
+extern bool c_upd_aggregate_solana( pc_price_t *ptr, uint64_t slot, int64_t timestamp ){
+#endif
   return upd_aggregate(ptr, slot, timestamp );
 }
 

--- a/program/c/src/oracle/oracle.h
+++ b/program/c/src/oracle/oracle.h
@@ -402,39 +402,6 @@ typedef struct cmd_upd_price
 
 static_assert( sizeof( cmd_upd_price_t ) == 40, "" );
 
-typedef struct cmd_upd_test
-{
-  uint32_t     ver_;
-  int32_t      cmd_;
-  uint32_t     num_;
-  int32_t      expo_;
-  int8_t       slot_diff_[PC_COMP_SIZE];
-  int64_t      price_[PC_COMP_SIZE];
-  uint64_t     conf_[PC_COMP_SIZE];
-} cmd_upd_test_t;
-
-#ifdef PC_PYTHNET
-
-// Replace Solana component size's contribution with Pythnet's.
-//
-// Note: Make sure to account here for all PC_COMP_SIZE-sized arrays in the struct.
-#define PC_EXPECTED_CMD_UPD_TEST_T_SIZE_PYTHNET (560 \
-						 - PC_COMP_SIZE_SOLANA * sizeof(int8_t) \
-						 - PC_COMP_SIZE_SOLANA * sizeof(int64_t) \
-						 - PC_COMP_SIZE_SOLANA * sizeof(uint64_t) \
-						 + PC_COMP_SIZE * sizeof(int8_t) \
-						 + PC_COMP_SIZE * sizeof(int64_t) \
-						 + PC_COMP_SIZE * sizeof(uint64_t) \
-						 )
-
-static_assert( sizeof( cmd_upd_test_t ) == PC_EXPECTED_CMD_UPD_TEST_T_SIZE_PYTHNET, "" );
-
-#undef PC_EXPECTED_CMD_UPD_TEST_T_SIZE_PYTHNET
-
-#else
-static_assert( sizeof( cmd_upd_test_t ) == 560, "" );
-#endif
-
 // structure of clock sysvar account
 typedef struct sysvar_clock
 {

--- a/program/c/src/oracle/oracle.h
+++ b/program/c/src/oracle/oracle.h
@@ -2,6 +2,7 @@
 
 #include <stdbool.h>
 #include "util/compat_stdint.h"
+#include "features.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -20,13 +21,17 @@ extern "C" {
 #define PC_PUBKEY_SIZE       32
 #define PC_PUBKEY_SIZE_64   (PC_PUBKEY_SIZE/sizeof(uint64_t))
 #define PC_MAP_TABLE_SIZE   640
-#define PC_COMP_SIZE_SOLANA      32
-#define PC_COMP_SIZE_PYTHNET     128
 
+  // Total price component slots available
+#define PC_NUM_COMP_SOLANA      32
+#define PC_NUM_COMP_PYTHNET     128
+
+// PC_NUM_COMP - number of price components in use
 #ifdef PC_PYTHNET
-#define PC_COMP_SIZE 64 // Not using full PC_COMP_SIZE_PYTHNET due to stack problems
+// Not whole PC_NUM_COMP_PYTHNET because of stack issues appearing in upd_aggregate()
+#define PC_NUM_COMP 64
 #else
-#define PC_COMP_SIZE PC_COMP_SIZE_SOLANA
+#define PC_NUM_COMP PC_NUM_COMP_SOLANA
 #endif
 
 #define PC_PROD_ACC_SIZE    512
@@ -200,15 +205,15 @@ typedef struct pc_price
   uint64_t        prev_conf_;         // confidence interval of previous aggregate with TRADING status
   int64_t         prev_timestamp_;    // unix timestamp of previous aggregate with TRADING status
   pc_price_info_t agg_;               // aggregate price information
-  pc_price_comp_t comp_[PC_COMP_SIZE];// component prices
+  pc_price_comp_t comp_[PC_NUM_COMP];// component prices
 } pc_price_t;
 
 #ifdef PC_PYTHNET
 
 // Replace Solana component size's contribution with Pythnet's
 #define PC_EXPECTED_PRICE_T_SIZE_PYTHNET (3312 \
-					- PC_COMP_SIZE_SOLANA * sizeof(pc_price_comp_t) \
-					+ PC_COMP_SIZE * sizeof(pc_price_comp_t) \
+					- PC_NUM_COMP_SOLANA * sizeof(pc_price_comp_t) \
+					+ PC_NUM_COMP * sizeof(pc_price_comp_t) \
 					)
 
 static_assert( sizeof( pc_price_t ) == PC_EXPECTED_PRICE_T_SIZE_PYTHNET, "" );

--- a/program/c/src/oracle/upd_aggregate.c
+++ b/program/c/src/oracle/upd_aggregate.c
@@ -4,8 +4,14 @@
 #include <solana_sdk.h>
 #include "oracle.h"
 #include "upd_aggregate.h"
+#include "features.h"
 
-extern bool c_upd_aggregate( pc_price_t *ptr, uint64_t slot, int64_t timestamp ){
+// Dynamically deciding the name prevents linking the wrong C binary flavor
+#ifdef PC_PYTHNET
+extern bool c_upd_aggregate_pythnet( pc_price_t *ptr, uint64_t slot, int64_t timestamp ){
+#else
+extern bool c_upd_aggregate_solana( pc_price_t *ptr, uint64_t slot, int64_t timestamp ){
+#endif
   return upd_aggregate(ptr, slot, timestamp );
 }
 

--- a/program/c/src/oracle/upd_aggregate.h
+++ b/program/c/src/oracle/upd_aggregate.h
@@ -5,17 +5,16 @@
 #include "model/price_model.c" /* FIXME: HACK TO DEAL WITH DOCKER LINKAGE ISSUES */
 #include "pd.h"
 
-
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 typedef struct pc_qset
 {
-  pd_t      iprice_[PC_COMP_SIZE];
-  pd_t      uprice_[PC_COMP_SIZE];
-  pd_t      lprice_[PC_COMP_SIZE];
-  pd_t      weight_[PC_COMP_SIZE];
+  pd_t      iprice_[PC_NUM_COMP];
+  pd_t      uprice_[PC_NUM_COMP];
+  pd_t      lprice_[PC_NUM_COMP];
+  pd_t      weight_[PC_NUM_COMP];
   int64_t   decay_[1+PC_MAX_SEND_LATENCY];
   int64_t   fact_[PC_FACTOR_SIZE];
 } pc_qset_t;
@@ -163,7 +162,7 @@ static inline bool upd_aggregate( pc_price_t *ptr, uint64_t slot, int64_t timest
   {
     uint32_t numv  = 0;
     uint32_t nprcs = (uint32_t)0;
-    int64_t  prcs[ PC_COMP_SIZE * 3 ]; // ~0.75KiB for current PC_COMP_SIZE (FIXME: DOUBLE CHECK THIS FITS INTO STACK FRAME LIMIT)
+    int64_t  prcs[ PC_NUM_COMP * 3 ]; // ~0.75KiB for current PC_NUM_COMP (FIXME: DOUBLE CHECK THIS FITS INTO STACK FRAME LIMIT)
     for ( uint32_t i = 0; i != ptr->num_; ++i ) {
       pc_price_comp_t *iptr = &ptr->comp_[i];
       // copy contributing price to aggregate snapshot
@@ -195,7 +194,7 @@ static inline bool upd_aggregate( pc_price_t *ptr, uint64_t slot, int64_t timest
     // note: numv>0 and nprcs = 3*numv at this point
     int64_t agg_p25;
     int64_t agg_p75;
-    int64_t scratch[ PC_COMP_SIZE * 3 ]; // ~0.75KiB for current PC_COMP_SIZE (FIXME: DOUBLE CHECK THIS FITS INTO STACK FRAME LIMIT)
+    int64_t scratch[ PC_NUM_COMP * 3 ]; // ~0.75KiB for current PC_NUM_COMP (FIXME: DOUBLE CHECK THIS FITS INTO STACK FRAME LIMIT)
     price_model_core( (uint64_t)nprcs, prcs, &agg_p25, &agg_price, &agg_p75, scratch );
 
     // get the left and right confidences

--- a/program/rust/Cargo.toml
+++ b/program/rust/Cargo.toml
@@ -43,6 +43,7 @@ lazy_static = "1.4.0"
 # to cargo-build-bpf at that point - we manually capture them at
 # compile-time and pass on to the child process.
 [features]
+check = [] # Skips make build in build.rs, use with cargo-clippy and cargo-check
 debug = []
 library = []
 pythnet = [] # logic-affecting features start with this one

--- a/program/rust/build.rs
+++ b/program/rust/build.rs
@@ -20,6 +20,9 @@ fn main() {
     // resulting static library. This allows building the program when used as a dependency of
     // another crate.
     let out_dir = std::env::var("OUT_DIR").unwrap();
+
+    // Useful for C binary debugging, not printed without -vv cargo flag
+    eprintln!("OUT_DIR is {}", out_dir);
     let out_dir = PathBuf::from(out_dir);
 
     let mut make_extra_flags = vec![];
@@ -27,7 +30,7 @@ fn main() {
 
     if has_feat_pythnet {
         // Define PC_PYTHNET for the *.so build
-        make_extra_flags.push("CFLAGS=-DPC_PYTHNET=1");
+        make_extra_flags.push("PC_PYTHNET=1");
 
         // Define PC_PYTHNET for the bindings build
         clang_extra_flags.push("-DPC_PYTHNET=1");
@@ -82,7 +85,7 @@ fn main() {
         .expect("Couldn't write bindings!");
 
     // Rerun the build script if either the rust or C code changes
-    println!("cargo:rerun-if-changed=../")
+    println!("cargo:rerun-if-changed=../");
 }
 
 fn do_make_build(extra_flags: Vec<&str>, targets: Vec<&str>, out_dir: &Path) {

--- a/program/rust/build.rs
+++ b/program/rust/build.rs
@@ -1,6 +1,12 @@
 use {
     bindgen::Builder,
-    std::{path::{PathBuf, Path}, process::Command},
+    std::{
+        path::{
+            Path,
+            PathBuf,
+        },
+        process::Command,
+    },
 };
 
 fn main() {

--- a/program/rust/build.rs
+++ b/program/rust/build.rs
@@ -29,7 +29,7 @@ fn main() {
     let mut clang_extra_flags = vec![];
 
     if has_feat_pythnet {
-        // Define PC_PYTHNET for the *.so build
+        // Define PC_PYTHNET for the C binary build
         make_extra_flags.push("PC_PYTHNET=1");
 
         // Define PC_PYTHNET for the bindings build

--- a/program/rust/build.rs
+++ b/program/rust/build.rs
@@ -19,9 +19,14 @@ fn main() {
     let out_dir = PathBuf::from(out_dir);
 
     let mut make_extra_flags = vec![];
+    let mut clang_extra_flags = vec![];
 
     if has_feat_pythnet {
+        // Define PC_PYTHNET for the *.so build
         make_extra_flags.push("CFLAGS=-DPC_PYTHNET=1");
+
+        // Define PC_PYTHNET for the bindings build
+        clang_extra_flags.push("-DPC_PYTHNET=1");
     }
 
     let mut make_targets = vec![];
@@ -73,10 +78,12 @@ fn main() {
     // Generate and write bindings
     let bindings = Builder::default()
         .clang_arg(format!("-I{:}", get_solana_inc_path().display()))
+        .clang_args(clang_extra_flags)
         .header("./src/bindings.h")
         .rustfmt_bindings(true)
         .generate()
         .expect("Unable to generate bindings");
+
     bindings
         .write_to_file("./codegen/bindings.rs")
         .expect("Couldn't write bindings!");

--- a/program/rust/src/accounts/price.rs
+++ b/program/rust/src/accounts/price.rs
@@ -29,8 +29,8 @@ mod price_pythnet {
         super::*,
         crate::{
             c_oracle_header::{
-                PC_COMP_SIZE_PYTHNET,
                 PC_MAX_SEND_LATENCY,
+                PC_NUM_COMP_PYTHNET,
                 PC_STATUS_TRADING,
             },
             error::OracleError,
@@ -82,10 +82,10 @@ mod price_pythnet {
         /// Last attempted aggregate results
         pub agg_:               PriceInfo,
         /// Publishers' price components. NOTE(2023-10-06): On Pythnet, not all
-        /// PC_COMP_SIZE_PYTHNET slots are used due to stack size
+        /// PC_NUM_COMP_PYTHNET slots are used due to stack size
         /// issues in the C code. For iterating over price components,
-        /// PC_COMP_SIZE must be used.
-        pub comp_:              [PriceComponent; PC_COMP_SIZE_PYTHNET as usize],
+        /// PC_NUM_COMP must be used.
+        pub comp_:              [PriceComponent; PC_NUM_COMP_PYTHNET as usize],
         /// Cumulative sums of aggregative price and confidence used to compute arithmetic moving averages
         pub price_cumulative:   PriceCumulative,
     }
@@ -188,7 +188,7 @@ mod price_solana {
 
     use {
         super::*,
-        crate::c_oracle_header::PC_COMP_SIZE_SOLANA,
+        crate::c_oracle_header::PC_NUM_COMP_SOLANA,
     };
 
     /// Legacy Solana-only price account format. This price account
@@ -242,7 +242,7 @@ mod price_solana {
         /// Last attempted aggregate results
         pub agg_:               PriceInfo,
         /// Publishers' price components
-        pub comp_:              [PriceComponent; PC_COMP_SIZE_SOLANA as usize],
+        pub comp_:              [PriceComponent; PC_NUM_COMP_SOLANA as usize],
     }
 
     impl PythAccount for PriceAccountSolana {

--- a/program/rust/src/accounts/price.rs
+++ b/program/rust/src/accounts/price.rs
@@ -37,8 +37,8 @@ mod price_pythnet {
         },
     };
 
-    /// Pythnet-only extended price account format. This is extension
-    /// is an append-only change that extra publisher slots and
+    /// Pythnet-only extended price account format. This extension is
+    /// an append-only change that adds extra publisher slots and
     /// PriceCumulative for TWAP processing.
     #[repr(C)]
     #[derive(Copy, Clone, Pod, Zeroable)]

--- a/program/rust/src/processor/add_publisher.rs
+++ b/program/rust/src/processor/add_publisher.rs
@@ -5,7 +5,7 @@ use {
             PriceComponent,
             PythAccount,
         },
-        c_oracle_header::PC_COMP_SIZE,
+        c_oracle_header::PC_NUM_COMP,
         deserialize::{
             load,
             load_checked,
@@ -64,7 +64,7 @@ pub fn add_publisher(
 
     let mut price_data = load_checked::<PriceAccount>(price_account, cmd_args.header.version)?;
 
-    if price_data.num_ >= PC_COMP_SIZE {
+    if price_data.num_ >= PC_NUM_COMP {
         return Err(ProgramError::InvalidArgument);
     }
 

--- a/program/rust/src/processor/upd_price.rs
+++ b/program/rust/src/processor/upd_price.rs
@@ -191,7 +191,6 @@ pub fn upd_price(
                 clock.unix_timestamp,
             );
         }
-        solana_program::msg!("After c_upd_aggregate call");
     }
 
     // Reload price data as a struct after c_upd_aggregate() borrow is dropped

--- a/program/rust/src/processor/upd_price.rs
+++ b/program/rust/src/processor/upd_price.rs
@@ -44,7 +44,11 @@ use {
 #[cfg(target_arch = "bpf")]
 #[link(name = "cpyth-bpf")]
 extern "C" {
-    pub fn c_upd_aggregate(_input: *mut u8, clock_slot: u64, clock_timestamp: i64) -> bool;
+    #[cfg(feature = "pythnet")]
+    pub fn c_upd_aggregate_pythnet(_input: *mut u8, clock_slot: u64, clock_timestamp: i64) -> bool;
+    #[cfg(not(feature = "pythnet"))]
+    pub fn c_upd_aggregate_solana(_input: *mut u8, clock_slot: u64, clock_timestamp: i64) -> bool;
+
     #[allow(unused)]
     pub fn c_upd_twap(_input: *mut u8, nslots: i64);
 }
@@ -52,9 +56,22 @@ extern "C" {
 #[cfg(not(target_arch = "bpf"))]
 #[link(name = "cpyth-native")]
 extern "C" {
-    pub fn c_upd_aggregate(_input: *mut u8, clock_slot: u64, clock_timestamp: i64) -> bool;
+    #[cfg(feature = "pythnet")]
+    pub fn c_upd_aggregate_pythnet(_input: *mut u8, clock_slot: u64, clock_timestamp: i64) -> bool;
+    #[cfg(not(feature = "pythnet"))]
+    pub fn c_upd_aggregate_solana(_input: *mut u8, clock_slot: u64, clock_timestamp: i64) -> bool;
+
     #[allow(unused)]
     pub fn c_upd_twap(_input: *mut u8, nslots: i64);
+}
+
+#[inline]
+pub unsafe fn c_upd_aggregate(input: *mut u8, clock_slot: u64, clock_timestamp: i64) -> bool {
+    solana_program::msg!("before upd_aggregate_call");
+    #[cfg(feature = "pythnet")]
+    return c_upd_aggregate_pythnet(input, clock_slot, clock_timestamp);
+    #[cfg(not(feature = "pythnet"))]
+    return c_upd_aggregate_solana(input, clock_slot, clock_timestamp);
 }
 
 /// Publish component price, never returning an error even if the update failed
@@ -175,6 +192,7 @@ pub fn upd_price(
                 clock.unix_timestamp,
             );
         }
+        solana_program::msg!("After c_upd_aggregate call");
     }
 
     // Reload price data as a struct after c_upd_aggregate() borrow is dropped

--- a/program/rust/src/processor/upd_price.rs
+++ b/program/rust/src/processor/upd_price.rs
@@ -67,7 +67,6 @@ extern "C" {
 
 #[inline]
 pub unsafe fn c_upd_aggregate(input: *mut u8, clock_slot: u64, clock_timestamp: i64) -> bool {
-    solana_program::msg!("before upd_aggregate_call");
     #[cfg(feature = "pythnet")]
     return c_upd_aggregate_pythnet(input, clock_slot, clock_timestamp);
     #[cfg(not(feature = "pythnet"))]

--- a/program/rust/src/tests/test_add_publisher.rs
+++ b/program/rust/src/tests/test_add_publisher.rs
@@ -6,7 +6,7 @@ use {
             PythAccount,
         },
         c_oracle_header::{
-            PC_COMP_SIZE,
+            PC_NUM_COMP,
             PC_VERSION,
         },
         deserialize::load_checked,
@@ -99,7 +99,7 @@ fn test_add_publisher() {
     PriceAccount::initialize(&price_account, PC_VERSION).unwrap();
 
     // Fill up price node
-    for i in 0..PC_COMP_SIZE {
+    for i in 0..PC_NUM_COMP {
         cmd.publisher = Pubkey::new_unique();
         instruction_data = bytes_of::<AddPublisherArgs>(&cmd);
         assert!(process_instruction(

--- a/program/rust/src/tests/test_sizes.rs
+++ b/program/rust/src/tests/test_sizes.rs
@@ -12,8 +12,8 @@ use {
             PythAccount,
         },
         c_oracle_header::{
-            PC_COMP_SIZE,
             PC_MAP_TABLE_SIZE,
+            PC_NUM_COMP,
             PC_VERSION,
             ZSTD_UPPER_BOUND,
         },
@@ -56,18 +56,18 @@ fn test_sizes() {
     {
         use crate::{
             accounts::PriceCumulative,
-            c_oracle_header::PC_COMP_SIZE_PYTHNET,
+            c_oracle_header::PC_NUM_COMP_PYTHNET,
         };
 
-        // Sanity-check the Pythnet PC_COMP_SIZE
-        assert_eq!(PC_COMP_SIZE, 64);
+        // Sanity-check the Pythnet PC_NUM_COMP
+        assert_eq!(PC_NUM_COMP, 64);
 
         assert_eq!(
             size_of::<PriceAccount>(),
             48 + u64::BITS as usize
                 + 3 * size_of::<Pubkey>()
                 + size_of::<PriceInfo>()
-                + (PC_COMP_SIZE_PYTHNET as usize) * size_of::<PriceComponent>()
+                + (PC_NUM_COMP_PYTHNET as usize) * size_of::<PriceComponent>()
                 + size_of::<PriceCumulative>()
         );
         assert_eq!(size_of::<PriceAccount>(), 12576);
@@ -78,17 +78,17 @@ fn test_sizes() {
 
     #[cfg(not(feature = "pythnet"))]
     {
-        use crate::c_oracle_header::PC_COMP_SIZE_SOLANA;
+        use crate::c_oracle_header::PC_NUM_COMP_SOLANA;
 
-        // Sanity-check the Solana PC_COMP_SIZE
-        assert_eq!(PC_COMP_SIZE, PC_COMP_SIZE_SOLANA);
+        // Sanity-check the Solana PC_NUM_COMP
+        assert_eq!(PC_NUM_COMP, PC_NUM_COMP_SOLANA);
 
         assert_eq!(
             size_of::<PriceAccount>(),
             48 + u64::BITS as usize
                 + 3 * size_of::<Pubkey>()
                 + size_of::<PriceInfo>()
-                + (PC_COMP_SIZE_SOLANA as usize) * size_of::<PriceComponent>()
+                + (PC_NUM_COMP_SOLANA as usize) * size_of::<PriceComponent>()
         );
         assert_eq!(size_of::<PriceAccount>(), 3312);
         assert!(size_of::<PriceAccount>() <= try_convert::<_, usize>(ZSTD_UPPER_BOUND).unwrap());

--- a/program/rust/src/tests/test_sizes.rs
+++ b/program/rust/src/tests/test_sizes.rs
@@ -12,6 +12,7 @@ use {
             PythAccount,
         },
         c_oracle_header::{
+            PC_COMP_SIZE,
             PC_MAP_TABLE_SIZE,
             PC_VERSION,
             ZSTD_UPPER_BOUND,
@@ -58,6 +59,9 @@ fn test_sizes() {
             c_oracle_header::PC_COMP_SIZE_PYTHNET,
         };
 
+        // Sanity-check the Pythnet PC_COMP_SIZE
+        assert_eq!(PC_COMP_SIZE, 64);
+
         assert_eq!(
             size_of::<PriceAccount>(),
             48 + u64::BITS as usize
@@ -75,6 +79,10 @@ fn test_sizes() {
     #[cfg(not(feature = "pythnet"))]
     {
         use crate::c_oracle_header::PC_COMP_SIZE_SOLANA;
+
+        // Sanity-check the Solana PC_COMP_SIZE
+        assert_eq!(PC_COMP_SIZE, PC_COMP_SIZE_SOLANA);
+
         assert_eq!(
             size_of::<PriceAccount>(),
             48 + u64::BITS as usize

--- a/program/rust/src/tests/test_sizes.rs
+++ b/program/rust/src/tests/test_sizes.rs
@@ -55,7 +55,7 @@ fn test_sizes() {
     {
         use crate::{
             accounts::PriceCumulative,
-            c_oracle_header::PC_COMP_SIZE_V2,
+            c_oracle_header::PC_COMP_SIZE_PYTHNET,
         };
 
         assert_eq!(
@@ -63,7 +63,7 @@ fn test_sizes() {
             48 + u64::BITS as usize
                 + 3 * size_of::<Pubkey>()
                 + size_of::<PriceInfo>()
-                + (PC_COMP_SIZE_V2 as usize) * size_of::<PriceComponent>()
+                + (PC_COMP_SIZE_PYTHNET as usize) * size_of::<PriceComponent>()
                 + size_of::<PriceCumulative>()
         );
         assert_eq!(size_of::<PriceAccount>(), 12576);
@@ -74,13 +74,13 @@ fn test_sizes() {
 
     #[cfg(not(feature = "pythnet"))]
     {
-        use crate::c_oracle_header::PC_COMP_SIZE;
+        use crate::c_oracle_header::PC_COMP_SIZE_SOLANA;
         assert_eq!(
             size_of::<PriceAccount>(),
             48 + u64::BITS as usize
                 + 3 * size_of::<Pubkey>()
                 + size_of::<PriceInfo>()
-                + (PC_COMP_SIZE as usize) * size_of::<PriceComponent>()
+                + (PC_COMP_SIZE_SOLANA as usize) * size_of::<PriceComponent>()
         );
         assert_eq!(size_of::<PriceAccount>(), 3312);
         assert!(size_of::<PriceAccount>() <= try_convert::<_, usize>(ZSTD_UPPER_BOUND).unwrap());


### PR DESCRIPTION
This change extends all methods that touch the price component array to use 64 publishers on Pythnet. This includes publisher addition/deletion and, notably, aggregation logic. The latter is the reason why we don't use all 128 publisher slots on Pythnet - the compiled size of `upd_aggregate` under 128 publishing slots breached the stack size limits, resulting in various tests failing with `entered unreachable code` panics.

# Summary of changes
* `program/c/makefile` - `CFLAGS` passthrough
* `program/c/src/oracle/oracle.h` - Use a `PC_PYTHNET` feature macro to decide the value of `PC_COMP_SIZE`, disambiguate into `PC_COMP_SIZE_SOLANA` and `PC_COMP_SIZE_PYTHNET`.
* `program/rust/build.rs` - detect the `pythnet` feature and define `PC_PYTHNET`` for the make build if set.
* `program/rust/src/accounts/price.rs` - use a single big array for price components on Pythnet.
* `program/rust/src/tests/test_sizes.rs` - Adjust size constants.

# Testing
* All unit tests and C static assertions continue to pass, including `test_add_publisher` which saturates the component array.

# Review Highlights
* `oracle.h` - It's not crystal clear to me how to prevent misuse between `PC_COMP_SIZE`, `PC_COMP_SIZE_SOLANA` and `PC_COMP_SIZE_PYTHNET`. `PC_COMP_SIZE` is the used size of the array, while the other two are total space available. In case of Solana, the two coincide