### PR TITLE
Oracle: Make permissions account mandatory for all privileged instructions

### DIFF
--- a/program/rust/src/tests/test_add_product.rs
+++ b/program/rust/src/tests/test_add_product.rs
@@ -5,6 +5,7 @@ use {
             clear_account,
             create_pc_str_t,
             MappingAccount,
+            PermissionAccount,
             ProductAccount,
             PythAccount,
         },
@@ -57,13 +58,25 @@ fn test_add_product() {
     let mut product_setup_2 = AccountSetup::new::<ProductAccount>(&program_id);
     let product_account_2 = product_setup_2.as_account_info();
 
+    let mut permissions_setup = AccountSetup::new_permission(&program_id);
+    let permissions_account = permissions_setup.as_account_info();
+
+    {
+        let mut permissions_account_data =
+            PermissionAccount::initialize(&permissions_account, PC_VERSION).unwrap();
+        permissions_account_data.master_authority = *funding_account.key;
+        permissions_account_data.data_curation_authority = *funding_account.key;
+        permissions_account_data.security_authority = *funding_account.key;
+    }
+
     let mut size = populate_instruction(&mut instruction_data, &[]);
     assert!(process_instruction(
         &program_id,
         &[
             funding_account.clone(),
             mapping_account.clone(),
-            product_account.clone()
+            product_account.clone(),
+            permissions_account.clone()
         ],
         &instruction_data[..size]
     )
@@ -93,7 +106,8 @@ fn test_add_product() {
         &[
             funding_account.clone(),
             mapping_account.clone(),
-            product_account_2.clone()
+            product_account_2.clone(),
+            permissions_account.clone()
         ],
         &instruction_data[..size]
     )
@@ -131,7 +145,8 @@ fn test_add_product() {
             &[
                 funding_account.clone(),
                 mapping_account.clone(),
-                product_account_3.clone()
+                product_account_3.clone(),
+                permissions_account.clone()
             ],
             &instruction_data[..size]
         ),
@@ -151,7 +166,8 @@ fn test_add_product() {
             &[
                 funding_account.clone(),
                 mapping_account.clone(),
-                product_account.clone()
+                product_account.clone(),
+                permissions_account.clone()
             ],
             &instruction_data[..size]
         )
@@ -173,7 +189,8 @@ fn test_add_product() {
             &[
                 funding_account.clone(),
                 mapping_account.clone(),
-                product_account.clone()
+                product_account.clone(),
+                permissions_account.clone()
             ],
             &instruction_data[..size]
         ),

--- a/program/rust/src/tests/test_add_publisher.rs
+++ b/program/rust/src/tests/test_add_publisher.rs
@@ -2,6 +2,7 @@ use {
     crate::{
         accounts::{
             clear_account,
+            PermissionAccount,
             PriceAccount,
             PythAccount,
         },
@@ -46,14 +47,29 @@ fn test_add_publisher() {
 
     **price_account.try_borrow_mut_lamports().unwrap() = 100;
 
+    let mut permissions_setup = AccountSetup::new_permission(&program_id);
+    let permissions_account = permissions_setup.as_account_info();
+
+    {
+        let mut permissions_account_data =
+            PermissionAccount::initialize(&permissions_account, PC_VERSION).unwrap();
+        permissions_account_data.master_authority = *funding_account.key;
+        permissions_account_data.data_curation_authority = *funding_account.key;
+        permissions_account_data.security_authority = *funding_account.key;
+    }
+
     // Expect the instruction to fail, because the price account isn't rent exempt
     assert_eq!(
         process_instruction(
             &program_id,
-            &[funding_account.clone(), price_account.clone(),],
+            &[
+                funding_account.clone(),
+                price_account.clone(),
+                permissions_account.clone(),
+            ],
             instruction_data
         ),
-        Err(OracleError::InvalidSignableAccount.into())
+        Err(OracleError::InvalidWritableAccount.into())
     );
 
     // Now give the price account enough lamports to be rent exempt
@@ -62,7 +78,11 @@ fn test_add_publisher() {
 
     assert!(process_instruction(
         &program_id,
-        &[funding_account.clone(), price_account.clone(),],
+        &[
+            funding_account.clone(),
+            price_account.clone(),
+            permissions_account.clone(),
+        ],
         instruction_data
     )
     .is_ok());
@@ -78,7 +98,11 @@ fn test_add_publisher() {
     assert_eq!(
         process_instruction(
             &program_id,
-            &[funding_account.clone(), price_account.clone(),],
+            &[
+                funding_account.clone(),
+                price_account.clone(),
+                permissions_account.clone(),
+            ],
             instruction_data
         ),
         Err(ProgramError::InvalidArgument)
@@ -90,7 +114,11 @@ fn test_add_publisher() {
     assert_eq!(
         process_instruction(
             &program_id,
-            &[funding_account.clone(), price_account.clone(),],
+            &[
+                funding_account.clone(),
+                price_account.clone(),
+                permissions_account.clone(),
+            ],
             instruction_data
         ),
         Err(OracleError::InvalidAccountHeader.into())
@@ -104,7 +132,11 @@ fn test_add_publisher() {
         instruction_data = bytes_of::<AddPublisherArgs>(&cmd);
         assert!(process_instruction(
             &program_id,
-            &[funding_account.clone(), price_account.clone(),],
+            &[
+                funding_account.clone(),
+                price_account.clone(),
+                permissions_account.clone(),
+            ],
             instruction_data
         )
         .is_ok());
@@ -122,7 +154,11 @@ fn test_add_publisher() {
     assert_eq!(
         process_instruction(
             &program_id,
-            &[funding_account.clone(), price_account.clone(),],
+            &[
+                funding_account.clone(),
+                price_account.clone(),
+                permissions_account.clone(),
+            ],
             instruction_data
         ),
         Err(ProgramError::InvalidArgument)

--- a/program/rust/src/tests/test_del_publisher.rs
+++ b/program/rust/src/tests/test_del_publisher.rs
@@ -1,6 +1,7 @@
 use {
     crate::{
         accounts::{
+            PermissionAccount,
             PriceAccount,
             PriceInfo,
             PythAccount,
@@ -64,9 +65,24 @@ fn test_del_publisher() {
         price_data.comp_[0].pub_ = publisher
     }
 
+    let mut permissions_setup = AccountSetup::new_permission(&program_id);
+    let permissions_account = permissions_setup.as_account_info();
+
+    {
+        let mut permissions_account_data =
+            PermissionAccount::initialize(&permissions_account, PC_VERSION).unwrap();
+        permissions_account_data.master_authority = *funding_account.key;
+        permissions_account_data.data_curation_authority = *funding_account.key;
+        permissions_account_data.security_authority = *funding_account.key;
+    }
+
     assert!(process_instruction(
         &program_id,
-        &[funding_account.clone(), price_account.clone(),],
+        &[
+            funding_account.clone(),
+            price_account.clone(),
+            permissions_account.clone(),
+        ],
         &instruction_data
     )
     .is_ok());
@@ -92,7 +108,11 @@ fn test_del_publisher() {
     // Delete publisher at position 0
     assert!(process_instruction(
         &program_id,
-        &[funding_account.clone(), price_account.clone(),],
+        &[
+            funding_account.clone(),
+            price_account.clone(),
+            permissions_account.clone(),
+        ],
         &instruction_data
     )
     .is_ok());
@@ -127,7 +147,11 @@ fn test_del_publisher() {
     // Delete publisher at position 1
     assert!(process_instruction(
         &program_id,
-        &[funding_account.clone(), price_account.clone(),],
+        &[
+            funding_account.clone(),
+            price_account.clone(),
+            permissions_account.clone(),
+        ],
         &instruction_data
     )
     .is_ok());

--- a/program/rust/src/tests/test_init_mapping.rs
+++ b/program/rust/src/tests/test_init_mapping.rs
@@ -45,9 +45,24 @@ fn test_init_mapping() {
     let mut mapping_setup = AccountSetup::new::<MappingAccount>(&program_id);
     let mut mapping_account = mapping_setup.as_account_info();
 
+    let mut permissions_setup = AccountSetup::new_permission(&program_id);
+    let permissions_account = permissions_setup.as_account_info();
+
+    {
+        let mut permissions_account_data =
+            PermissionAccount::initialize(&permissions_account, PC_VERSION).unwrap();
+        permissions_account_data.master_authority = *funding_account.key;
+        permissions_account_data.data_curation_authority = *funding_account.key;
+        permissions_account_data.security_authority = *funding_account.key;
+    }
+
     assert!(process_instruction(
         &program_id,
-        &[funding_account.clone(), mapping_account.clone()],
+        &[
+            funding_account.clone(),
+            mapping_account.clone(),
+            permissions_account.clone(),
+        ],
         instruction_data
     )
     .is_ok());
@@ -64,7 +79,11 @@ fn test_init_mapping() {
     assert_eq!(
         process_instruction(
             &program_id,
-            &[funding_account.clone(), mapping_account.clone()],
+            &[
+                funding_account.clone(),
+                mapping_account.clone(),
+                permissions_account.clone(),
+            ],
             instruction_data
         ),
         Err(OracleError::InvalidFreshAccount.into())
@@ -73,7 +92,7 @@ fn test_init_mapping() {
     clear_account(&mapping_account).unwrap();
 
     assert_eq!(
-        process_instruction(&program_id, &[funding_account.clone()], instruction_data),
+        process_instruction(&program_id, &[funding_account.clone(),], instruction_data),
         Err(OracleError::InvalidNumberOfAccounts.into())
     );
 
@@ -82,31 +101,27 @@ fn test_init_mapping() {
     assert_eq!(
         process_instruction(
             &program_id,
-            &[funding_account.clone(), mapping_account.clone()],
+            &[
+                funding_account.clone(),
+                mapping_account.clone(),
+                permissions_account.clone(),
+            ],
             instruction_data
         ),
         Err(OracleError::InvalidFundingAccount.into())
     );
 
     funding_account.is_signer = true;
-    mapping_account.is_signer = false;
-
-    assert_eq!(
-        process_instruction(
-            &program_id,
-            &[funding_account.clone(), mapping_account.clone()],
-            instruction_data
-        ),
-        Err(OracleError::InvalidSignableAccount.into())
-    );
-
-    mapping_account.is_signer = true;
     funding_account.is_writable = false;
 
     assert_eq!(
         process_instruction(
             &program_id,
-            &[funding_account.clone(), mapping_account.clone()],
+            &[
+                funding_account.clone(),
+                mapping_account.clone(),
+                permissions_account.clone(),
+            ],
             instruction_data
         ),
         Err(OracleError::InvalidFundingAccount.into())
@@ -118,10 +133,14 @@ fn test_init_mapping() {
     assert_eq!(
         process_instruction(
             &program_id,
-            &[funding_account.clone(), mapping_account.clone()],
+            &[
+                funding_account.clone(),
+                mapping_account.clone(),
+                permissions_account.clone(),
+            ],
             instruction_data
         ),
-        Err(OracleError::InvalidSignableAccount.into())
+        Err(OracleError::InvalidWritableAccount.into())
     );
 
     mapping_account.is_writable = true;
@@ -130,10 +149,14 @@ fn test_init_mapping() {
     assert_eq!(
         process_instruction(
             &program_id,
-            &[funding_account.clone(), mapping_account.clone()],
+            &[
+                funding_account.clone(),
+                mapping_account.clone(),
+                permissions_account.clone(),
+            ],
             instruction_data
         ),
-        Err(OracleError::InvalidSignableAccount.into())
+        Err(OracleError::InvalidWritableAccount.into())
     );
 
     mapping_account.owner = &program_id;
@@ -143,7 +166,11 @@ fn test_init_mapping() {
     assert_eq!(
         process_instruction(
             &program_id,
-            &[funding_account.clone(), mapping_account.clone()],
+            &[
+                funding_account.clone(),
+                mapping_account.clone(),
+                permissions_account.clone(),
+            ],
             instruction_data
         ),
         Err(OracleError::AccountTooSmall.into())
@@ -153,7 +180,11 @@ fn test_init_mapping() {
 
     assert!(process_instruction(
         &program_id,
-        &[funding_account.clone(), mapping_account.clone()],
+        &[
+            funding_account.clone(),
+            mapping_account.clone(),
+            permissions_account.clone(),
+        ],
         instruction_data
     )
     .is_ok());

--- a/program/rust/src/utils.rs
+++ b/program/rust/src/utils.rs
@@ -57,26 +57,6 @@ pub fn check_valid_funding_account(account: &AccountInfo) -> Result<(), ProgramE
     )
 }
 
-pub fn valid_signable_account(
-    program_id: &Pubkey,
-    account: &AccountInfo,
-) -> Result<bool, ProgramError> {
-    Ok(account.is_signer
-        && account.is_writable
-        && account.owner == program_id
-        && get_rent()?.is_exempt(account.lamports(), account.data_len()))
-}
-
-pub fn check_valid_signable_account(
-    program_id: &Pubkey,
-    account: &AccountInfo,
-) -> Result<(), ProgramError> {
-    pyth_assert(
-        valid_signable_account(program_id, account)?,
-        OracleError::InvalidSignableAccount.into(),
-    )
-}
-
 /// Check that `account` is a valid signable pyth account or
 /// that `funding_account` is a signer and is permissioned by the `permission_account`
 pub fn check_valid_signable_account_or_permissioned_funding_account(
@@ -101,7 +81,7 @@ pub fn check_valid_signable_account_or_permissioned_funding_account(
         )?;
         check_valid_writable_account(program_id, account)
     } else {
-        check_valid_signable_account(program_id, account)
+        OracleError::InvalidSignableAccount.into()
     }
 }
 

--- a/program/rust/src/utils.rs
+++ b/program/rust/src/utils.rs
@@ -81,7 +81,7 @@ pub fn check_valid_signable_account_or_permissioned_funding_account(
         )?;
         check_valid_writable_account(program_id, account)
     } else {
-        OracleError::InvalidSignableAccount.into()
+        Err(OracleError::InvalidSignableAccount.into())
     }
 }
 


### PR DESCRIPTION
# Motivation
During an audit of oracle code, Amin and I discovered that it is still possible to circumvent the new permissions PDA mechanism if you simply don't pass the permissions account. If you as an attacker have control over price/product/mapping private keys, you can use the legacy privkey-based access control, which means the oracle has a significantly larger attack surface than necessary. This change makes the permissions account mandatory and adjusts all affected unit tests.

# Summary of changes
* `program/rust/src/tests/pyth_simulator.rs` - always use permissions account in instruction wrappers
* `program/rust/src/utils.rs` - Return error on missing permissions account
* `program/rust/src/tests/` - Add `permissions_account_setup` harness assignments to all affected tests.

# Review Highlights
* `program/rust/src/tests/` - Some of the assertions were removed, as they were testing the legacy privkey access control which is no longer available. That said, it's important that useful assertions were not removed. 