### PR TITLE
add support to configure max latency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2506,7 +2506,7 @@ dependencies = [
 
 [[package]]
 name = "pyth-oracle"
-version = "2.25.0"
+version = "2.26.0"
 dependencies = [
  "bincode",
  "bindgen",

--- a/program/c/src/oracle/oracle.h
+++ b/program/c/src/oracle/oracle.h
@@ -195,8 +195,9 @@ typedef struct pc_price
   pc_ema_t        twac_;              // time-weighted average conf interval
   int64_t         timestamp_;         // unix timestamp of aggregate price
   uint8_t         min_pub_;           // min publishers for valid price
-  int8_t          drv2_;              // space for future derived values
-  int16_t         drv3_;              // space for future derived values
+  int8_t          message_sent_;      // flag to indicate if the current aggregate price has been sent as a message to the message buffer, 0 if not sent, 1 if sent
+  uint8_t         max_latency_;       // configurable max latency in slots between send and receive
+  int8_t          drv3_;              // space for future derived values
   int32_t         drv4_;              // space for future derived values
   pc_pub_key_t    prod_;              // product id/ref-account
   pc_pub_key_t    next_;              // next price account in list

--- a/program/c/src/oracle/upd_aggregate.h
+++ b/program/c/src/oracle/upd_aggregate.h
@@ -175,7 +175,7 @@ static inline bool upd_aggregate( pc_price_t *ptr, uint64_t slot, int64_t timest
            // No overflow for INT64_MIN+conf or INT64_MAX-conf as 0 < conf < INT64_MAX
            // These checks ensure that price - conf and price + conf do not overflow.
            (int64_t)0 < conf && (INT64_MIN + conf) <= price && price <= (INT64_MAX-conf) &&
-           slot_diff >= 0 && slot_diff <= PC_MAX_SEND_LATENCY ) {
+           slot_diff <= (ptr->max_latency_ ? ptr->max_latency_ : PC_MAX_SEND_LATENCY) ) {
         numv += 1;
         prcs[ nprcs++ ] = price - conf;
         prcs[ nprcs++ ] = price;

--- a/program/c/src/oracle/upd_aggregate.h
+++ b/program/c/src/oracle/upd_aggregate.h
@@ -175,6 +175,7 @@ static inline bool upd_aggregate( pc_price_t *ptr, uint64_t slot, int64_t timest
            // No overflow for INT64_MIN+conf or INT64_MAX-conf as 0 < conf < INT64_MAX
            // These checks ensure that price - conf and price + conf do not overflow.
            (int64_t)0 < conf && (INT64_MIN + conf) <= price && price <= (INT64_MAX-conf) &&
+           // slot_diff is implicitly >= 0 due to the check in Rust code ensuring publishing_slot is always less than or equal to the current slot.
            slot_diff <= (ptr->max_latency_ ? ptr->max_latency_ : PC_MAX_SEND_LATENCY) ) {
         numv += 1;
         prcs[ nprcs++ ] = price - conf;

--- a/program/c/src/oracle/upd_aggregate.h
+++ b/program/c/src/oracle/upd_aggregate.h
@@ -171,12 +171,13 @@ static inline bool upd_aggregate( pc_price_t *ptr, uint64_t slot, int64_t timest
       int64_t slot_diff = ( int64_t )slot - ( int64_t )( iptr->agg_.pub_slot_ );
       int64_t price     = iptr->agg_.price_;
       int64_t conf      = ( int64_t )( iptr->agg_.conf_ );
+      int64_t max_latency = ptr->max_latency_ ? ptr->max_latency_ : PC_MAX_SEND_LATENCY;
       if ( iptr->agg_.status_ == PC_STATUS_TRADING &&
            // No overflow for INT64_MIN+conf or INT64_MAX-conf as 0 < conf < INT64_MAX
            // These checks ensure that price - conf and price + conf do not overflow.
            (int64_t)0 < conf && (INT64_MIN + conf) <= price && price <= (INT64_MAX-conf) &&
            // slot_diff is implicitly >= 0 due to the check in Rust code ensuring publishing_slot is always less than or equal to the current slot.
-           slot_diff <= (ptr->max_latency_ ? ptr->max_latency_ : PC_MAX_SEND_LATENCY) ) {
+           slot_diff <= max_latency ) {
         numv += 1;
         prcs[ nprcs++ ] = price - conf;
         prcs[ nprcs++ ] = price;

--- a/program/rust/Cargo.toml
+++ b/program/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyth-oracle"
-version = "2.25.0"
+version = "2.26.0"
 edition = "2021"
 license = "Apache 2.0"
 publish = false

--- a/program/rust/src/accounts/price.rs
+++ b/program/rust/src/accounts/price.rs
@@ -176,13 +176,17 @@ mod price_pythnet {
     }
 
     impl PriceCumulative {
-        pub fn update(&mut self, price: i64, conf: u64, slot_gap: u64, max_latency: i16) {
+        pub fn update(&mut self, price: i64, conf: u64, slot_gap: u64, max_latency: u8) {
             self.price += i128::from(price) * i128::from(slot_gap);
             self.conf += u128::from(conf) * u128::from(slot_gap);
             // Use PC_MAX_SEND_LATENCY if max_latency is 0, otherwise use max_latency
-            let latency = if max_latency == 0 { PC_MAX_SEND_LATENCY.into() } else { max_latency.into() };
+            let latency = if max_latency == 0 {
+                u64::from(PC_MAX_SEND_LATENCY)
+            } else {
+                u64::from(max_latency)
+            };
             // This is expected to saturate at 0 most of the time (while the feed is up).
-            self.num_down_slots += slot_gap.saturating_sub(latency as u64);
+            self.num_down_slots += slot_gap.saturating_sub(latency);
         }
     }
 }

--- a/program/rust/src/accounts/price.rs
+++ b/program/rust/src/accounts/price.rs
@@ -65,7 +65,10 @@ mod price_pythnet {
         /// Minimum valid publisher quotes for a succesful aggregation
         pub min_pub_:           u8,
         pub message_sent_:      u8,
-        pub unused_2_:          i16,
+        /// Configurable max latency in slots between send and receive
+        pub max_latency_:       u8,
+        /// Unused placeholder for alignment
+        pub unused_2_:          i8,
         pub unused_3_:          i32,
         /// Corresponding product account
         pub product_account:    Pubkey,
@@ -116,6 +119,7 @@ mod price_pythnet {
                     self.agg_.price_,
                     self.agg_.conf_,
                     self.agg_.pub_slot_.saturating_sub(self.prev_slot_),
+                    self.max_latency_,
                 ); // pub_slot should always be >= prev_slot, but we protect ourselves against underflow just in case
                 Ok(())
             } else {
@@ -172,11 +176,13 @@ mod price_pythnet {
     }
 
     impl PriceCumulative {
-        pub fn update(&mut self, price: i64, conf: u64, slot_gap: u64) {
+        pub fn update(&mut self, price: i64, conf: u64, slot_gap: u64, max_latency: i16) {
             self.price += i128::from(price) * i128::from(slot_gap);
             self.conf += u128::from(conf) * u128::from(slot_gap);
+            // Use PC_MAX_SEND_LATENCY if max_latency is 0, otherwise use max_latency
+            let latency = if max_latency == 0 { PC_MAX_SEND_LATENCY.into() } else { max_latency.into() };
             // This is expected to saturate at 0 most of the time (while the feed is up).
-            self.num_down_slots += slot_gap.saturating_sub(PC_MAX_SEND_LATENCY.into());
+            self.num_down_slots += slot_gap.saturating_sub(latency as u64);
         }
     }
 }
@@ -225,7 +231,10 @@ mod price_solana {
         /// Whether the current aggregate price has been sent as a message to the message buffer.
         /// 0 = false, 1 = true. (this is a u8 to make the Pod trait happy)
         pub message_sent_:      u8,
-        pub unused_2_:          i16,
+        /// Configurable max latency in slots between send and receive
+        pub max_latency_:       u8,
+        /// Unused placeholder for alignment
+        pub unused_2_:          i8,
         pub unused_3_:          i32,
         /// Corresponding product account
         pub product_account:    Pubkey,

--- a/program/rust/src/tests/test_twap.rs
+++ b/program/rust/src/tests/test_twap.rs
@@ -208,7 +208,6 @@ fn test_twap_unit() {
         price_cumulative_overflow.num_down_slots,
         u64::MAX - u64::from(u8::MAX)
     );
-    // u64::MAX - u64::from(u8::MAX)
     assert_eq!(price_cumulative_overflow.unused, 0);
 
     let mut price_cumulative_nonzero_max_latency = PriceCumulative {

--- a/program/rust/src/tests/test_upd_aggregate.rs
+++ b/program/rust/src/tests/test_upd_aggregate.rs
@@ -280,38 +280,6 @@ fn test_upd_aggregate() {
         assert_eq!(price_data.prev_timestamp_, 5);
     }
 
-    // // check max_latency_ = 0 defaults to PC_MAX_SEND_LATENCY
-    // {
-    //     let mut price_data = load_checked::<PriceAccount>(&price_account, PC_VERSION).unwrap();
-    //     price_data.num_ = 1;
-    //     price_data.agg_.pub_slot_ = 1050;
-    //     price_data.comp_[0].latest_ = p5;
-    // }
-
-    // unsafe {
-    //     assert!(c_upd_aggregate(
-    //         price_account.try_borrow_mut_data().unwrap().as_mut_ptr(),
-    //         1051,
-    //         13,
-    //     ));
-    // }
-
-    // {
-    //     let price_data = load_checked::<PriceAccount>(&price_account, PC_VERSION).unwrap();
-
-    //     assert_eq!(price_data.max_latency_, 0);
-    //     assert_eq!(price_data.agg_.price_, 500);
-    //     assert_eq!(price_data.agg_.conf_, 50);
-    //     assert_eq!(price_data.twap_.val_, 177);
-    //     assert_eq!(price_data.twac_.val_, 34);
-    //     assert_eq!(price_data.num_qt_, 1);
-    //     assert_eq!(price_data.timestamp_, 13);
-    //     assert_eq!(price_data.prev_slot_, 1025);
-    //     assert_eq!(price_data.prev_price_, 245);
-    //     assert_eq!(price_data.prev_conf_, 85);
-    //     assert_eq!(price_data.prev_timestamp_, 5);
-    // }
-
     // ensure the update occurs within the PC_MAX_SEND_LATENCY limit of 25 slots, allowing the aggregated price to reflect both p4 and p5 contributions
     {
         let mut price_data = load_checked::<PriceAccount>(&price_account, PC_VERSION).unwrap();
@@ -336,8 +304,6 @@ fn test_upd_aggregate() {
         assert_eq!(price_data.max_latency_, 0);
         assert_eq!(price_data.agg_.price_, 445);
         assert_eq!(price_data.agg_.conf_, 55);
-        assert_eq!(price_data.twap_.val_, 168);
-        assert_eq!(price_data.twac_.val_, 35);
         assert_eq!(price_data.num_qt_, 2);
         assert_eq!(price_data.timestamp_, 13);
         assert_eq!(price_data.prev_slot_, 1025);
@@ -361,8 +327,6 @@ fn test_upd_aggregate() {
         assert_eq!(price_data.max_latency_, 0);
         assert_eq!(price_data.agg_.price_, 500);
         assert_eq!(price_data.agg_.conf_, 50);
-        assert_eq!(price_data.twap_.val_, 203);
-        assert_eq!(price_data.twac_.val_, 36);
         assert_eq!(price_data.num_qt_, 1);
         assert_eq!(price_data.timestamp_, 14);
         assert_eq!(price_data.prev_slot_, 1025);
@@ -398,8 +362,6 @@ fn test_upd_aggregate() {
         assert_eq!(price_data.agg_.status_, PC_STATUS_UNKNOWN);
         assert_eq!(price_data.agg_.price_, 500);
         assert_eq!(price_data.agg_.conf_, 50);
-        assert_eq!(price_data.twap_.val_, 203);
-        assert_eq!(price_data.twac_.val_, 36);
         assert_eq!(price_data.num_qt_, 0);
         assert_eq!(price_data.timestamp_, 15);
         assert_eq!(price_data.prev_slot_, 1000);

--- a/program/rust/src/tests/test_upd_aggregate.rs
+++ b/program/rust/src/tests/test_upd_aggregate.rs
@@ -59,21 +59,14 @@ fn test_upd_aggregate() {
         corp_act_status_: 0,
     };
 
-    let p5: PriceInfo = PriceInfo {
+    let mut p5: PriceInfo = PriceInfo {
         price_:           500,
         conf_:            50,
         status_:          PC_STATUS_TRADING,
-        pub_slot_:        1050,
+        pub_slot_:        1024,
         corp_act_status_: 0,
     };
 
-    let p6: PriceInfo = PriceInfo {
-        price_:           600,
-        conf_:            60,
-        status_:          PC_STATUS_TRADING,
-        pub_slot_:        1074,
-        corp_act_status_: 0,
-    };
 
     let mut instruction_data = [0u8; size_of::<UpdPriceArgs>()];
     populate_instruction(&mut instruction_data, 42, 2, 1);
@@ -287,19 +280,78 @@ fn test_upd_aggregate() {
         assert_eq!(price_data.prev_timestamp_, 5);
     }
 
-    // check max_latency_ = 0 defaults to PC_MAX_SEND_LATENCY
+    // // check max_latency_ = 0 defaults to PC_MAX_SEND_LATENCY
+    // {
+    //     let mut price_data = load_checked::<PriceAccount>(&price_account, PC_VERSION).unwrap();
+    //     price_data.num_ = 1;
+    //     price_data.agg_.pub_slot_ = 1050;
+    //     price_data.comp_[0].latest_ = p5;
+    // }
+
+    // unsafe {
+    //     assert!(c_upd_aggregate(
+    //         price_account.try_borrow_mut_data().unwrap().as_mut_ptr(),
+    //         1051,
+    //         13,
+    //     ));
+    // }
+
+    // {
+    //     let price_data = load_checked::<PriceAccount>(&price_account, PC_VERSION).unwrap();
+
+    //     assert_eq!(price_data.max_latency_, 0);
+    //     assert_eq!(price_data.agg_.price_, 500);
+    //     assert_eq!(price_data.agg_.conf_, 50);
+    //     assert_eq!(price_data.twap_.val_, 177);
+    //     assert_eq!(price_data.twac_.val_, 34);
+    //     assert_eq!(price_data.num_qt_, 1);
+    //     assert_eq!(price_data.timestamp_, 13);
+    //     assert_eq!(price_data.prev_slot_, 1025);
+    //     assert_eq!(price_data.prev_price_, 245);
+    //     assert_eq!(price_data.prev_conf_, 85);
+    //     assert_eq!(price_data.prev_timestamp_, 5);
+    // }
+
+    // ensure the update occurs within the PC_MAX_SEND_LATENCY limit of 25 slots, allowing the aggregated price to reflect both p4 and p5 contributions
     {
         let mut price_data = load_checked::<PriceAccount>(&price_account, PC_VERSION).unwrap();
-        price_data.num_ = 1;
-        price_data.agg_.pub_slot_ = 1050;
-        price_data.comp_[0].latest_ = p5;
+        price_data.num_ = 2;
+        price_data.last_slot_ = 1000;
+        price_data.agg_.pub_slot_ = 1000;
+        price_data.comp_[0].latest_ = p4;
+        price_data.comp_[1].latest_ = p5;
     }
 
     unsafe {
         assert!(c_upd_aggregate(
             price_account.try_borrow_mut_data().unwrap().as_mut_ptr(),
-            1051,
+            1025,
             13,
+        ));
+    }
+
+    {
+        let price_data = load_checked::<PriceAccount>(&price_account, PC_VERSION).unwrap();
+
+        assert_eq!(price_data.max_latency_, 0);
+        assert_eq!(price_data.agg_.price_, 445);
+        assert_eq!(price_data.agg_.conf_, 55);
+        assert_eq!(price_data.twap_.val_, 168);
+        assert_eq!(price_data.twac_.val_, 35);
+        assert_eq!(price_data.num_qt_, 2);
+        assert_eq!(price_data.timestamp_, 13);
+        assert_eq!(price_data.prev_slot_, 1025);
+        assert_eq!(price_data.prev_price_, 245);
+        assert_eq!(price_data.prev_conf_, 85);
+        assert_eq!(price_data.prev_timestamp_, 5);
+    }
+
+    // verify behavior when publishing halts for 1 slot, causing the slot difference from p5 to exceed the PC_MAX_SEND_LATENCY threshold of 25.
+    unsafe {
+        assert!(c_upd_aggregate(
+            price_account.try_borrow_mut_data().unwrap().as_mut_ptr(),
+            1026,
+            14,
         ));
     }
 
@@ -309,91 +361,33 @@ fn test_upd_aggregate() {
         assert_eq!(price_data.max_latency_, 0);
         assert_eq!(price_data.agg_.price_, 500);
         assert_eq!(price_data.agg_.conf_, 50);
-        assert_eq!(price_data.twap_.val_, 177);
-        assert_eq!(price_data.twac_.val_, 34);
-        assert_eq!(price_data.num_qt_, 1);
-        assert_eq!(price_data.timestamp_, 13);
-        assert_eq!(price_data.prev_slot_, 1025);
-        assert_eq!(price_data.prev_price_, 245);
-        assert_eq!(price_data.prev_conf_, 85);
-        assert_eq!(price_data.prev_timestamp_, 5);
-    }
-
-    // ensure the update occurs within the PC_MAX_SEND_LATENCY limit of 25 slots, allowing the aggregated price to reflect both p5 and p6 contributions
-    {
-        let mut price_data = load_checked::<PriceAccount>(&price_account, PC_VERSION).unwrap();
-        price_data.num_ = 2;
-        price_data.last_slot_ = 1025;
-        price_data.agg_.pub_slot_ = 1050;
-        price_data.comp_[0].latest_ = p5;
-        price_data.comp_[1].latest_ = p6;
-    }
-
-    unsafe {
-        assert!(c_upd_aggregate(
-            price_account.try_borrow_mut_data().unwrap().as_mut_ptr(),
-            1075,
-            14,
-        ));
-    }
-
-    {
-        let price_data = load_checked::<PriceAccount>(&price_account, PC_VERSION).unwrap();
-
-        assert_eq!(price_data.max_latency_, 0);
-        assert_eq!(price_data.agg_.price_, 545);
-        assert_eq!(price_data.agg_.conf_, 55);
-        assert_eq!(price_data.twap_.val_, 212);
+        assert_eq!(price_data.twap_.val_, 203);
         assert_eq!(price_data.twac_.val_, 36);
-        assert_eq!(price_data.num_qt_, 2);
+        assert_eq!(price_data.num_qt_, 1);
         assert_eq!(price_data.timestamp_, 14);
-        assert_eq!(price_data.prev_slot_, 1050);
-        assert_eq!(price_data.prev_price_, 500);
-        assert_eq!(price_data.prev_conf_, 50);
+        assert_eq!(price_data.prev_slot_, 1025);
+        assert_eq!(price_data.prev_price_, 445);
+        assert_eq!(price_data.prev_conf_, 55);
         assert_eq!(price_data.prev_timestamp_, 13);
     }
 
-    // verify behavior when publishing halts for 1 slot, causing the slot difference from p5 to exceed the PC_MAX_SEND_LATENCY threshold of 25.
-    unsafe {
-        assert!(c_upd_aggregate(
-            price_account.try_borrow_mut_data().unwrap().as_mut_ptr(),
-            1076,
-            15,
-        ));
-    }
-
-    {
-        let price_data = load_checked::<PriceAccount>(&price_account, PC_VERSION).unwrap();
-
-        assert_eq!(price_data.max_latency_, 0);
-        assert_eq!(price_data.agg_.price_, 600);
-        assert_eq!(price_data.agg_.conf_, 60);
-        assert_eq!(price_data.twap_.val_, 244);
-        assert_eq!(price_data.twac_.val_, 38);
-        assert_eq!(price_data.num_qt_, 1);
-        assert_eq!(price_data.timestamp_, 15);
-        assert_eq!(price_data.prev_slot_, 1075);
-        assert_eq!(price_data.prev_price_, 545);
-        assert_eq!(price_data.prev_conf_, 55);
-        assert_eq!(price_data.prev_timestamp_, 14);
-    }
-
-    // verify behavior when max_latency_ is set to 5, this should result in PC_STATUS_UNKNOWN status
+    // verify behavior when max_latency_ is set to 5, and all components pub_slot_ gap is more than 5, this should result in PC_STATUS_UNKNOWN status
     {
         let mut price_data = load_checked::<PriceAccount>(&price_account, PC_VERSION).unwrap();
         price_data.max_latency_ = 5;
         price_data.num_ = 2;
-        price_data.last_slot_ = 1025;
-        price_data.agg_.pub_slot_ = 1050;
-        price_data.comp_[0].latest_ = p5;
-        price_data.comp_[1].latest_ = p6;
+        price_data.last_slot_ = 1000;
+        price_data.agg_.pub_slot_ = 1000;
+        p5.pub_slot_ = 1004;
+        price_data.comp_[0].latest_ = p4;
+        price_data.comp_[1].latest_ = p5;
     }
 
     unsafe {
         assert!(!c_upd_aggregate(
             price_account.try_borrow_mut_data().unwrap().as_mut_ptr(),
-            1080,
-            16,
+            1010,
+            15,
         ));
     }
 
@@ -402,16 +396,16 @@ fn test_upd_aggregate() {
 
         assert_eq!(price_data.max_latency_, 5);
         assert_eq!(price_data.agg_.status_, PC_STATUS_UNKNOWN);
-        assert_eq!(price_data.agg_.price_, 600);
-        assert_eq!(price_data.agg_.conf_, 60);
-        assert_eq!(price_data.twap_.val_, 244);
-        assert_eq!(price_data.twac_.val_, 38);
+        assert_eq!(price_data.agg_.price_, 500);
+        assert_eq!(price_data.agg_.conf_, 50);
+        assert_eq!(price_data.twap_.val_, 203);
+        assert_eq!(price_data.twac_.val_, 36);
         assert_eq!(price_data.num_qt_, 0);
-        assert_eq!(price_data.timestamp_, 16);
-        assert_eq!(price_data.prev_slot_, 1050);
-        assert_eq!(price_data.prev_price_, 600);
-        assert_eq!(price_data.prev_conf_, 60);
-        assert_eq!(price_data.prev_timestamp_, 15);
+        assert_eq!(price_data.timestamp_, 15);
+        assert_eq!(price_data.prev_slot_, 1000);
+        assert_eq!(price_data.prev_price_, 500);
+        assert_eq!(price_data.prev_conf_, 50);
+        assert_eq!(price_data.prev_timestamp_, 14);
     }
 }
 

--- a/program/rust/src/tests/test_upd_aggregate.rs
+++ b/program/rust/src/tests/test_upd_aggregate.rs
@@ -59,6 +59,22 @@ fn test_upd_aggregate() {
         corp_act_status_: 0,
     };
 
+    let p5: PriceInfo = PriceInfo {
+        price_:           500,
+        conf_:            50,
+        status_:          PC_STATUS_TRADING,
+        pub_slot_:        1050,
+        corp_act_status_: 0,
+    };
+
+    let p6: PriceInfo = PriceInfo {
+        price_:           600,
+        conf_:            60,
+        status_:          PC_STATUS_TRADING,
+        pub_slot_:        1074,
+        corp_act_status_: 0,
+    };
+
     let mut instruction_data = [0u8; size_of::<UpdPriceArgs>()];
     populate_instruction(&mut instruction_data, 42, 2, 1);
 
@@ -77,6 +93,7 @@ fn test_upd_aggregate() {
         price_data.agg_.pub_slot_ = 1000;
         price_data.comp_[0].latest_ = p1;
     }
+
     unsafe {
         assert!(c_upd_aggregate(
             price_account.try_borrow_mut_data().unwrap().as_mut_ptr(),
@@ -133,7 +150,6 @@ fn test_upd_aggregate() {
         assert_eq!(price_data.prev_conf_, 10);
         assert_eq!(price_data.prev_timestamp_, 1);
     }
-
 
     // three publishers
     {
@@ -236,6 +252,7 @@ fn test_upd_aggregate() {
             10,
         ));
     }
+
     {
         let price_data = load_checked::<PriceAccount>(&price_account, PC_VERSION).unwrap();
 
@@ -268,6 +285,133 @@ fn test_upd_aggregate() {
         assert_eq!(price_data.prev_price_, 245);
         assert_eq!(price_data.prev_conf_, 85);
         assert_eq!(price_data.prev_timestamp_, 5);
+    }
+
+    // check max_latency_ = 0 defaults to PC_MAX_SEND_LATENCY
+    {
+        let mut price_data = load_checked::<PriceAccount>(&price_account, PC_VERSION).unwrap();
+        price_data.num_ = 1;
+        price_data.agg_.pub_slot_ = 1050;
+        price_data.comp_[0].latest_ = p5;
+    }
+
+    unsafe {
+        assert!(c_upd_aggregate(
+            price_account.try_borrow_mut_data().unwrap().as_mut_ptr(),
+            1051,
+            13,
+        ));
+    }
+
+    {
+        let price_data = load_checked::<PriceAccount>(&price_account, PC_VERSION).unwrap();
+
+        assert_eq!(price_data.max_latency_, 0);
+        assert_eq!(price_data.agg_.price_, 500);
+        assert_eq!(price_data.agg_.conf_, 50);
+        assert_eq!(price_data.twap_.val_, 177);
+        assert_eq!(price_data.twac_.val_, 34);
+        assert_eq!(price_data.num_qt_, 1);
+        assert_eq!(price_data.timestamp_, 13);
+        assert_eq!(price_data.prev_slot_, 1025);
+        assert_eq!(price_data.prev_price_, 245);
+        assert_eq!(price_data.prev_conf_, 85);
+        assert_eq!(price_data.prev_timestamp_, 5);
+    }
+
+    // ensure the update occurs within the PC_MAX_SEND_LATENCY limit of 25 slots, allowing the aggregated price to reflect both p5 and p6 contributions
+    {
+        let mut price_data = load_checked::<PriceAccount>(&price_account, PC_VERSION).unwrap();
+        price_data.num_ = 2;
+        price_data.last_slot_ = 1025;
+        price_data.agg_.pub_slot_ = 1050;
+        price_data.comp_[0].latest_ = p5;
+        price_data.comp_[1].latest_ = p6;
+    }
+
+    unsafe {
+        assert!(c_upd_aggregate(
+            price_account.try_borrow_mut_data().unwrap().as_mut_ptr(),
+            1075,
+            14,
+        ));
+    }
+
+    {
+        let price_data = load_checked::<PriceAccount>(&price_account, PC_VERSION).unwrap();
+
+        assert_eq!(price_data.max_latency_, 0);
+        assert_eq!(price_data.agg_.price_, 545);
+        assert_eq!(price_data.agg_.conf_, 55);
+        assert_eq!(price_data.twap_.val_, 212);
+        assert_eq!(price_data.twac_.val_, 36);
+        assert_eq!(price_data.num_qt_, 2);
+        assert_eq!(price_data.timestamp_, 14);
+        assert_eq!(price_data.prev_slot_, 1050);
+        assert_eq!(price_data.prev_price_, 500);
+        assert_eq!(price_data.prev_conf_, 50);
+        assert_eq!(price_data.prev_timestamp_, 13);
+    }
+
+    // verify behavior when publishing halts for 1 slot, causing the slot difference from p5 to exceed the PC_MAX_SEND_LATENCY threshold of 25.
+    unsafe {
+        assert!(c_upd_aggregate(
+            price_account.try_borrow_mut_data().unwrap().as_mut_ptr(),
+            1076,
+            15,
+        ));
+    }
+
+    {
+        let price_data = load_checked::<PriceAccount>(&price_account, PC_VERSION).unwrap();
+
+        assert_eq!(price_data.max_latency_, 0);
+        assert_eq!(price_data.agg_.price_, 600);
+        assert_eq!(price_data.agg_.conf_, 60);
+        assert_eq!(price_data.twap_.val_, 244);
+        assert_eq!(price_data.twac_.val_, 38);
+        assert_eq!(price_data.num_qt_, 1);
+        assert_eq!(price_data.timestamp_, 15);
+        assert_eq!(price_data.prev_slot_, 1075);
+        assert_eq!(price_data.prev_price_, 545);
+        assert_eq!(price_data.prev_conf_, 55);
+        assert_eq!(price_data.prev_timestamp_, 14);
+    }
+
+    // verify behavior when max_latency_ is set to 5, this should result in PC_STATUS_UNKNOWN status
+    {
+        let mut price_data = load_checked::<PriceAccount>(&price_account, PC_VERSION).unwrap();
+        price_data.max_latency_ = 5;
+        price_data.num_ = 2;
+        price_data.last_slot_ = 1025;
+        price_data.agg_.pub_slot_ = 1050;
+        price_data.comp_[0].latest_ = p5;
+        price_data.comp_[1].latest_ = p6;
+    }
+
+    unsafe {
+        assert!(!c_upd_aggregate(
+            price_account.try_borrow_mut_data().unwrap().as_mut_ptr(),
+            1080,
+            16,
+        ));
+    }
+
+    {
+        let price_data = load_checked::<PriceAccount>(&price_account, PC_VERSION).unwrap();
+
+        assert_eq!(price_data.max_latency_, 5);
+        assert_eq!(price_data.agg_.status_, PC_STATUS_UNKNOWN);
+        assert_eq!(price_data.agg_.price_, 600);
+        assert_eq!(price_data.agg_.conf_, 60);
+        assert_eq!(price_data.twap_.val_, 244);
+        assert_eq!(price_data.twac_.val_, 38);
+        assert_eq!(price_data.num_qt_, 0);
+        assert_eq!(price_data.timestamp_, 16);
+        assert_eq!(price_data.prev_slot_, 1050);
+        assert_eq!(price_data.prev_price_, 600);
+        assert_eq!(price_data.prev_conf_, 60);
+        assert_eq!(price_data.prev_timestamp_, 15);
     }
 }
 


### PR DESCRIPTION
add configurable max latency in slots between send and receive

for price feeds with more publishers this can be reduced instead of using the default 25 value to reduce latency