### PR TITLE
chore: cleanup permissions

### DIFF
--- a/program/rust/src/processor/add_price.rs
+++ b/program/rust/src/processor/add_price.rs
@@ -16,8 +16,8 @@ use {
         instruction::AddPriceArgs,
         utils::{
             check_exponent_range,
+            check_permissioned_funding_account,
             check_valid_funding_account,
-            check_valid_signable_account_or_permissioned_funding_account,
             pyth_assert,
         },
         OracleError,
@@ -48,26 +48,24 @@ pub fn add_price(
     )?;
 
 
-    let (funding_account, product_account, price_account, permissions_account_option) =
-        match accounts {
-            [x, y, z] => Ok((x, y, z, None)),
-            [x, y, z, p] => Ok((x, y, z, Some(p))),
-            _ => Err(OracleError::InvalidNumberOfAccounts),
-        }?;
+    let (funding_account, product_account, price_account, permissions_account) = match accounts {
+        [x, y, z, p] => Ok((x, y, z, p)),
+        _ => Err(OracleError::InvalidNumberOfAccounts),
+    }?;
 
     check_valid_funding_account(funding_account)?;
-    check_valid_signable_account_or_permissioned_funding_account(
+    check_permissioned_funding_account(
         program_id,
         product_account,
         funding_account,
-        permissions_account_option,
+        permissions_account,
         &cmd_args.header,
     )?;
-    check_valid_signable_account_or_permissioned_funding_account(
+    check_permissioned_funding_account(
         program_id,
         price_account,
         funding_account,
-        permissions_account_option,
+        permissions_account,
         &cmd_args.header,
     )?;
 

--- a/program/rust/src/processor/add_product.rs
+++ b/program/rust/src/processor/add_product.rs
@@ -13,8 +13,8 @@ use {
         },
         instruction::CommandHeader,
         utils::{
+            check_permissioned_funding_account,
             check_valid_funding_account,
-            check_valid_signable_account_or_permissioned_funding_account,
             pyth_assert,
             try_convert,
         },
@@ -41,28 +41,27 @@ pub fn add_product(
     accounts: &[AccountInfo],
     instruction_data: &[u8],
 ) -> ProgramResult {
-    let (funding_account, tail_mapping_account, new_product_account, permissions_account_option) =
+    let (funding_account, tail_mapping_account, new_product_account, permissions_account) =
         match accounts {
-            [x, y, z] => Ok((x, y, z, None)),
-            [x, y, z, p] => Ok((x, y, z, Some(p))),
+            [x, y, z, p] => Ok((x, y, z, p)),
             _ => Err(OracleError::InvalidNumberOfAccounts),
         }?;
 
     let hdr = load::<CommandHeader>(instruction_data)?;
 
     check_valid_funding_account(funding_account)?;
-    check_valid_signable_account_or_permissioned_funding_account(
+    check_permissioned_funding_account(
         program_id,
         tail_mapping_account,
         funding_account,
-        permissions_account_option,
+        permissions_account,
         hdr,
     )?;
-    check_valid_signable_account_or_permissioned_funding_account(
+    check_permissioned_funding_account(
         program_id,
         new_product_account,
         funding_account,
-        permissions_account_option,
+        permissions_account,
         hdr,
     )?;
 

--- a/program/rust/src/processor/add_publisher.rs
+++ b/program/rust/src/processor/add_publisher.rs
@@ -12,8 +12,8 @@ use {
         },
         instruction::AddPublisherArgs,
         utils::{
+            check_permissioned_funding_account,
             check_valid_funding_account,
-            check_valid_signable_account_or_permissioned_funding_account,
             pyth_assert,
             try_convert,
         },
@@ -46,18 +46,17 @@ pub fn add_publisher(
         ProgramError::InvalidArgument,
     )?;
 
-    let (funding_account, price_account, permissions_account_option) = match accounts {
-        [x, y] => Ok((x, y, None)),
-        [x, y, p] => Ok((x, y, Some(p))),
+    let (funding_account, price_account, permissions_account) = match accounts {
+        [x, y, p] => Ok((x, y, p)),
         _ => Err(OracleError::InvalidNumberOfAccounts),
     }?;
 
     check_valid_funding_account(funding_account)?;
-    check_valid_signable_account_or_permissioned_funding_account(
+    check_permissioned_funding_account(
         program_id,
         price_account,
         funding_account,
-        permissions_account_option,
+        permissions_account,
         &cmd_args.header,
     )?;
 

--- a/program/rust/src/processor/del_price.rs
+++ b/program/rust/src/processor/del_price.rs
@@ -10,8 +10,8 @@ use {
         },
         instruction::CommandHeader,
         utils::{
+            check_permissioned_funding_account,
             check_valid_funding_account,
-            check_valid_signable_account_or_permissioned_funding_account,
             pyth_assert,
         },
         OracleError,
@@ -37,28 +37,26 @@ pub fn del_price(
     accounts: &[AccountInfo],
     instruction_data: &[u8],
 ) -> ProgramResult {
-    let (funding_account, product_account, price_account, permissions_account_option) =
-        match accounts {
-            [w, x, y] => Ok((w, x, y, None)),
-            [w, x, y, p] => Ok((w, x, y, Some(p))),
-            _ => Err(OracleError::InvalidNumberOfAccounts),
-        }?;
+    let (funding_account, product_account, price_account, permissions_account) = match accounts {
+        [w, x, y, p] => Ok((w, x, y, p)),
+        _ => Err(OracleError::InvalidNumberOfAccounts),
+    }?;
 
     let cmd_args = load::<CommandHeader>(instruction_data)?;
 
     check_valid_funding_account(funding_account)?;
-    check_valid_signable_account_or_permissioned_funding_account(
+    check_permissioned_funding_account(
         program_id,
         product_account,
         funding_account,
-        permissions_account_option,
+        permissions_account,
         cmd_args,
     )?;
-    check_valid_signable_account_or_permissioned_funding_account(
+    check_permissioned_funding_account(
         program_id,
         price_account,
         funding_account,
-        permissions_account_option,
+        permissions_account,
         cmd_args,
     )?;
 

--- a/program/rust/src/processor/del_product.rs
+++ b/program/rust/src/processor/del_product.rs
@@ -10,8 +10,8 @@ use {
         },
         instruction::CommandHeader,
         utils::{
+            check_permissioned_funding_account,
             check_valid_funding_account,
-            check_valid_signable_account_or_permissioned_funding_account,
             pyth_assert,
             try_convert,
         },
@@ -44,29 +44,27 @@ pub fn del_product(
     accounts: &[AccountInfo],
     instruction_data: &[u8],
 ) -> ProgramResult {
-    let (funding_account, mapping_account, product_account, permissions_account_option) =
-        match accounts {
-            [w, x, y] => Ok((w, x, y, None)),
-            [w, x, y, p] => Ok((w, x, y, Some(p))),
-            _ => Err(OracleError::InvalidNumberOfAccounts),
-        }?;
+    let (funding_account, mapping_account, product_account, permissions_account) = match accounts {
+        [w, x, y, p] => Ok((w, x, y, p)),
+        _ => Err(OracleError::InvalidNumberOfAccounts),
+    }?;
 
     let cmd_args = load::<CommandHeader>(instruction_data)?;
 
     check_valid_funding_account(funding_account)?;
-    check_valid_signable_account_or_permissioned_funding_account(
+    check_permissioned_funding_account(
         program_id,
         mapping_account,
         funding_account,
-        permissions_account_option,
+        permissions_account,
         cmd_args,
     )?;
 
-    check_valid_signable_account_or_permissioned_funding_account(
+    check_permissioned_funding_account(
         program_id,
         product_account,
         funding_account,
-        permissions_account_option,
+        permissions_account,
         cmd_args,
     )?;
 

--- a/program/rust/src/processor/del_publisher.rs
+++ b/program/rust/src/processor/del_publisher.rs
@@ -11,8 +11,8 @@ use {
         },
         instruction::DelPublisherArgs,
         utils::{
+            check_permissioned_funding_account,
             check_valid_funding_account,
-            check_valid_signable_account_or_permissioned_funding_account,
             pyth_assert,
             try_convert,
         },
@@ -45,18 +45,17 @@ pub fn del_publisher(
         ProgramError::InvalidArgument,
     )?;
 
-    let (funding_account, price_account, permissions_account_option) = match accounts {
-        [x, y] => Ok((x, y, None)),
-        [x, y, p] => Ok((x, y, Some(p))),
+    let (funding_account, price_account, permissions_account) = match accounts {
+        [x, y, p] => Ok((x, y, p)),
         _ => Err(OracleError::InvalidNumberOfAccounts),
     }?;
 
     check_valid_funding_account(funding_account)?;
-    check_valid_signable_account_or_permissioned_funding_account(
+    check_permissioned_funding_account(
         program_id,
         price_account,
         funding_account,
-        permissions_account_option,
+        permissions_account,
         &cmd_args.header,
     )?;
 

--- a/program/rust/src/processor/init_mapping.rs
+++ b/program/rust/src/processor/init_mapping.rs
@@ -7,8 +7,8 @@ use {
         deserialize::load,
         instruction::CommandHeader,
         utils::{
+            check_permissioned_funding_account,
             check_valid_funding_account,
-            check_valid_signable_account_or_permissioned_funding_account,
         },
         OracleError,
     },
@@ -27,20 +27,19 @@ pub fn init_mapping(
     accounts: &[AccountInfo],
     instruction_data: &[u8],
 ) -> ProgramResult {
-    let (funding_account, fresh_mapping_account, permissions_account_option) = match accounts {
-        [x, y] => Ok((x, y, None)),
-        [x, y, p] => Ok((x, y, Some(p))),
+    let (funding_account, fresh_mapping_account, permissions_account) = match accounts {
+        [x, y, p] => Ok((x, y, p)),
         _ => Err(OracleError::InvalidNumberOfAccounts),
     }?;
 
     let hdr = load::<CommandHeader>(instruction_data)?;
 
     check_valid_funding_account(funding_account)?;
-    check_valid_signable_account_or_permissioned_funding_account(
+    check_permissioned_funding_account(
         program_id,
         fresh_mapping_account,
         funding_account,
-        permissions_account_option,
+        permissions_account,
         hdr,
     )?;
 

--- a/program/rust/src/processor/init_price.rs
+++ b/program/rust/src/processor/init_price.rs
@@ -12,8 +12,8 @@ use {
         instruction::InitPriceArgs,
         utils::{
             check_exponent_range,
+            check_permissioned_funding_account,
             check_valid_funding_account,
-            check_valid_signable_account_or_permissioned_funding_account,
             pyth_assert,
         },
         OracleError,
@@ -41,18 +41,17 @@ pub fn init_price(
 
     check_exponent_range(cmd_args.exponent)?;
 
-    let (funding_account, price_account, permissions_account_option) = match accounts {
-        [x, y] => Ok((x, y, None)),
-        [x, y, p] => Ok((x, y, Some(p))),
+    let (funding_account, price_account, permissions_account) = match accounts {
+        [x, y, p] => Ok((x, y, p)),
         _ => Err(OracleError::InvalidNumberOfAccounts),
     }?;
 
     check_valid_funding_account(funding_account)?;
-    check_valid_signable_account_or_permissioned_funding_account(
+    check_permissioned_funding_account(
         program_id,
         price_account,
         funding_account,
-        permissions_account_option,
+        permissions_account,
         &cmd_args.header,
     )?;
 

--- a/program/rust/src/processor/set_max_latency.rs
+++ b/program/rust/src/processor/set_max_latency.rs
@@ -7,8 +7,8 @@ use {
         },
         instruction::SetMaxLatencyArgs,
         utils::{
+            check_permissioned_funding_account,
             check_valid_funding_account,
-            check_valid_signable_account_or_permissioned_funding_account,
             pyth_assert,
         },
         OracleError,
@@ -37,18 +37,17 @@ pub fn set_max_latency(
         ProgramError::InvalidArgument,
     )?;
 
-    let (funding_account, price_account, permissions_account_option) = match accounts {
-        [x, y] => Ok((x, y, None)),
-        [x, y, p] => Ok((x, y, Some(p))),
+    let (funding_account, price_account, permissions_account) = match accounts {
+        [x, y, p] => Ok((x, y, p)),
         _ => Err(OracleError::InvalidNumberOfAccounts),
     }?;
 
     check_valid_funding_account(funding_account)?;
-    check_valid_signable_account_or_permissioned_funding_account(
+    check_permissioned_funding_account(
         program_id,
         price_account,
         funding_account,
-        permissions_account_option,
+        permissions_account,
         &cmd.header,
     )?;
 

--- a/program/rust/src/processor/set_min_pub.rs
+++ b/program/rust/src/processor/set_min_pub.rs
@@ -7,8 +7,8 @@ use {
         },
         instruction::SetMinPubArgs,
         utils::{
+            check_permissioned_funding_account,
             check_valid_funding_account,
-            check_valid_signable_account_or_permissioned_funding_account,
             pyth_assert,
         },
         OracleError,
@@ -37,18 +37,17 @@ pub fn set_min_pub(
         ProgramError::InvalidArgument,
     )?;
 
-    let (funding_account, price_account, permissions_account_option) = match accounts {
-        [x, y] => Ok((x, y, None)),
-        [x, y, p] => Ok((x, y, Some(p))),
+    let (funding_account, price_account, permissions_account) = match accounts {
+        [x, y, p] => Ok((x, y, p)),
         _ => Err(OracleError::InvalidNumberOfAccounts),
     }?;
 
     check_valid_funding_account(funding_account)?;
-    check_valid_signable_account_or_permissioned_funding_account(
+    check_permissioned_funding_account(
         program_id,
         price_account,
         funding_account,
-        permissions_account_option,
+        permissions_account,
         &cmd.header,
     )?;
 

--- a/program/rust/src/processor/upd_product.rs
+++ b/program/rust/src/processor/upd_product.rs
@@ -10,8 +10,8 @@ use {
         },
         instruction::CommandHeader,
         utils::{
+            check_permissioned_funding_account,
             check_valid_funding_account,
-            check_valid_signable_account_or_permissioned_funding_account,
         },
         OracleError,
     },
@@ -31,20 +31,19 @@ pub fn upd_product(
     accounts: &[AccountInfo],
     instruction_data: &[u8],
 ) -> ProgramResult {
-    let (funding_account, product_account, permissions_account_option) = match accounts {
-        [x, y] => Ok((x, y, None)),
-        [x, y, p] => Ok((x, y, Some(p))),
+    let (funding_account, product_account, permissions_account) = match accounts {
+        [x, y, p] => Ok((x, y, p)),
         _ => Err(OracleError::InvalidNumberOfAccounts),
     }?;
 
     let hdr = load::<CommandHeader>(instruction_data)?;
 
     check_valid_funding_account(funding_account)?;
-    check_valid_signable_account_or_permissioned_funding_account(
+    check_permissioned_funding_account(
         program_id,
         product_account,
         funding_account,
-        permissions_account_option,
+        permissions_account,
         hdr,
     )?;
 

--- a/program/rust/src/tests/test_check_valid_signable_account_or_permissioned_funding_account.rs
+++ b/program/rust/src/tests/test_check_valid_signable_account_or_permissioned_funding_account.rs
@@ -11,9 +11,8 @@ use {
             CommandHeader,
             OracleCommand,
         },
-        utils::check_valid_signable_account_or_permissioned_funding_account,
+        utils::check_permissioned_funding_account,
     },
-    solana_program::program_error::ProgramError,
     solana_sdk::signature::{
         Keypair,
         Signer,
@@ -53,29 +52,12 @@ pub fn test_permissions_account_mandatory() {
         permissions_account_data.security_authority = *funding_account.key;
     }
 
-    // Permissions account not specified, but signer statuses correct
-    // for deprecated privkey flow.
     assert_eq!(
-        check_valid_signable_account_or_permissioned_funding_account(
+        check_permissioned_funding_account(
             &program_kp.pubkey(),
             &prod_account,
             &funding_account,
-            None,
-            &CommandHeader {
-                version: PC_VERSION,
-                command: OracleCommand::UpdProduct as i32,
-            },
-        ),
-        Err(ProgramError::Custom(605))
-    );
-
-    // Identical, but permission account is specified
-    assert_eq!(
-        check_valid_signable_account_or_permissioned_funding_account(
-            &program_kp.pubkey(),
-            &prod_account,
-            &funding_account,
-            Some(&permissions_account),
+            &permissions_account,
             &CommandHeader {
                 version: PC_VERSION,
                 command: OracleCommand::UpdProduct as i32,

--- a/program/rust/src/utils.rs
+++ b/program/rust/src/utils.rs
@@ -59,30 +59,25 @@ pub fn check_valid_funding_account(account: &AccountInfo) -> Result<(), ProgramE
 
 /// Check that `account` is a valid signable pyth account or
 /// that `funding_account` is a signer and is permissioned by the `permission_account`
-pub fn check_valid_signable_account_or_permissioned_funding_account(
+pub fn check_permissioned_funding_account(
     program_id: &Pubkey,
     account: &AccountInfo,
     funding_account: &AccountInfo,
-    permissions_account_option: Option<&AccountInfo>,
+    permissions_account: &AccountInfo,
     cmd_hdr: &CommandHeader,
 ) -> Result<(), ProgramError> {
-    if let Some(permissions_account) = permissions_account_option {
-        check_valid_permissions_account(program_id, permissions_account)?;
-        let permissions_account_data =
-            load_checked::<PermissionAccount>(permissions_account, cmd_hdr.version)?;
-        check_valid_funding_account(funding_account)?;
-        pyth_assert(
-            permissions_account_data.is_authorized(
-                funding_account.key,
-                OracleCommand::from_i32(cmd_hdr.command)
-                    .ok_or(OracleError::UnrecognizedInstruction)?,
-            ),
-            OracleError::PermissionViolation.into(),
-        )?;
-        check_valid_writable_account(program_id, account)
-    } else {
-        Err(OracleError::InvalidSignableAccount.into())
-    }
+    check_valid_permissions_account(program_id, permissions_account)?;
+    let permissions_account_data =
+        load_checked::<PermissionAccount>(permissions_account, cmd_hdr.version)?;
+    check_valid_funding_account(funding_account)?;
+    pyth_assert(
+        permissions_account_data.is_authorized(
+            funding_account.key,
+            OracleCommand::from_i32(cmd_hdr.command).ok_or(OracleError::UnrecognizedInstruction)?,
+        ),
+        OracleError::PermissionViolation.into(),
+    )?;
+    check_valid_writable_account(program_id, account)
 }
 
 /// Returns `true` if the `account` is fresh, i.e., its data can be overwritten.


### PR DESCRIPTION
Now that the old permissions are gone, we can cleanup some code where the user could choose whether or not to pass the permissions account