### PR TITLE
refactor: move upd_twap from upd_aggregate to rust upd_price

### DIFF
--- a/program/c/src/oracle/upd_aggregate.h
+++ b/program/c/src/oracle/upd_aggregate.h
@@ -134,14 +134,6 @@ static inline void upd_twap(
 // update aggregate price
 static inline bool upd_aggregate( pc_price_t *ptr, uint64_t slot, int64_t timestamp )
 {
-  // only re-compute aggregate in next slot
-  if ( slot <= ptr->agg_.pub_slot_ ) {
-    return false;
-  }
-
-  // get number of slots from last published valid price
-  int64_t agg_diff = ( int64_t )slot - ( int64_t )( ptr->last_slot_ );
-
   // Update the value of the previous price, if it had TRADING status.
   if ( ptr->agg_.status_ == PC_STATUS_TRADING ) {
     ptr->prev_slot_      = ptr->agg_.pub_slot_;
@@ -224,7 +216,6 @@ static inline bool upd_aggregate( pc_price_t *ptr, uint64_t slot, int64_t timest
   ptr->agg_.price_  = agg_price;
   ptr->agg_.conf_   = (uint64_t)agg_conf;
 
-  upd_twap( ptr, agg_diff );
   return true;
 }
 

--- a/program/rust/src/processor/upd_price.rs
+++ b/program/rust/src/processor/upd_price.rs
@@ -179,12 +179,6 @@ pub fn upd_price(
     #[allow(unused_variables)]
     let mut aggregate_updated = false;
 
-    let agg_diff = {
-        (clock.slot as i64)
-            - load_checked::<PriceAccount>(price_account, cmd_args.header.version)?.last_slot_
-                as i64
-    };
-
     // NOTE: c_upd_aggregate must use a raw pointer to price
     // data. Solana's `<account>.borrow_*` methods require exclusive
     // access, i.e. no other borrow can exist for the account.
@@ -196,6 +190,11 @@ pub fn upd_price(
                 clock.slot,
                 clock.unix_timestamp,
             );
+            let agg_diff = {
+                (clock.slot as i64)
+                    - load_checked::<PriceAccount>(price_account, cmd_args.header.version)?
+                        .prev_slot_ as i64
+            };
             c_upd_twap(price_account.try_borrow_mut_data()?.as_mut_ptr(), agg_diff);
         }
     }

--- a/program/rust/src/processor/upd_price.rs
+++ b/program/rust/src/processor/upd_price.rs
@@ -196,10 +196,7 @@ pub fn upd_price(
                 clock.slot,
                 clock.unix_timestamp,
             );
-            c_upd_twap(
-                price_account.try_borrow_mut_data()?.as_mut_ptr(),
-                agg_diff, // Ensure slots_since_last_update is cast to i64, as expected by the function signature
-            );
+            c_upd_twap(price_account.try_borrow_mut_data()?.as_mut_ptr(), agg_diff);
         }
     }
 

--- a/program/rust/src/processor/upd_price.rs
+++ b/program/rust/src/processor/upd_price.rs
@@ -179,6 +179,12 @@ pub fn upd_price(
     #[allow(unused_variables)]
     let mut aggregate_updated = false;
 
+    let agg_diff = {
+        (clock.slot as i64)
+            - load_checked::<PriceAccount>(price_account, cmd_args.header.version)?.last_slot_
+                as i64
+    };
+
     // NOTE: c_upd_aggregate must use a raw pointer to price
     // data. Solana's `<account>.borrow_*` methods require exclusive
     // access, i.e. no other borrow can exist for the account.
@@ -189,6 +195,10 @@ pub fn upd_price(
                 price_account.try_borrow_mut_data()?.as_mut_ptr(),
                 clock.slot,
                 clock.unix_timestamp,
+            );
+            c_upd_twap(
+                price_account.try_borrow_mut_data()?.as_mut_ptr(),
+                agg_diff, // Ensure slots_since_last_update is cast to i64, as expected by the function signature
             );
         }
     }

--- a/program/rust/src/tests/test_upd_aggregate.rs
+++ b/program/rust/src/tests/test_upd_aggregate.rs
@@ -100,8 +100,6 @@ fn test_upd_aggregate() {
 
         assert_eq!(price_data.agg_.price_, 100);
         assert_eq!(price_data.agg_.conf_, 10);
-        assert_eq!(price_data.twap_.val_, 100);
-        assert_eq!(price_data.twac_.val_, 10);
         assert_eq!(price_data.num_qt_, 1);
         assert_eq!(price_data.timestamp_, 1);
         assert_eq!(price_data.prev_slot_, 0);
@@ -134,8 +132,6 @@ fn test_upd_aggregate() {
 
         assert_eq!(price_data.agg_.price_, 145);
         assert_eq!(price_data.agg_.conf_, 55);
-        assert_eq!(price_data.twap_.val_, 106);
-        assert_eq!(price_data.twac_.val_, 16);
         assert_eq!(price_data.num_qt_, 2);
         assert_eq!(price_data.timestamp_, 2);
         assert_eq!(price_data.prev_slot_, 1000);
@@ -169,8 +165,6 @@ fn test_upd_aggregate() {
 
         assert_eq!(price_data.agg_.price_, 200);
         assert_eq!(price_data.agg_.conf_, 90);
-        assert_eq!(price_data.twap_.val_, 114);
-        assert_eq!(price_data.twac_.val_, 23);
         assert_eq!(price_data.num_qt_, 3);
         assert_eq!(price_data.timestamp_, 3);
         assert_eq!(price_data.prev_slot_, 1000);
@@ -205,8 +199,6 @@ fn test_upd_aggregate() {
 
         assert_eq!(price_data.agg_.price_, 245);
         assert_eq!(price_data.agg_.conf_, 85);
-        assert_eq!(price_data.twap_.val_, 125);
-        assert_eq!(price_data.twac_.val_, 28);
         assert_eq!(price_data.num_qt_, 4);
         assert_eq!(price_data.timestamp_, 4);
         assert_eq!(price_data.last_slot_, 1001);


### PR DESCRIPTION
this is the first refactor in part of the same slot agg changes, intentionally keeping it small and limited to `upd_twap` so that it's easier to review