### PR TITLE
refactor: optimize some checks on upd_price

### DIFF
--- a/program/rust/src/processor/upd_price.rs
+++ b/program/rust/src/processor/upd_price.rs
@@ -13,7 +13,7 @@ use {
         instruction::UpdPriceArgs,
         utils::{
             check_valid_funding_account,
-            check_valid_writable_account_without_rent_check,
+            check_valid_writable_account,
             get_status_for_conf_price_ratio,
             is_component_update,
             pyth_assert,
@@ -123,7 +123,7 @@ pub fn upd_price(
     }?;
 
     check_valid_funding_account(funding_account)?;
-    check_valid_writable_account_without_rent_check(program_id, price_account)?;
+    check_valid_writable_account(program_id, price_account)?;
     // Check clock
     let clock = Clock::from_account_info(clock_account)?;
 

--- a/program/rust/src/processor/upd_price.rs
+++ b/program/rust/src/processor/upd_price.rs
@@ -13,7 +13,7 @@ use {
         instruction::UpdPriceArgs,
         utils::{
             check_valid_funding_account,
-            check_valid_writable_account,
+            check_valid_writable_account_without_rent_check,
             get_status_for_conf_price_ratio,
             is_component_update,
             pyth_assert,
@@ -123,7 +123,7 @@ pub fn upd_price(
     }?;
 
     check_valid_funding_account(funding_account)?;
-    check_valid_writable_account(program_id, price_account)?;
+    check_valid_writable_account_without_rent_check(program_id, price_account)?;
     // Check clock
     let clock = Clock::from_account_info(clock_account)?;
 

--- a/program/rust/src/tests/test_add_publisher.rs
+++ b/program/rust/src/tests/test_add_publisher.rs
@@ -58,21 +58,7 @@ fn test_add_publisher() {
         permissions_account_data.security_authority = *funding_account.key;
     }
 
-    // Expect the instruction to fail, because the price account isn't rent exempt
-    assert_eq!(
-        process_instruction(
-            &program_id,
-            &[
-                funding_account.clone(),
-                price_account.clone(),
-                permissions_account.clone(),
-            ],
-            instruction_data
-        ),
-        Err(OracleError::InvalidWritableAccount.into())
-    );
-
-    // Now give the price account enough lamports to be rent exempt
+    // Give the price account enough lamports to be rent exempt
     **price_account.try_borrow_mut_lamports().unwrap() =
         Rent::minimum_balance(&Rent::default(), PriceAccount::MINIMUM_SIZE);
 

--- a/program/rust/src/utils.rs
+++ b/program/rust/src/utils.rs
@@ -115,9 +115,7 @@ fn valid_writable_account(
     program_id: &Pubkey,
     account: &AccountInfo,
 ) -> Result<bool, ProgramError> {
-    Ok(account.is_writable
-        && account.owner == program_id
-        && get_rent()?.is_exempt(account.lamports(), account.data_len()))
+    Ok(account.is_writable && account.owner == program_id)
 }
 
 pub fn check_valid_writable_account(
@@ -130,24 +128,11 @@ pub fn check_valid_writable_account(
     )
 }
 
-pub fn check_valid_writable_account_without_rent_check(
-    program_id: &Pubkey,
-    account: &AccountInfo,
-) -> Result<(), ProgramError> {
-    pyth_assert(
-        account.is_writable && account.owner == program_id,
-        OracleError::InvalidWritableAccount.into(),
-    )
-}
-
 fn valid_readable_account(
     program_id: &Pubkey,
     account: &AccountInfo,
 ) -> Result<bool, ProgramError> {
-    Ok(
-        account.owner == program_id
-            && get_rent()?.is_exempt(account.lamports(), account.data_len()),
-    )
+    Ok(account.owner == program_id)
 }
 
 pub fn check_valid_readable_account(

--- a/program/rust/src/utils.rs
+++ b/program/rust/src/utils.rs
@@ -130,6 +130,16 @@ pub fn check_valid_writable_account(
     )
 }
 
+pub fn check_valid_writable_account_without_rent_check(
+    program_id: &Pubkey,
+    account: &AccountInfo,
+) -> Result<(), ProgramError> {
+    pyth_assert(
+        account.is_writable && account.owner == program_id,
+        OracleError::InvalidWritableAccount.into(),
+    )
+}
+
 fn valid_readable_account(
     program_id: &Pubkey,
     account: &AccountInfo,
@@ -180,11 +190,7 @@ pub fn get_status_for_conf_price_ratio(
     confidence: u64,
     status: u32,
 ) -> Result<u32, OracleError> {
-    let mut threshold_conf = price / MAX_CI_DIVISOR;
-
-    if threshold_conf < 0 {
-        threshold_conf = -threshold_conf;
-    }
+    let threshold_conf = price.abs() / MAX_CI_DIVISOR;
 
     if confidence > try_convert::<_, u64>(threshold_conf)? {
         Ok(PC_STATUS_IGNORED)


### PR DESCRIPTION
- Remove rent check because it costs 500CU (+10% of upd_price without aggregate) and it really is not needed.
- Use abs() on checking confidence threshold because it's incredibly slow on negative prices (2000CU). We don't have negative prices but will guard us in the future.