### PR TITLE
Fix Typo in `oracle.h` File

### DIFF
--- a/program/c/src/oracle/oracle.h
+++ b/program/c/src/oracle/oracle.h
@@ -248,7 +248,7 @@ static_assert( sizeof( pc_price_t ) == PC_EXPECTED_PRICE_T_SIZE_PYTHNET, "" );
 
 
 // This constant needs to be an upper bound of the price account size, it is used within pythd for ztsd.
-// It is set tighly to the current price account + 96 component prices + 48 bytes for cumulative sums
+// It is set tightly to the current price account + 96 component prices + 48 bytes for cumulative sums
 const uint64_t ZSTD_UPPER_BOUND = 3312 + 96 * sizeof( pc_price_comp_t) + 48;
 
 


### PR DESCRIPTION
# Pull Request: Fix Typo in `oracle.h` File

## Summary
This pull request fixes a minor typo in the `oracle.h` file. The word **"tighly"** has been corrected to **"tightly"** in a comment explaining the `ZSTD_UPPER_BOUND` constant.

## Details of the Change
This change updates a comment to provide clearer documentation. It has no impact on functionality or runtime behavior.

### Modified File
- `program/c/src/oracle/oracle.h`

### Diff
```diff
- // It is set tighly to the current price account + 96 component prices + 48 bytes for cumulative sums
+ // It is set tightly to the current price account + 96 component prices + 48 bytes for cumulative sums
