### PR TITLE
Fix Typos in `pub_stats.hpp` and `prng.h`

### DIFF
--- a/pc/pub_stats.hpp
+++ b/pc/pub_stats.hpp
@@ -12,7 +12,7 @@ namespace pc
 
     pub_stats();
 
-    // number of prices submited
+    // number of prices submitted
     uint64_t get_num_sent() const;
 
     // number of observed aggregate slot updates

--- a/program/c/src/oracle/util/prng.h
+++ b/program/c/src/oracle/util/prng.h
@@ -307,7 +307,7 @@ static inline double prng_double_o ( prng_t * prng ) { return prng_uint64_to_dou
 
    Rejection method based.  Specifically, the number of prng slots
    consumed is typically 1 but theoretically might be higher
-   occassionally (64-bit wide types consume prng slots twice as fast).
+   occasionally (64-bit wide types consume prng slots twice as fast).
 
    Deterministic prng slot consumption possible with a slightly more
    approximate implementation (bound the number of iterations such that


### PR DESCRIPTION
# Fix Typos in `pub_stats.hpp` and `prng.h`

## Description

This pull request fixes minor typographical errors in the comments of two files:  
- **`pub_stats.hpp`**: Corrected "submited" to "submitted".  
- **`prng.h`**: Corrected "occassionally" to "occasionally".

### Changes:

1. **In `pub_stats.hpp`**:
   - Before:  
     ```cpp
     // number of prices submited
     ```
   - After:  
     ```cpp
     // number of prices submitted
     ```

2. **In `prng.h`**:
   - Before:  
     ```cpp
     occassionally (64-bit wide types consume prng slots twice as fast).
     ```
   - After:  
     ```cpp
     occasionally (64-bit wide types consume prng slots twice as fast).
     ```

## Motivation

Enhance the readability and professionalism of the codebase by correcting typographical errors in comments.

## Testing

No functional changes were made to the code. No additional tests are required.

---

If there are further suggestions or edits needed, feel free to let me know! 😊
