### PR TITLE
404-Update test_publish_websocket.cpp

### DIFF
--- a/pctest/test_publish_websocket.cpp
+++ b/pctest/test_publish_websocket.cpp
@@ -20,7 +20,7 @@
 
 /*
 This file demonstrates how to use publish price updates to the Pyth Network using
-the pythd websocket API described at https://docs.pyth.network/publish-data/pyth-client-websocket-api.
+the pythd websocket API described at https://docs.pyth.network/express-relay/websocket-api-reference.
 
 High-level flow:
 - Call get_product_list_and_subscribe to fetch the product metadata, enabling us to associate the price account public 


### PR DESCRIPTION
# Fix: Updated broken link in documentation

## Changes
1. **Link Update**:
   - Replaced the broken link `https://docs.pyth.network/publish-data/pyth-client-websocket-api` with the correct link `https://docs.pyth.network/express-relay/websocket-api-reference`.

## Purpose
- Resolved a 404 error by updating the outdated link.
- Improved documentation usability and ensured the reference is accurate and accessible.
