### PR TITLE
program/rust: Instruction docs: Add the permissions account 

### DIFF
--- a/program/rust/src/instruction.rs
+++ b/program/rust/src/instruction.rs
@@ -24,10 +24,7 @@ pub enum OracleCommand {
     // account[0] funding account       [signer writable]
     // account[1] mapping account       [signer writable]
     InitMapping           = 0,
-    /// Initialize and add new mapping account
-    // account[0] funding account       [signer writable]
-    // account[1] tail mapping account  [signer writable]
-    // account[2] new mapping account   [signer writable]
+    /// deprecated
     AddMapping            = 1,
     /// Initialize and add new product reference data account
     // account[0] funding account       [signer writable]
@@ -39,10 +36,10 @@ pub enum OracleCommand {
     // account[1] product account       [signer writable]
     UpdProduct            = 3,
     /// Add new price account to a product account
-    // account[0] funding account        [signer writable]
-    // account[1] product account        [writable]
-    // account[2] new price account      [writable]
-    // account[3] permissions account    [writable]
+    // account[0] funding account       [signer writable]
+    // account[1] product account       [writable]
+    // account[2] new price account     [writable]
+    // account[3] permissions account   [writable]
     AddPrice              = 4,
     /// Add publisher to symbol account
     // account[0] funding account       [signer writable]
@@ -79,10 +76,7 @@ pub enum OracleCommand {
     // account[1] price account         [writable]
     // account[2] sysvar_clock account  []
     UpdPriceNoFailOnError = 13,
-    /// Resizes a price account so that it fits the Time Machine
-    // account[0] funding account       [signer writable]
-    // account[1] price account         [signer writable]
-    // account[2] system program        []
+    /// deprecated
     ResizePriceAccount    = 14,
     /// Deletes a price account
     // account[0] funding account       [signer writable]
@@ -90,24 +84,24 @@ pub enum OracleCommand {
     // account[2] price account         [signer writable]
     DelPrice              = 15,
     /// Deletes a product account
-    // key[0] funding account       [signer writable]
-    // key[1] mapping account       [signer writable]
-    // key[2] product account       [signer writable]
+    // account[0] funding account       [signer writable]
+    // account[1] mapping account       [signer writable]
+    // account[2] product account       [signer writable]
     DelProduct            = 16,
     /// Update authorities
-    // key[0] upgrade authority         [signer writable]
-    // key[1] programdata account       []
-    // key[2] permissions account       [writable]
-    // key[3] system program            []
+    // account[0] upgrade authority     [signer writable]
+    // account[1] programdata account   []
+    // account[2] permissions account   [writable]
+    // account[3] system program        []
     UpdPermissions        = 17,
     /// Set max latency
     // account[0] funding account       [signer writable]
     // account[1] price account         [signer writable]
     SetMaxLatency         = 18,
     /// Init price feed index
-    // account[0] funding account        [signer writable]
-    // account[1] price account          [writable]
-    // account[2] permissions account    [writable]
+    // account[0] funding account       [signer writable]
+    // account[1] price account         [writable]
+    // account[2] permissions account   [writable]
     InitPriceFeedIndex    = 19,
 }
 

--- a/program/rust/src/instruction.rs
+++ b/program/rust/src/instruction.rs
@@ -23,6 +23,7 @@ pub enum OracleCommand {
     /// Initialize first mapping list account
     // account[0] funding account       [signer writable]
     // account[1] mapping account       [signer writable]
+    // account[2] permissions account   []
     InitMapping           = 0,
     /// deprecated
     AddMapping            = 1,
@@ -30,10 +31,12 @@ pub enum OracleCommand {
     // account[0] funding account       [signer writable]
     // account[1] mapping account       [signer writable]
     // account[2] new product account   [signer writable]
+    // account[3] permissions account   []
     AddProduct            = 2,
     /// Update product account
     // account[0] funding account       [signer writable]
     // account[1] product account       [signer writable]
+    // account[2] permissions account   []
     UpdProduct            = 3,
     /// Add new price account to a product account
     // account[0] funding account       [signer writable]
@@ -44,10 +47,12 @@ pub enum OracleCommand {
     /// Add publisher to symbol account
     // account[0] funding account       [signer writable]
     // account[1] price account         [signer writable]
+    // account[2] permissions account   []
     AddPublisher          = 5,
     /// Delete publisher from symbol account
     // account[0] funding account       [signer writable]
     // account[1] price account         [signer writable]
+    // account[2] permissions account   []
     DelPublisher          = 6,
     /// Publish component price
     // account[0] funding account       [signer writable]
@@ -62,6 +67,7 @@ pub enum OracleCommand {
     /// (Re)initialize price account
     // account[0] funding account       [signer writable]
     // account[1] new price account     [signer writable]
+    // account[2] permissions account   []
     InitPrice             = 9,
     /// deprecated
     InitTest              = 10,
@@ -70,6 +76,7 @@ pub enum OracleCommand {
     /// Set min publishers
     // account[0] funding account       [signer writable]
     // account[1] price account         [signer writable]
+    // account[2] permissions account   []
     SetMinPub             = 12,
     /// Publish component price, never returning an error even if the update failed
     // account[0] funding account       [signer writable]
@@ -82,11 +89,13 @@ pub enum OracleCommand {
     // account[0] funding account       [signer writable]
     // account[1] product account       [signer writable]
     // account[2] price account         [signer writable]
+    // account[3] permissions account   []
     DelPrice              = 15,
     /// Deletes a product account
     // account[0] funding account       [signer writable]
     // account[1] mapping account       [signer writable]
     // account[2] product account       [signer writable]
+    // account[3] permissions account   []
     DelProduct            = 16,
     /// Update authorities
     // account[0] upgrade authority     [signer writable]
@@ -97,6 +106,7 @@ pub enum OracleCommand {
     /// Set max latency
     // account[0] funding account       [signer writable]
     // account[1] price account         [signer writable]
+    // account[2] permissions account   []
     SetMaxLatency         = 18,
     /// Init price feed index
     // account[0] funding account       [signer writable]

--- a/program/rust/src/processor/add_product.rs
+++ b/program/rust/src/processor/add_product.rs
@@ -36,6 +36,7 @@ use {
 // account[0] funding account       [signer writable]
 // account[1] mapping account       [signer writable]
 // account[2] new product account   [signer writable]
+// account[3] permissions account   []
 pub fn add_product(
     program_id: &Pubkey,
     accounts: &[AccountInfo],

--- a/program/rust/src/processor/add_publisher.rs
+++ b/program/rust/src/processor/add_publisher.rs
@@ -44,6 +44,7 @@ pub const DISABLE_ACCUMULATOR_V2: [u8; 32] = [
 /// Add publisher to symbol account
 // account[0] funding account       [signer writable]
 // account[1] price account         [signer writable]
+// account[2] permissions account   []
 pub fn add_publisher(
     program_id: &Pubkey,
     accounts: &[AccountInfo],

--- a/program/rust/src/processor/del_price.rs
+++ b/program/rust/src/processor/del_price.rs
@@ -30,6 +30,7 @@ use {
 // account[0] funding account       [signer writable]
 // account[1] product account       [signer writable]
 // account[2] price account         [signer writable]
+// account[3] permissions account   []
 /// Warning: This function is dangerous and will break any programs that depend on the deleted
 /// price account!
 pub fn del_price(

--- a/program/rust/src/processor/del_product.rs
+++ b/program/rust/src/processor/del_product.rs
@@ -39,6 +39,7 @@ use {
 // account[0] funding account       [signer writable]
 // account[1] mapping account       [signer writable]
 // account[2] product account       [signer writable]
+// account[3] permissions account   []
 pub fn del_product(
     program_id: &Pubkey,
     accounts: &[AccountInfo],

--- a/program/rust/src/processor/del_product.rs
+++ b/program/rust/src/processor/del_product.rs
@@ -36,9 +36,9 @@ use {
 /// little weird, as it allows you to construct a list of multiple mapping accounts where non-tail
 /// accounts have empty space. This is fine however; users should simply add new products to the
 /// first available spot.
-// key[0] funding account       [signer writable]
-// key[1] mapping account       [signer writable]
-// key[2] product account       [signer writable]
+// account[0] funding account       [signer writable]
+// account[1] mapping account       [signer writable]
+// account[2] product account       [signer writable]
 pub fn del_product(
     program_id: &Pubkey,
     accounts: &[AccountInfo],

--- a/program/rust/src/processor/del_publisher.rs
+++ b/program/rust/src/processor/del_publisher.rs
@@ -32,6 +32,7 @@ use {
 /// Delete publisher from symbol account
 // account[0] funding account       [signer writable]
 // account[1] price account         [signer writable]
+// account[2] permissions account   []
 pub fn del_publisher(
     program_id: &Pubkey,
     accounts: &[AccountInfo],

--- a/program/rust/src/processor/init_price.rs
+++ b/program/rust/src/processor/init_price.rs
@@ -32,6 +32,7 @@ use {
 /// (Re)initialize price account
 // account[0] funding account       [signer writable]
 // account[1] new price account     [signer writable]
+// account[2] permissions account   []
 pub fn init_price(
     program_id: &Pubkey,
     accounts: &[AccountInfo],

--- a/program/rust/src/processor/set_max_latency.rs
+++ b/program/rust/src/processor/set_max_latency.rs
@@ -25,6 +25,7 @@ use {
 /// Set max latency
 // account[0] funding account       [signer writable]
 // account[1] price account         [signer writable]
+// account[2] permissions account   []
 pub fn set_max_latency(
     program_id: &Pubkey,
     accounts: &[AccountInfo],

--- a/program/rust/src/processor/set_min_pub.rs
+++ b/program/rust/src/processor/set_min_pub.rs
@@ -25,6 +25,7 @@ use {
 /// Set min publishers
 // account[0] funding account       [signer writable]
 // account[1] price account         [signer writable]
+// account[2] permissions account   []
 pub fn set_min_pub(
     program_id: &Pubkey,
     accounts: &[AccountInfo],

--- a/program/rust/src/processor/upd_permissions.rs
+++ b/program/rust/src/processor/upd_permissions.rs
@@ -29,10 +29,10 @@ use {
 /// Updates permissions for the pyth oracle program
 /// This function can create and update the permissions accounts, which stores
 /// several public keys that can execute administrative instructions in the pyth program
-// key[0] upgrade authority         [signer writable]
-// key[1] programdata account       []
-// key[2] permissions account       [writable]
-// key[3] system program            []
+// account[0] upgrade authority     [signer writable]
+// account[1] programdata account   []
+// account[2] permissions account   [writable]
+// account[3] system program        []
 pub fn upd_permissions(
     program_id: &Pubkey,
     accounts: &[AccountInfo],

--- a/program/rust/src/processor/upd_product.rs
+++ b/program/rust/src/processor/upd_product.rs
@@ -26,6 +26,7 @@ use {
 /// The metadata is provided as a list of key-value pairs at the end of the `instruction_data`.
 // account[0] funding account       [signer writable]
 // account[1] product account       [signer writable]
+// account[2] permissions account   []
 pub fn upd_product(
     program_id: &Pubkey,
     accounts: &[AccountInfo],


### PR DESCRIPTION
Indentation of the account description was inconsistent in a few cases.
The permissions account is required by most instructions, but is documented only in two of them.